### PR TITLE
chore(state): post-merge review polish for #57 and #61

### DIFF
--- a/nucl_parquet/build_radiation_state.py
+++ b/nucl_parquet/build_radiation_state.py
@@ -29,6 +29,22 @@ from .download import data_dir as _resolve_data_dir
 _LEVEL_EXACT_MATCH_KEV = 0.5
 
 
+class BuildIntegrityError(RuntimeError):
+    """Raised when a data refresh introduces drift past the documented ceilings."""
+
+
+# Empirical baselines from v0.10.1 (#58) data: 77 orphan (Z,A), 2577 unlabeled-
+# excited radiation rows. Ceilings sit ~10% above the floors — tight enough to
+# catch silent drift from a future ENSDF refresh, loose enough to absorb a
+# small batch of new (Z,A) coverage. `>` (strict) is the breach test, so a
+# count exactly equal to the ceiling does *not* raise. Bump only after
+# auditing whether the new entries are genuine cascade parents (correctly
+# labelled '') or real isomers missing from nuclides.parquet (need backfill —
+# see #58 Phase 2).
+_ORPHAN_CEILING = 90
+_UNLABELED_EXCITED_CEILING = 2800
+
+
 def build(data_dir: Path | None = None) -> None:
     """Add state column to all radiation/*.parquet files."""
     if data_dir is None:
@@ -82,18 +98,6 @@ def build(data_dir: Path | None = None) -> None:
     _validate(data_dir)
 
 
