### PR TITLE
fix(ci): use PAT for release-please so tag pushes trigger release.yml

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,5 +14,9 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
+          # PAT (or GitHub App token) is required so the tag push triggers
+          # release.yml. GITHUB_TOKEN-pushed tags are silently ignored by
+          # workflow triggers — see #35 / #57 for the history.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary

Fixes the root cause of why every release before v0.10.0 silently failed to fire \`release.yml\`, and why v0.10.0 itself had to be re-tagged manually after merge to publish.

## Problem

GitHub doesn't trigger workflows from tags or PRs created by \`GITHUB_TOKEN\`. \`release-please-action\` defaults to using \`GITHUB_TOKEN\`, so when it pushes the \`v*\` tag on PR merge, \`release.yml\` (which triggers on \`tags: [\"v*\"]\`) silently does nothing. We've worked around this twice manually:
- Re-pushing the \`v0.10.0\` tag with my CLI auth (today)
- The whole #35 saga where this masked broken release jobs for 5 versions

## Fix

Pass an explicit \`token: \${{ secrets.RELEASE_PLEASE_TOKEN }}\` to the action. PAT-pushed tags trigger workflows.

## Required setup before merge

You need to create the secret:

1. **Create a PAT** at https://github.com/settings/personal-access-tokens/new
   - Resource owner: \`exoma-ch\`
   - Repository access: \`Only select repositories\` → \`nucl-parquet\`
   - Repository permissions: \`Contents: Read and write\`, \`Pull requests: Read and write\`, \`Workflows: Read and write\`
   - Expiration: 1 year (set a calendar reminder to rotate)
2. **Save it** at https://github.com/exoma-ch/nucl-parquet/settings/secrets/actions/new as \`RELEASE_PLEASE_TOKEN\`
3. **Merge this PR**

Without the secret, \`secrets.RELEASE_PLEASE_TOKEN\` evaluates to empty and the action falls back to \`GITHUB_TOKEN\` — back to the broken behaviour.

## Long-term

Better than a PAT: install the \"Release Please\" GitHub App or a generic GitHub App with the same scopes. App tokens don't expire on a calendar and aren't tied to a person. Filed mentally as a future cleanup; PAT is fine for now.

## Test plan

- [ ] Secret \`RELEASE_PLEASE_TOKEN\` exists in repo secrets
- [ ] After merge, next release-please PR opens normally
- [ ] When that release PR merges, \`release.yml\` fires automatically (no manual tag re-push)