### PR TITLE
feat(rs): add SubshellPeDb, XcomDb, ElectronDb

### DIFF
--- a/clients/rs/nucl-parquet/Cargo.toml
+++ b/clients/rs/nucl-parquet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nucl-parquet"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Nuclear data as Parquet — zero-copy cross-section lookups for Monte Carlo transport"
 license = "MIT"

--- a/clients/rs/nucl-parquet/src/electron.rs
+++ b/clients/rs/nucl-parquet/src/electron.rs
@@ -1,0 +1,259 @@
+//! EEDL electron interaction cross-sections.
+//!
+//! Per-element electron cross-sections for elastic scattering, bremsstrahlung,
+//! excitation, and ionization processes. Data loaded from `meta/eedl/*.parquet`.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use arrow::array::{Float64Array, Int32Array, StringArray};
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+
+use crate::error::Error;
+use crate::interp::{log_log_interp, sort_paired_vecs};
+
+/// Electron interaction process types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ElectronProcess {
+    /// Elastic scattering
+    Elastic,
+    /// Bremsstrahlung radiation
+    Bremsstrahlung,
+    /// Excitation
+    Excitation,
+    /// Ionization (total — sum of all subshell ionization)
+    Ionization,
+}
+
+/// EEDL electron interaction database.
+///
+/// Thread-safe: `Send + Sync`. Share via `Arc<ElectronDb>`.
+#[derive(Clone)]
+pub struct ElectronDb {
+    /// (Z, ElectronProcess) -> (energies_MeV sorted, xs_barns sorted)
+    xs_tables: HashMap<(u8, ElectronProcess), (Vec<f64>, Vec<f64>)>,
+}
+
+unsafe impl Send for ElectronDb {}
+unsafe impl Sync for ElectronDb {}
+
+impl ElectronDb {
+    /// Load EEDL data from the nucl-parquet `meta/` directory.
+    ///
+    /// Reads `meta/eedl/*.parquet`.
+    pub fn open(meta_dir: impl AsRef<Path>) -> crate::Result<Self> {
+        let dir = meta_dir.as_ref().join("eedl");
+
+        if !dir.exists() {
+            return Err(Error::DataDirNotFound(dir.to_path_buf()));
+        }
+
+        let mut xs_tables = HashMap::new();
+
+        for entry in fs::read_dir(&dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("parquet") {
+                continue;
+            }
+
+            let file = fs::File::open(&path)?;
+            let reader = ParquetRecordBatchReaderBuilder::try_new(file)?.build()?;
+
+            let mut process_data: HashMap<ElectronProcess, (Vec<f64>, Vec<f64>)> = HashMap::new();
+            let mut z_val: Option<u8> = None;
+
+            for batch in reader {
+                let batch = batch?;
+
+                let z_col = batch
+                    .column_by_name("Z")
+                    .and_then(|c| c.as_any().downcast_ref::<Int32Array>());
+                let e_col = batch
+                    .column_by_name("energy_MeV")
+                    .and_then(|c| c.as_any().downcast_ref::<Float64Array>());
+                let proc_col = batch
+                    .column_by_name("process")
+                    .and_then(|c| c.as_any().downcast_ref::<StringArray>());
+                let xs_col = batch
+                    .column_by_name("xs_barns")
+                    .and_then(|c| c.as_any().downcast_ref::<Float64Array>());
+
+                if let (Some(z), Some(e), Some(proc), Some(xs)) = (z_col, e_col, proc_col, xs_col)
+                {
+                    for i in 0..batch.num_rows() {
+                        if z_val.is_none() {
+                            z_val = Some(z.value(i) as u8);
+                        }
+                        let proc_str = proc.value(i);
+                        let process = match proc_str {
+                            "elastic" => Some(ElectronProcess::Elastic),
+                            "bremsstrahlung" => Some(ElectronProcess::Bremsstrahlung),
+                            "excitation" => Some(ElectronProcess::Excitation),
+                            _ if proc_str.starts_with("ionization") => {
+                                Some(ElectronProcess::Ionization)
+                            }
+                            _ => None,
+                        };
+                        if let Some(p) = process {
+                            let entry = process_data.entry(p).or_default();
+                            entry.0.push(e.value(i));
+                            entry.1.push(xs.value(i));
+                        }
+                    }
+                }
+            }
+
+            if let Some(z) = z_val {
+                // Subshell ionization rows share the same energy grid; sum them.
+                if let Some((energies, xs_vals)) =
+                    process_data.remove(&ElectronProcess::Ionization)
+                {
+                    let summed = sum_by_energy(&energies, &xs_vals);
+                    process_data.insert(ElectronProcess::Ionization, summed);
+                }
+
+                for (process, (mut energies, mut xs)) in process_data {
+                    sort_paired_vecs(&mut energies, &mut xs);
+                    xs_tables.insert((z, process), (energies, xs));
+                }
+            }
+        }
+
+        Ok(Self { xs_tables })
+    }
+
+    /// Cross-section [barns/atom] for element Z at energy E [MeV] for a given process.
+    ///
+    /// Returns `f64::NAN` if the element or process is not loaded.
+    #[inline]
+    pub fn cross_section(&self, z: u8, energy_mev: f64, process: ElectronProcess) -> f64 {
+        match self.xs_tables.get(&(z, process)) {
+            Some((e, xs)) => log_log_interp(e, xs, energy_mev),
+            None => f64::NAN,
+        }
+    }
+
+    /// Total cross-section [barns/atom] (elastic + bremsstrahlung + excitation + ionization).
+    ///
+    /// Returns `f64::NAN` if no data is loaded for the element.
+    #[inline]
+    pub fn total_cross_section(&self, z: u8, energy_mev: f64) -> f64 {
+        let processes = [
+            ElectronProcess::Elastic,
+            ElectronProcess::Bremsstrahlung,
+            ElectronProcess::Excitation,
+            ElectronProcess::Ionization,
+        ];
+        let mut total = 0.0;
+        let mut found = false;
+        for p in &processes {
+            let xs = self.cross_section(z, energy_mev, *p);
+            if xs.is_finite() {
+                total += xs;
+                found = true;
+            }
+        }
+        if found {
+            total
+        } else {
+            f64::NAN
+        }
+    }
+
+    /// Check if data is loaded for element Z.
+    pub fn has_element(&self, z: u8) -> bool {
+        self.xs_tables
+            .contains_key(&(z, ElectronProcess::Elastic))
+    }
+
+    /// Number of elements loaded.
+    pub fn num_elements(&self) -> usize {
+        self.xs_tables
+            .keys()
+            .filter(|(_, p)| *p == ElectronProcess::Elastic)
+            .count()
+    }
+}
+
+/// Sum cross-section values that share the same energy.
+///
+/// EEDL ionization data has separate rows per subshell at the same energy grid.
+/// This function groups by energy and sums the cross-sections.
+fn sum_by_energy(energies: &[f64], values: &[f64]) -> (Vec<f64>, Vec<f64>) {
+    let mut map: HashMap<u64, f64> = HashMap::new();
+    let mut order: Vec<u64> = Vec::new();
+
+    for (&e, &v) in energies.iter().zip(values.iter()) {
+        let key = e.to_bits();
+        let entry = map.entry(key).or_insert_with(|| {
+            order.push(key);
+            0.0
+        });
+        *entry += v;
+    }
+
+    let mut result_e: Vec<f64> = Vec::with_capacity(order.len());
+    let mut result_v: Vec<f64> = Vec::with_capacity(order.len());
+    for key in &order {
+        result_e.push(f64::from_bits(*key));
+        result_v.push(map[key]);
+    }
+
+    (result_e, result_v)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn meta_dir() -> std::path::PathBuf {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("..")
+            .join("meta")
+    }
+
+    #[test]
+    #[ignore = "requires nucl-parquet data files"]
+    fn open_succeeds() {
+        let db = ElectronDb::open(meta_dir()).unwrap();
+        assert!(db.has_element(29)); // Cu
+        assert!(db.num_elements() > 0);
+    }
+
+    #[test]
+    #[ignore = "requires nucl-parquet data files"]
+    fn cu_elastic_xs_positive() {
+        let db = ElectronDb::open(meta_dir()).unwrap();
+        let xs = db.cross_section(29, 1.0, ElectronProcess::Elastic);
+        assert!(
+            xs.is_finite() && xs > 0.0,
+            "Cu elastic XS at 1 MeV: {xs}"
+        );
+    }
+
+    #[test]
+    #[ignore = "requires nucl-parquet data files"]
+    fn cu_total_xs_positive() {
+        let db = ElectronDb::open(meta_dir()).unwrap();
+        let total = db.total_cross_section(29, 1.0);
+        assert!(
+            total.is_finite() && total > 0.0,
+            "Cu total electron XS at 1 MeV: {total}"
+        );
+    }
+
+    #[test]
+    #[ignore = "requires nucl-parquet data files"]
+    fn cu_bremsstrahlung_positive() {
+        let db = ElectronDb::open(meta_dir()).unwrap();
+        let xs = db.cross_section(29, 1.0, ElectronProcess::Bremsstrahlung);
+        assert!(
+            xs.is_finite() && xs > 0.0,
+            "Cu bremsstrahlung XS at 1 MeV: {xs}"
+        );
+    }
+}