-# Empirical baselines from the v0.10.0+#58 data: 77 orphan (Z,A) and 2577
-# unlabeled-excited radiation rows. The ceilings allow modest headroom for
-# routine ENSDF refreshes; a refresh that introduces dramatically more
-# orphans/unlabeled rows almost certainly indicates new (Z,A) coverage in
-# radiation that nuclides.parquet hasn't caught up with — surface it loudly
-# rather than silently expanding the "ground" bucket. Bump these only after
-# verifying the new entries are genuine cascade parents (not real isomers
-# missing from nuclides — see #58 Phase 2).
-_ORPHAN_CEILING = 100
-_UNLABELED_EXCITED_CEILING = 3000
-
-
 def _surface_diagnostics(
     orphans: set[tuple[int, int]],
     unlabeled_excited: list[tuple[int, int, float, str, float]],
@@ -135,10 +139,6 @@ def _surface_diagnostics(
             "before bumping the ceilings (see #58 Phase 2)."
         )
         raise BuildIntegrityError(msg)
-
-
-class BuildIntegrityError(RuntimeError):
-    """Raised when a data refresh introduces drift past the documented ceilings."""
 
 
 def _assign_states(

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -17,6 +17,7 @@ Design notes:
 
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 
 import duckdb
@@ -205,26 +206,44 @@ def test_assigner_far_match_is_ground_not_isomer() -> None:
 
 def test_assigner_threshold_boundary_inclusive() -> None:
     """Boundary at exactly _LEVEL_EXACT_MATCH_KEV is *inclusive* (labelled isomer).
-    Pinned so a future tweak from `>` to `>=` is caught."""
+    Pinned so a future tweak from `>` to `>=` is caught. Covers below, at,
+    and just-past the threshold."""
     state_map = {(1, 1): [("m", 100.0)]}
     df = _mk_rad(
         [
-            {"Z": 1, "A": 1, "parent_level_keV": 100.5},  # exactly at threshold → 'm'
+            {"Z": 1, "A": 1, "parent_level_keV": 100.49},  # below threshold → 'm'
+            {"Z": 1, "A": 1, "parent_level_keV": 100.5},  # exactly at → 'm'
             {"Z": 1, "A": 1, "parent_level_keV": 100.51},  # just past → ''
         ]
     )
     unlabeled: list = []
     states = _assign_states(df, state_map=state_map, orphans=set(), unlabeled_excited=unlabeled)
-    assert states == ["m", ""]
+    assert states == ["m", "m", ""]
     assert len(unlabeled) == 1
 
 
 def test_surface_diagnostics_within_ceilings_only_warns() -> None:
-    """Counts at or below the ceiling stay as warnings (build still succeeds)."""
+    """Counts at the ceiling stay as warnings (build still succeeds). Pins
+    that both warnings (orphan + unlabeled) fire and that their messages
+    contain the expected anchor strings — a regression that collapses both
+    into one warning, swaps message text, or drops the example payload
+    would slip past `pytest.warns(UserWarning)` alone."""
     orphans = {(99, 199 + i) for i in range(_ORPHAN_CEILING)}
     unlabeled = [(1, 1, 100.0, "m", 50.0)] * _UNLABELED_EXCITED_CEILING
-    with pytest.warns(UserWarning):
+    with pytest.warns(UserWarning) as rec:
         _surface_diagnostics(orphans, unlabeled)  # must not raise
+    assert len(rec) == 2
+    assert any("no entry in state_map" in str(w.message) for w in rec)
+    assert any("farther than" in str(w.message) for w in rec)
+    assert any("Examples:" in str(w.message) for w in rec)
+
+
+def test_surface_diagnostics_empty_no_warning() -> None:
+    """Empty diagnostics → no warning fires. Catches a regression that
+    would warn unconditionally."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any warning becomes a test failure
+        _surface_diagnostics(set(), [])
 
 
 def test_surface_diagnostics_breach_raises() -> None:
@@ -252,6 +271,62 @@ def test_assert_unique_levels_accepts_distinct() -> None:
 
 
 # ---------------------------------------------------------------------------
+# get_state_map unit tests — hand-rolled nuclides.parquet so this works
+# without `@pytest.mark.data`. Covers the rewrite from PR #61.
+# ---------------------------------------------------------------------------
+
+
+def _write_synthetic_nuclides(tmp_path: Path, rows: list[dict]) -> Path:
+    """Write a minimal nuclides.parquet under tmp_path with the schema
+    `get_state_map` reads."""
+    nuc_dir = tmp_path / "meta" / "ensdf"
+    nuc_dir.mkdir(parents=True)
+    df = pl.DataFrame(rows, schema={"Z": pl.Int32, "A": pl.Int32, "state": pl.Utf8, "level_keV": pl.Float64})
+    df.write_parquet(nuc_dir / "nuclides.parquet")
+    return tmp_path
+
+
+def test_get_state_map_missing_file_raises(tmp_path: Path) -> None:
+    """Pipeline order: build_nuclides must run before build_radiation_state.
+    A missing nuclides.parquet must raise a clear FileNotFoundError naming
+    the file — never a downstream cryptic DuckDB error."""
+    with pytest.raises(FileNotFoundError, match="nuclides.parquet"):
+        get_state_map(tmp_path)
+
+
+def test_get_state_map_filters_ground_null_and_zero_z(tmp_path: Path) -> None:
+    """Only isomers with non-empty state, non-NULL level_keV, and Z>0 enter
+    the state_map. Pins three filters that the rewrite from PR #61 added —
+    dropping any of them re-introduces the pre-#58 phantom-isomer hazard."""
+    data_dir = _write_synthetic_nuclides(
+        tmp_path,
+        [
+            {"Z": 63, "A": 152, "state": "", "level_keV": 0.0},  # ground — must skip
+            {"Z": 63, "A": 152, "state": "m", "level_keV": 45.6},  # real isomer — keep
+            {"Z": 25, "A": 46, "state": "m", "level_keV": None},  # NULL level — must skip
+            {"Z": 0, "A": 247, "state": "m", "level_keV": 100.0},  # Z=0 SF — must skip
+            {"Z": 43, "A": 99, "state": "m", "level_keV": 142.68},  # real isomer — keep
+        ],
+    )
+    state_map = get_state_map(data_dir)
+    assert state_map == {(63, 152): [("m", 45.6)], (43, 99): [("m", 142.68)]}
+
+
+def test_get_state_map_groups_multiple_isomers_per_za(tmp_path: Path) -> None:
+    """Two isomers for the same (Z,A) collect into one list entry."""
+    data_dir = _write_synthetic_nuclides(
+        tmp_path,
+        [
+            {"Z": 47, "A": 110, "state": "m", "level_keV": 117.6},
+            {"Z": 47, "A": 110, "state": "m2", "level_keV": 1499.0},
+        ],
+    )
+    state_map = get_state_map(data_dir)
+    assert (47, 110) in state_map
+    assert sorted(state_map[(47, 110)]) == [("m", 117.6), ("m2", 1499.0)]
+
+
+# ---------------------------------------------------------------------------
 # Invariants + spot-checks over real data (@pytest.mark.data).
 # ---------------------------------------------------------------------------
 
@@ -263,6 +338,9 @@ def test_state_map_is_subset_of_nuclides(data_dir_path: Path) -> None:
     to the pre-#58 behaviour of fabricating isomers from levels.parquet or
     radiation parent_level_keV."""
     state_map = get_state_map(data_dir_path)
+    # An empty state_map would trivially pass the subset check below — guard
+    # against a regression that returns {} (wrong path, wrong column filter).
+    assert state_map, "state_map is empty — get_state_map regressed silently"
 
     db = duckdb.connect()
     nuc_path = data_dir_path / "meta" / "ensdf" / "nuclides.parquet"


### PR DESCRIPTION
## Summary

Round-2 fresh-agent reviews of the merged #57 + #61 fixes flagged a few small follow-ups; this PR bundles the cheap concrete patches.

### Implementation polish (`build_radiation_state.py`)
- Move `BuildIntegrityError` class above its first use site (was a runtime-safe forward reference, but stylistically odd).
- Tighten `_ORPHAN_CEILING` 100 → 90 and `_UNLABELED_EXCITED_CEILING` 3000 → 2800. Empirical floor (77, 2577) now sits ~10% below the ceilings — tight enough to catch silent ENSDF-refresh drift, loose enough to absorb a small batch of new (Z,A) coverage.
- Document `>` (strict) breach semantics so a count *exactly* at the ceiling does not raise.

### Test coverage (`tests/test_state.py`)
- Add 3 unit tests for `get_state_map` covering FileNotFoundError, the 3-way filter (state != '', level_keV NOT NULL, Z > 0), and multi-isomer (Z,A) grouping — none of these were covered without `@pytest.mark.data`.
- `test_state_map_is_subset_of_nuclides`: assert state_map is non-empty (was trivially passing for `{}`).
- `test_surface_diagnostics_within_ceilings_only_warns`: assert exact warning count == 2 and message anchor strings ("no entry in state_map", "farther than", "Examples:") so a regression collapsing/swapping/silently dropping payload is caught.
- `test_surface_diagnostics_empty_no_warning`: pin that empty input emits zero warnings.
- `test_assigner_threshold_boundary_inclusive`: extend to cover below-, at-, and just-past-threshold cases.

## Test plan

- [x] `uv run pytest tests/ -q` — 56 passed (was 52)
- [x] `uv run python -m nucl_parquet.build_radiation_state` — succeeds; warnings within the new ceilings (77 ≤ 90, 2577 ≤ 2800)
- [x] No data files regenerated — empirical counts unchanged

Refs: #57, #58