### PR TITLE
fix(go): align module path with actual directory (closes #40)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,5 +82,5 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           VERSION=${GITHUB_REF#refs/tags/v}
-          git tag -a "go/nucl-parquet/v${VERSION}" -m "Go v${VERSION}"
-          git push origin "go/nucl-parquet/v${VERSION}"
+          git tag -a "clients/go/nucl-parquet/v${VERSION}" -m "Go v${VERSION}"
+          git push origin "clients/go/nucl-parquet/v${VERSION}"

--- a/clients/go/nucl-parquet/go.mod
+++ b/clients/go/nucl-parquet/go.mod
@@ -1,4 +1,4 @@
-module github.com/exoma-ch/nucl-parquet/go/nucl-parquet
+module github.com/exoma-ch/nucl-parquet/clients/go/nucl-parquet
 
 go 1.22
 


### PR DESCRIPTION
## Summary

The Go module declared itself at \`github.com/exoma-ch/nucl-parquet/go/nucl-parquet\`, but sources moved to \`clients/go/nucl-parquet/\`. \`go get\` against the declared path fails silently — Go walks path segments in the repo and there is no top-level \`go/\` dir. All \`go/nucl-parquet/v*\` tags (v0.3.1–v0.9.0) are orphaned by the same mismatch.

## Changes

- \`clients/go/nucl-parquet/go.mod\`: \`module ... /clients/go/nucl-parquet\`
- \`.github/workflows/release.yml\`: \`go-tag\` job pushes \`clients/go/nucl-parquet/v*\` tags

## Breaking?

Pre-1.0 pkg, and the "old" path was already broken, so only nominally breaking. Old tags left orphaned (harmless).

After merge + next release, consumers install with:

\`\`\`bash
go get github.com/exoma-ch/nucl-parquet/clients/go/nucl-parquet@latest
\`\`\`

## Test plan

- [ ] CI \`Go module\` job passes (runs \`go vet\` + \`go test\` — only possible if module path resolves)
- [ ] After next release, \`go get ...@clients/go/nucl-parquet/v0.9.1\` resolves