--- a/clients/rs/nucl-parquet/src/lib.rs
+++ b/clients/rs/nucl-parquet/src/lib.rs
@@ -31,19 +31,25 @@
 //! # }
 //! ```
 
+mod electron;
 mod error;
 mod interp;
 mod meta;
 mod photon;
 mod relaxation;
 mod stopping;
+mod subshell_pe;
+mod xcom;
 mod xs;
 
+pub use electron::{ElectronDb, ElectronProcess};
 pub use error::Error;
 pub use meta::{AbundanceEntry, AbundancesDb, DecayDb, DecayEntry, DoseDb};
 pub use photon::{PhotonDb, Process};
 pub use relaxation::{RelaxationDb, Transition, TransitionType};
 pub use stopping::StoppingDb;
+pub use subshell_pe::SubshellPeDb;
+pub use xcom::XcomDb;
 pub use xs::{CrossSectionDb, XsEntry};
 
 /// Result type for nucl-parquet operations.

--- a/clients/rs/nucl-parquet/src/subshell_pe.rs
+++ b/clients/rs/nucl-parquet/src/subshell_pe.rs
@@ -1,0 +1,207 @@
+//! EPDL97 subshell photoelectric cross-sections.
+//!
+//! Per-element, per-subshell photoelectric cross-sections and binding energies.
+//! Data loaded from `meta/epdl97/subshell_pe/*.parquet`.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use arrow::array::{Float64Array, Int32Array, StringArray};
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+
+use crate::error::Error;
+use crate::interp::{log_log_interp, sort_paired_vecs};
+
+/// Subshell photoelectric cross-section database (EPDL97).
+///
+/// Thread-safe: `Send + Sync`. Share via `Arc<SubshellPeDb>`.
+#[derive(Clone)]
+pub struct SubshellPeDb {
+    /// (Z, shell_index) -> (energies_MeV sorted, xs_barns sorted)
+    xs_tables: HashMap<(u8, u8), (Vec<f64>, Vec<f64>)>,
+    /// (Z, shell_index) -> binding edge energy [MeV]
+    binding_energies: HashMap<(u8, u8), f64>,
+    /// Z -> list of shell names (index matches shell_index)
+    shell_names: HashMap<u8, Vec<String>>,
+}
+
+unsafe impl Send for SubshellPeDb {}
+unsafe impl Sync for SubshellPeDb {}
+
+impl SubshellPeDb {
+    /// Load subshell photoelectric data from the nucl-parquet `meta/` directory.
+    ///
+    /// Reads `meta/epdl97/subshell_pe/*.parquet`.
+    pub fn open(meta_dir: impl AsRef<Path>) -> crate::Result<Self> {
+        let dir = meta_dir.as_ref().join("epdl97").join("subshell_pe");
+
+        if !dir.exists() {
+            return Err(Error::DataDirNotFound(dir.to_path_buf()));
+        }
+
+        let mut xs_tables = HashMap::new();
+        let mut binding_energies = HashMap::new();
+        let mut shell_names: HashMap<u8, Vec<String>> = HashMap::new();
+
+        for entry in fs::read_dir(&dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("parquet") {
+                continue;
+            }
+
+            let file = fs::File::open(&path)?;
+            let reader = ParquetRecordBatchReaderBuilder::try_new(file)?.build()?;
+
+            let mut shell_data: HashMap<String, (Vec<f64>, Vec<f64>, f64)> = HashMap::new();
+            let mut z_val: Option<u8> = None;
+
+            for batch in reader {
+                let batch = batch?;
+
+                let z_col = batch
+                    .column_by_name("Z")
+                    .and_then(|c| c.as_any().downcast_ref::<Int32Array>());
+                let e_col = batch
+                    .column_by_name("energy_MeV")
+                    .and_then(|c| c.as_any().downcast_ref::<Float64Array>());
+                let shell_col = batch
+                    .column_by_name("subshell")
+                    .and_then(|c| c.as_any().downcast_ref::<StringArray>());
+                let xs_col = batch
+                    .column_by_name("xs_barns")
+                    .and_then(|c| c.as_any().downcast_ref::<Float64Array>());
+                let edge_col = batch
+                    .column_by_name("edge_MeV")
+                    .and_then(|c| c.as_any().downcast_ref::<Float64Array>());
+
+                if let (Some(z), Some(e), Some(shell), Some(xs), Some(edge)) =
+                    (z_col, e_col, shell_col, xs_col, edge_col)
+                {
+                    for i in 0..batch.num_rows() {
+                        if z_val.is_none() {
+                            z_val = Some(z.value(i) as u8);
+                        }
+                        let shell_name = shell.value(i).to_string();
+                        let entry = shell_data
+                            .entry(shell_name)
+                            .or_insert_with(|| (Vec::new(), Vec::new(), edge.value(i)));
+                        entry.0.push(e.value(i));
+                        entry.1.push(xs.value(i));
+                    }
+                }
+            }
+
+            if let Some(z) = z_val {
+                let mut names: Vec<String> = shell_data.keys().cloned().collect();
+                names.sort();
+
+                for (idx, name) in names.iter().enumerate() {
+                    let (mut energies, mut xs, edge) =
+                        shell_data.remove(name).expect("key exists");
+                    sort_paired_vecs(&mut energies, &mut xs);
+                    let shell_idx = idx as u8;
+                    xs_tables.insert((z, shell_idx), (energies, xs));
+                    binding_energies.insert((z, shell_idx), edge);
+                }
+                shell_names.insert(z, names);
+            }
+        }
+
+        Ok(Self {
+            xs_tables,
+            binding_energies,
+            shell_names,
+        })
+    }
+
+    /// Photoelectric cross-section [barns/atom] for a specific subshell.
+    ///
+    /// `shell` is the 0-based shell index (ordered alphabetically by shell name).
+    /// Returns `f64::NAN` if the element or shell is not loaded.
+    #[inline]
+    pub fn cross_section(&self, z: u8, shell: u8, energy_mev: f64) -> f64 {
+        match self.xs_tables.get(&(z, shell)) {
+            Some((e, xs)) => log_log_interp(e, xs, energy_mev),
+            None => f64::NAN,
+        }
+    }
+
+    /// Binding energy [MeV] for a specific subshell.
+    ///
+    /// Returns `f64::NAN` if the element or shell is not loaded.
+    #[inline]
+    pub fn binding_energy(&self, z: u8, shell: u8) -> f64 {
+        self.binding_energies
+            .get(&(z, shell))
+            .copied()
+            .unwrap_or(f64::NAN)
+    }
+
+    /// Number of subshells loaded for element Z.
+    pub fn num_shells(&self, z: u8) -> usize {
+        self.shell_names
+            .get(&z)
+            .map(|v| v.len())
+            .unwrap_or(0)
+    }
+
+    /// Shell name at the given index (e.g. "K", "L1", "M3").
+    pub fn shell_name(&self, z: u8, shell: u8) -> Option<&str> {
+        self.shell_names
+            .get(&z)
+            .and_then(|v| v.get(shell as usize))
+            .map(|s| s.as_str())
+    }
+
+    /// Check if data is loaded for element Z.
+    pub fn has_element(&self, z: u8) -> bool {
+        self.shell_names.contains_key(&z)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn meta_dir() -> std::path::PathBuf {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("..")
+            .join("meta")
+    }
+
+    #[test]
+    #[ignore = "requires nucl-parquet data files"]
+    fn open_succeeds() {
+        let db = SubshellPeDb::open(meta_dir()).unwrap();
+        assert!(db.has_element(29)); // Cu
+    }
+
+    #[test]
+    #[ignore = "requires nucl-parquet data files"]
+    fn cu_has_multiple_shells() {
+        let db = SubshellPeDb::open(meta_dir()).unwrap();
+        let n = db.num_shells(29);
+        assert!(n > 1, "Cu should have multiple subshells, got {n}");
+    }
+
+    #[test]
+    #[ignore = "requires nucl-parquet data files"]
+    fn cu_xs_positive() {
+        let db = SubshellPeDb::open(meta_dir()).unwrap();
+        // Shell 0 (alphabetically first, e.g. "K") at 0.1 MeV
+        let xs = db.cross_section(29, 0, 0.1);
+        assert!(xs.is_finite() && xs > 0.0, "Cu shell 0 XS at 0.1 MeV: {xs}");
+    }
+
+    #[test]
+    #[ignore = "requires nucl-parquet data files"]
+    fn cu_binding_energy_positive() {
+        let db = SubshellPeDb::open(meta_dir()).unwrap();
+        let be = db.binding_energy(29, 0);
+        assert!(be.is_finite() && be > 0.0, "Cu shell 0 binding energy: {be}");
+    }
+}

--- a/clients/rs/nucl-parquet/src/xcom.rs
+++ b/clients/rs/nucl-parquet/src/xcom.rs
@@ -1,0 +1,265 @@
+//! XCOM mass attenuation and energy-absorption coefficients.
+//!
+//! Provides µ/ρ and µ_en/ρ lookups for elements (by Z) and compounds (by name)
+//! with log-log interpolation. Data loaded from `meta/xcom_elements.parquet`
+//! and `meta/xcom_compounds.parquet`.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use arrow::array::{Float64Array, Int32Array, StringArray};
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+
+use crate::interp::{log_log_interp, sort_paired_vecs};
+
+/// XCOM mass attenuation coefficient database.
+///
+/// Thread-safe: `Send + Sync`. Share via `Arc<XcomDb>`.
+#[derive(Clone)]
+pub struct XcomDb {
+    /// Z -> (energy_MeV sorted, mu_rho_cm2_g sorted)
+    elem_mu_rho: HashMap<u8, (Vec<f64>, Vec<f64>)>,
+    /// Z -> (energy_MeV sorted, mu_en_rho_cm2_g sorted)
+    elem_mu_en_rho: HashMap<u8, (Vec<f64>, Vec<f64>)>,
+    /// material name -> (energy_MeV sorted, mu_rho_cm2_g sorted)
+    comp_mu_rho: HashMap<String, (Vec<f64>, Vec<f64>)>,
+    /// material name -> (energy_MeV sorted, mu_en_rho_cm2_g sorted)
+    comp_mu_en_rho: HashMap<String, (Vec<f64>, Vec<f64>)>,
+}
+
+unsafe impl Send for XcomDb {}
+unsafe impl Sync for XcomDb {}
+
+impl XcomDb {
+    /// Load XCOM data from the nucl-parquet `meta/` directory.
+    ///
+    /// Reads `meta/xcom_elements.parquet` and `meta/xcom_compounds.parquet`.
+    pub fn open(meta_dir: impl AsRef<Path>) -> crate::Result<Self> {
+        let meta = meta_dir.as_ref();
+
+        let (elem_mu_rho, elem_mu_en_rho) =
+            Self::load_elements(&meta.join("xcom_elements.parquet"))?;
+        let (comp_mu_rho, comp_mu_en_rho) =
+            Self::load_compounds(&meta.join("xcom_compounds.parquet"))?;
+
+        Ok(Self {
+            elem_mu_rho,
+            elem_mu_en_rho,
+            comp_mu_rho,
+            comp_mu_en_rho,
+        })
+    }
+
+    /// Mass attenuation coefficient µ/ρ [cm²/g] for element Z.
+    ///
+    /// Returns `f64::NAN` if the element is not loaded.
+    #[inline]
+    pub fn mu_rho(&self, z: u8, energy_mev: f64) -> f64 {
+        match self.elem_mu_rho.get(&z) {
+            Some((e, v)) => log_log_interp(e, v, energy_mev),
+            None => f64::NAN,
+        }
+    }
+
+    /// Mass energy-absorption coefficient µ_en/ρ [cm²/g] for element Z.
+    ///
+    /// Returns `f64::NAN` if the element is not loaded.
+    #[inline]
+    pub fn mu_en_rho(&self, z: u8, energy_mev: f64) -> f64 {
+        match self.elem_mu_en_rho.get(&z) {
+            Some((e, v)) => log_log_interp(e, v, energy_mev),
+            None => f64::NAN,
+        }
+    }
+
+    /// Compound mass attenuation coefficient µ/ρ [cm²/g] by material name.
+    ///
+    /// Returns `f64::NAN` if the compound is not loaded.
+    #[inline]
+    pub fn compound_mu_rho(&self, compound: &str, energy_mev: f64) -> f64 {
+        match self.comp_mu_rho.get(compound) {
+            Some((e, v)) => log_log_interp(e, v, energy_mev),
+            None => f64::NAN,
+        }
+    }
+
+    /// Compound mass energy-absorption coefficient µ_en/ρ [cm²/g] by material name.
+    ///
+    /// Returns `f64::NAN` if the compound is not loaded.
+    #[inline]
+    pub fn compound_mu_en_rho(&self, compound: &str, energy_mev: f64) -> f64 {
+        match self.comp_mu_en_rho.get(compound) {
+            Some((e, v)) => log_log_interp(e, v, energy_mev),
+            None => f64::NAN,
+        }
+    }
+
+    /// Check if data is loaded for element Z.
+    pub fn has_element(&self, z: u8) -> bool {
+        self.elem_mu_rho.contains_key(&z)
+    }
+
+    /// List of loaded compound material names.
+    pub fn compound_names(&self) -> Vec<&str> {
+        self.comp_mu_rho.keys().map(|s| s.as_str()).collect()
+    }
+
+    // --- Internal loaders ---
+
+    fn load_elements(
+        path: &Path,
+    ) -> crate::Result<(
+        HashMap<u8, (Vec<f64>, Vec<f64>)>,
+        HashMap<u8, (Vec<f64>, Vec<f64>)>,
+    )> {
+        let mut mu_rho: HashMap<u8, (Vec<f64>, Vec<f64>)> = HashMap::new();
+        let mut mu_en: HashMap<u8, (Vec<f64>, Vec<f64>)> = HashMap::new();
+
+        let file = fs::File::open(path)?;
+        let reader = ParquetRecordBatchReaderBuilder::try_new(file)?.build()?;
+
+        for batch in reader {
+            let batch = batch?;
+
+            let z_col = batch
+                .column_by_name("Z")
+                .and_then(|c| c.as_any().downcast_ref::<Int32Array>());
+            let e_col = batch
+                .column_by_name("energy_MeV")
+                .and_then(|c| c.as_any().downcast_ref::<Float64Array>());
+            let mr_col = batch
+                .column_by_name("mu_rho_cm2_g")
+                .and_then(|c| c.as_any().downcast_ref::<Float64Array>());
+            let men_col = batch
+                .column_by_name("mu_en_rho_cm2_g")
+                .and_then(|c| c.as_any().downcast_ref::<Float64Array>());
+
+            if let (Some(z), Some(e), Some(mr), Some(men)) = (z_col, e_col, mr_col, men_col) {
+                for i in 0..batch.num_rows() {
+                    let zv = z.value(i) as u8;
+                    let ev = e.value(i);
+                    let entry_mr = mu_rho.entry(zv).or_default();
+                    entry_mr.0.push(ev);
+                    entry_mr.1.push(mr.value(i));
+                    let entry_men = mu_en.entry(zv).or_default();
+                    entry_men.0.push(ev);
+                    entry_men.1.push(men.value(i));
+                }
+            }
+        }
+
+        for (e_vec, v_vec) in mu_rho.values_mut() {
+            sort_paired_vecs(e_vec, v_vec);
+        }
+        for (e_vec, v_vec) in mu_en.values_mut() {
+            sort_paired_vecs(e_vec, v_vec);
+        }
+
+        Ok((mu_rho, mu_en))
+    }
+
+    fn load_compounds(
+        path: &Path,
+    ) -> crate::Result<(
+        HashMap<String, (Vec<f64>, Vec<f64>)>,
+        HashMap<String, (Vec<f64>, Vec<f64>)>,
+    )> {
+        let mut mu_rho: HashMap<String, (Vec<f64>, Vec<f64>)> = HashMap::new();
+        let mut mu_en: HashMap<String, (Vec<f64>, Vec<f64>)> = HashMap::new();
+
+        let file = fs::File::open(path)?;
+        let reader = ParquetRecordBatchReaderBuilder::try_new(file)?.build()?;
+
+        for batch in reader {
+            let batch = batch?;
+
+            let mat_col = batch
+                .column_by_name("material")
+                .and_then(|c| c.as_any().downcast_ref::<StringArray>());
+            let e_col = batch
+                .column_by_name("energy_MeV")
+                .and_then(|c| c.as_any().downcast_ref::<Float64Array>());
+            let mr_col = batch
+                .column_by_name("mu_rho_cm2_g")
+                .and_then(|c| c.as_any().downcast_ref::<Float64Array>());
+            let men_col = batch
+                .column_by_name("mu_en_rho_cm2_g")
+                .and_then(|c| c.as_any().downcast_ref::<Float64Array>());
+
+            if let (Some(mat), Some(e), Some(mr), Some(men)) = (mat_col, e_col, mr_col, men_col) {
+                for i in 0..batch.num_rows() {
+                    let name = mat.value(i).to_string();
+                    let ev = e.value(i);
+                    let entry_mr = mu_rho.entry(name.clone()).or_default();
+                    entry_mr.0.push(ev);
+                    entry_mr.1.push(mr.value(i));
+                    let entry_men = mu_en.entry(name).or_default();
+                    entry_men.0.push(ev);
+                    entry_men.1.push(men.value(i));
+                }
+            }
+        }
+
+        for (e_vec, v_vec) in mu_rho.values_mut() {
+            sort_paired_vecs(e_vec, v_vec);
+        }
+        for (e_vec, v_vec) in mu_en.values_mut() {
+            sort_paired_vecs(e_vec, v_vec);
+        }
+
+        Ok((mu_rho, mu_en))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn meta_dir() -> std::path::PathBuf {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("..")
+            .join("meta")
+    }
+
+    #[test]
+    #[ignore = "requires nucl-parquet data files"]
+    fn open_succeeds() {
+        let db = XcomDb::open(meta_dir()).unwrap();
+        assert!(db.has_element(29)); // Cu
+    }
+
+    #[test]
+    #[ignore = "requires nucl-parquet data files"]
+    fn cu_mu_rho_positive() {
+        let db = XcomDb::open(meta_dir()).unwrap();
+        let mu = db.mu_rho(29, 0.1);
+        assert!(mu.is_finite() && mu > 0.0, "Cu mu/rho at 0.1 MeV: {mu}");
+    }
+
+    #[test]
+    #[ignore = "requires nucl-parquet data files"]
+    fn cu_mu_en_rho_positive() {
+        let db = XcomDb::open(meta_dir()).unwrap();
+        let mu = db.mu_en_rho(29, 0.1);
+        assert!(
+            mu.is_finite() && mu > 0.0,
+            "Cu mu_en/rho at 0.1 MeV: {mu}"
+        );
+    }
+
+    #[test]
+    #[ignore = "requires nucl-parquet data files"]
+    fn water_compound_exists() {
+        let db = XcomDb::open(meta_dir()).unwrap();
+        let names = db.compound_names();
+        assert!(
+            names.contains(&"water"),
+            "water should be in compound list: {names:?}"
+        );
+        let mu = db.compound_mu_rho("water", 0.1);
+        assert!(mu.is_finite() && mu > 0.0, "water mu/rho at 0.1 MeV: {mu}");
+    }
+}


### PR DESCRIPTION
## Summary

- `SubshellPeDb` — subshell photoelectric XS from EPDL97 for vacancy shell selection
- `XcomDb` — mass attenuation µ/ρ and µ_en/ρ for 92 elements + pre-tabulated compounds
- `ElectronDb` — EEDL electron cross-sections (elastic, bremsstrahlung, ionization)

All `Send + Sync`, load-at-open into `HashMap`, log-log interpolation. Bumps crate to v0.6.1.

Closes #29

## Test plan
- [x] `cargo build` clean
- [x] `cargo test` — 8 unit + 2 doc tests pass (23 integration tests ignored without data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)