### PR TITLE
feat(ci): MCP publish jobs + lockstep versioning (closes #39)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,56 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
+  pypi-mcp:
+    name: Publish nucl-parquet-mcp to PyPI
+    runs-on: ubuntu-latest
+    environment: pypi-mcp
+    defaults:
+      run:
+        working-directory: clients/py/nucl-parquet-mcp
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv build
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: clients/py/nucl-parquet-mcp/dist
+
+  npm-mcp:
+    name: Publish @nucl-parquet/mcp to npm
+    runs-on: ubuntu-latest
+    environment: npm
+    permissions:
+      contents: read
+      id-token: write
+    defaults:
+      run:
+        working-directory: clients/ts/nucl-parquet-mcp
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+      - run: npm ci
+      - run: npm run build
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  cargo-mcp:
+    name: Publish nucl-parquet-mcp to crates.io
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: clients/rs/nucl-parquet-mcp
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo publish --allow-dirty
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
   go-tag:
     name: Mirror Go module tag
     runs-on: ubuntu-latest

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,8 +12,23 @@
           "jsonpath": "$.package.version"
         },
         {
+          "type": "toml",
+          "path": "clients/rs/nucl-parquet-mcp/Cargo.toml",
+          "jsonpath": "$.package.version"
+        },
+        {
+          "type": "toml",
+          "path": "clients/py/nucl-parquet-mcp/pyproject.toml",
+          "jsonpath": "$.project.version"
+        },
+        {
           "type": "json",
           "path": "clients/ts/nucl-parquet/package.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "clients/ts/nucl-parquet-mcp/package.json",
           "jsonpath": "$.version"
         }
       ]


### PR DESCRIPTION
## Summary

Three MCP packages (\`nucl-parquet-mcp\` rs + py, \`@nucl-parquet/mcp\` ts) had no publish jobs in \`release.yml\`. Their versions drifted manually: rs 0.3.9 (crates.io has 0.3.8), py 0.3.8 (never on PyPI), ts 0.8.1 (never on npm). The BASE_URL fix from #37 can't reach users without this.

## Approach

**Option (a)** per #39: lockstep MCP versions with the core \`nucl-parquet\` release. Pre-1.0 fast-forward accepted.

- \`release-please-config.json\`: \`extra-files\` now covers all six version-bearing files (root pyproject, rs+ts core, rs+py+ts MCP). One release PR bumps them all.
- \`release.yml\`: three new publish jobs — \`pypi-mcp\`, \`npm-mcp\`, \`cargo-mcp\` — mirroring the core ones.

At next release (likely v0.9.1), MCP packages jump from 0.3.x/0.8.x to v0.9.1. Users pinning old MCP versions need to unpin.

## Required admin config (before first successful release)

- [ ] **PyPI**: register \`nucl-parquet-mcp\` as a trusted publisher for this repo (new GitHub environment \`pypi-mcp\`). Workflow: \`release.yml\`, job: \`pypi-mcp\`.
- [ ] **npm**: ensure \`NPM_TOKEN\` scope covers \`@nucl-parquet/mcp\` (likely already does via org token).
- [ ] **crates.io**: \`CARGO_REGISTRY_TOKEN\` already published \`nucl-parquet-mcp\` v0.3.8 — no change needed.

If \`pypi-mcp\` env is missing at release time, that job fails but the others continue — not a hard block.

## Test plan

- [ ] CI passes on this PR (no release trigger yet — publish jobs only run on \`v*\` tag push)
- [ ] After merge + next release-please PR merge, observe all six publish jobs in the release workflow run
- [ ] Verify \`cargo install nucl-parquet-mcp\`, \`uv tool install nucl-parquet-mcp\`, \`npx @nucl-parquet/mcp\` all work post-release

## Related

- Depends on ordering with #45 (go-tag path) and #44 (prek) — any order is fine, they don't conflict