### PR TITLE
fix(g4): ensdfstate -> nuclides + ground_states (closes #69)

### DIFF
--- a/nucl_parquet/g4/__init__.py
+++ b/nucl_parquet/g4/__init__.py
@@ -1,0 +1,16 @@
+"""G4-derived data converters.
+
+Build-time scripts that transform Geant4 ASCII data files (already published as
+Parquet by the strata project) into nucl-parquet's v0.10.x-compatible parquet
+schemas. Per ADR-0002, transforms preserve the legacy column names (`level_keV`,
+`half_life_s`, `jp`) while dual-carrying strata-native columns (`spin_x2`,
+`floating_level_flag`, `magnetic_moment_jt`) for a future v1.0 cutover.
+
+Modules
+-------
+- :mod:`nucl_parquet.g4.ensdfstate` — G4ENSDFSTATE3.0 → ``nuclides.parquet`` +
+  ``ground_states.parquet``, joined with AME2020 (mass excess) and IUPAC
+  (abundance) auxiliary tables.
+"""
+
+from __future__ import annotations

--- a/nucl_parquet/g4/ensdfstate.py
+++ b/nucl_parquet/g4/ensdfstate.py
@@ -76,6 +76,25 @@ _OUT_GROUND_STATES = Path("meta/ensdf/ground_states.parquet")
 # ---------------------------------------------------------------------------
 
 
+def _half_life_expr(col: str = "mean_life_ns") -> pl.Expr:
+    """Polars expression mirror of ``convert_mean_life`` for batch transforms.
+
+    Single source of truth — both the Python primitive (used in unit tests)
+    and the production batch path (``_build_states_frame``) consume the
+    same logic; a future optimization on either branch is forced to update
+    the other or break the round-trip test in ``tests/test_g4_ensdfstate``.
+    """
+    return (
+        pl.when(pl.col(col).is_null())
+        .then(None)
+        .when(pl.col(col) == G4_STABLE_MEAN_LIFE_NS)
+        .then(pl.lit(math.inf))
+        .when(pl.col(col) == 0.0)
+        .then(pl.lit(0.0))
+        .otherwise(pl.col(col) * LN2 * 1e-9)
+    )
+
+
 def convert_mean_life(mean_life_ns: float | None) -> float | None:
     """G4 ``mean_life_ns`` -> ``half_life_s`` per ADR-0002.
 
@@ -194,21 +213,21 @@ def _build_states_frame(strata: pl.DataFrame, elements: pl.DataFrame) -> pl.Data
     converted = strata.rename({"z": "Z", "a": "A", "excitation_kev": "level_keV"}).with_columns(
         Z=pl.col("Z").cast(pl.Int32),
         A=pl.col("A").cast(pl.Int32),
-        # Pure-Polars half-life conversion mirroring `convert_mean_life`. We
-        # preserve NULL by checking is_not_null() first.
-        half_life_s=pl.when(pl.col("mean_life_ns").is_null())
-        .then(None)
-        .when(pl.col("mean_life_ns") == G4_STABLE_MEAN_LIFE_NS)
-        .then(pl.lit(math.inf))
-        .when(pl.col("mean_life_ns") == 0.0)
-        .then(pl.lit(0.0))
-        .otherwise(pl.col("mean_life_ns") * LN2 * 1e-9),
+        # Half-life conversion via the shared expression — same logic the
+        # convert_mean_life Python primitive (unit-tested) implements.
+        half_life_s=_half_life_expr("mean_life_ns"),
         # jp encoding via map_elements — the per-row branching is awkward in
         # pure-Polars and the row count (28 k) is small enough.
         jp=pl.struct(["spin_x2", "floating_level_flag"]).map_elements(
             lambda s: encode_jp(s["spin_x2"], s["floating_level_flag"]),
             return_dtype=pl.String,
         ),
+        # Dual-carry parity column per ADR-0002. G4ENSDFSTATE doesn't expose
+        # parity (column 4 is floating_level_flag, not parity), so we ship
+        # all-NULL here. PhotonEvaporation (#70) populates parity from jpi's
+        # sign for level rows. Keeping the column ensures schema stability:
+        # v1.0 cleanup is a column drop, not a column re-introduction.
+        parity=pl.lit(None, dtype=pl.Int8),
     )
     return converted.join(elements.select(["Z", "symbol"]), on="Z", how="left")
 
@@ -233,8 +252,11 @@ def build_nuclides(strata: pl.DataFrame, elements: pl.DataFrame) -> pl.DataFrame
         pl.lit(None, dtype=pl.Float64).alias("decay_1_pct"),
         pl.lit(None, dtype=pl.String).alias("decay_2"),
         pl.lit(None, dtype=pl.Float64).alias("decay_2_pct"),
-        # Dual-carry per ADR-0002.
+        # Dual-carry per ADR-0002. parity is all-NULL on this branch
+        # (G4ENSDFSTATE doesn't expose parity; PhotonEvaporation #70 will
+        # populate it from jpi-sign for level rows).
         pl.col("spin_x2").cast(pl.Int16),
+        pl.col("parity").cast(pl.Int8),
         pl.col("floating_level_flag").cast(pl.String),
         # Bonus.
         pl.col("magnetic_moment_jt").cast(pl.Float64),
@@ -300,8 +322,11 @@ def build_ground_states(
         pl.col("atomic_mass_microu").cast(pl.Float64),
         pl.col("atomic_mass_unc_microu").cast(pl.Float64),
         pl.col("ame_is_estimated").cast(pl.Boolean),
-        # Dual-carry per ADR-0002.
+        # Dual-carry per ADR-0002. parity is all-NULL on this branch
+        # (G4ENSDFSTATE doesn't expose parity; PhotonEvaporation #70 will
+        # populate it from jpi-sign for level rows).
         pl.col("spin_x2").cast(pl.Int16),
+        pl.col("parity").cast(pl.Int8),
         pl.col("floating_level_flag").cast(pl.String),
         # Bonus.
         pl.col("magnetic_moment_jt").cast(pl.Float64),

--- a/nucl_parquet/g4/ensdfstate.py
+++ b/nucl_parquet/g4/ensdfstate.py
@@ -1,0 +1,361 @@
+"""Build ``meta/ensdf/nuclides.parquet`` and ``meta/ensdf/ground_states.parquet``
+from strata's G4ENSDFSTATE3.0 mirror, joined with AME2020 (mass excess) and
+IUPAC (abundances) auxiliaries.
+
+Per ADR-0002 the v0.10.x output schema is preserved:
+
+- ``level_keV``      <- ``excitation_kev`` (rename only)
+- ``half_life_s``    <- ``convert_mean_life(mean_life_ns)`` (see below)
+- ``jp``             <- ``encode_jp(spin_x2)`` (J-only string; G4ENSDFSTATE
+  does not ship parity, only ``floating_level_flag``)
+- ``state``          <- ``''`` for ground; ``'m'``, ``'m2'`` ... for ascending
+  long-lived isomers per (Z, A) using the canonical >1 ms threshold
+- Dual-carry: ``spin_x2`` (Int16) + ``floating_level_flag`` (str) shipped beside
+  ``jp`` for the v1.0 cleanup path.
+- Bonus: ``magnetic_moment_jt`` (Float64).
+
+``ground_states.parquet`` is a strict ground-state filter LEFT-JOINed onto AME2020
+and IUPAC compositions on (Z, A); rows with no aux match keep NULL.
+
+Half-life conversion (binding spec from ADR-0002):
+
+==================================  =============================
+G4 ``mean_life_ns`` value           Output ``half_life_s``
+==================================  =============================
+``> 0``                             ``mean_life_ns * ln(2) * 1e-9``
+``-1`` (G4 stable sentinel)         ``+inf`` (IEEE-754 infinity)
+``0`` (prompt sentinel)             ``0.0``
+NULL / missing                      NULL
+==================================  =============================
+
+Crucial: the ``-1`` sentinel MUST be intercepted before multiplication. A naive
+``-1 * ln(2) * 1e-9`` yields a *negative* half-life that silently corrupts
+downstream queries — the boundary is unit-tested explicitly.
+
+Usage
+-----
+::
+
+    uv run python -m nucl_parquet.g4.ensdfstate
+    # or programmatically:
+    from nucl_parquet.g4.ensdfstate import build
+    build()
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+from pathlib import Path
+
+import polars as pl
+
+from nucl_parquet.download import data_dir as _resolve_data_dir
+
+LN2 = math.log(2.0)
+
+# ENSDF convention: "long-lived" isomer threshold = T_1/2 > 1 ms. Converted to
+# mean-life ns: 1 ms / ln(2) = 1.4427e-3 s = 1.4427e6 ns.
+LONG_LIVED_MEAN_LIFE_NS_THRESHOLD = 1.4427e6
+
+# G4 ENSDFSTATE sentinels (per strata's gen_ensdfstate_parquet.py).
+G4_STABLE_MEAN_LIFE_NS = -1.0
+G4_UNKNOWN_SPIN_X2 = -2  # parser uses -2 when token cannot be parsed.
+
+# Default relative input/output paths under the data root.
+_STRATA_ENSDFSTATE = Path("g4_raw/strata-nuclear/ensdfstate.parquet")
+_AME2020 = Path("auxiliary/ame2020.parquet")
+_IUPAC = Path("auxiliary/iupac_compositions.parquet")
+_ELEMENTS = Path("meta/elements.parquet")
+_OUT_NUCLIDES = Path("meta/ensdf/nuclides.parquet")
+_OUT_GROUND_STATES = Path("meta/ensdf/ground_states.parquet")
+
+
+# ---------------------------------------------------------------------------
+# Pure transform primitives (unit-tested in tests/test_g4_ensdfstate.py).
+# ---------------------------------------------------------------------------
+
+
+def convert_mean_life(mean_life_ns: float | None) -> float | None:
+    """G4 ``mean_life_ns`` -> ``half_life_s`` per ADR-0002.
+
+    The ``-1`` G4 stable-sentinel MUST be intercepted before multiplication;
+    otherwise a naive product yields a negative half-life.
+    """
+    if mean_life_ns is None:
+        return None
+    if mean_life_ns == G4_STABLE_MEAN_LIFE_NS:
+        return math.inf
+    if mean_life_ns == 0.0:
+        return 0.0
+    return mean_life_ns * LN2 * 1e-9
+
+
+def encode_jp(spin_x2: int | None, floating_level_flag: str | None = None) -> str | None:
+    """Encode ``spin_x2`` to a v0.10.x-style ``jp`` string.
+
+    G4ENSDFSTATE does not carry parity; only spin (as 2J) and a
+    ``floating_level_flag`` token are available. Therefore ``jp`` is J-only.
+
+    - ``spin_x2 = -2`` (G4 parser unknown sentinel) -> ``None``
+    - even ``spin_x2`` -> integer J (e.g. 12 -> "6")
+    - odd ``spin_x2``  -> half-integer J (e.g. 3 -> "3/2")
+    - ``spin_x2 = 0``  -> "0"
+    - any non-trivial ``floating_level_flag`` (anything other than '-') is
+      preserved verbatim as a suffix in parens, e.g. spin_x2=3 + flag '+X'
+      -> "3/2(+X)". Strata's '-' indicates "not floating" and is dropped.
+    """
+    if spin_x2 is None or spin_x2 == G4_UNKNOWN_SPIN_X2:
+        return None
+    if spin_x2 < 0:
+        return None
+    if spin_x2 % 2 == 0:
+        j = str(spin_x2 // 2)
+    else:
+        j = f"{spin_x2}/2"
+    if floating_level_flag and floating_level_flag != "-":
+        return f"{j}({floating_level_flag})"
+    return j
+
+
+def assign_state_labels(df: pl.DataFrame) -> pl.DataFrame:
+    """Label rows in ``df`` with ``state`` ('' / 'm' / 'm2' / ...).
+
+    ``df`` must contain ``Z``, ``A``, ``level_keV``, ``mean_life_ns``. The
+    ground state (lowest ``level_keV`` per (Z,A), expected to be 0) gets ``''``;
+    long-lived isomers (``mean_life_ns > 1.44e6`` ns ≈ T½ > 1 ms) above ground
+    are labeled ``m``, ``m2``, ... in ascending ``level_keV`` order.
+
+    Excited levels that do not meet the long-lived threshold are NOT included
+    in the returned frame; this filter mirrors the v0.10.x ``nuclides.parquet``
+    convention.
+    """
+    # Ground state per (Z,A): the row with the lowest level_keV. We assume
+    # exactly one ground per (Z,A) — strata's input guarantees this.
+    is_ground = pl.col("level_keV") == pl.col("level_keV").min().over(["Z", "A"])
+
+    long_lived = (pl.col("mean_life_ns").is_not_null()) & (
+        (pl.col("mean_life_ns") > LONG_LIVED_MEAN_LIFE_NS_THRESHOLD)
+        | (pl.col("mean_life_ns") == G4_STABLE_MEAN_LIFE_NS)
+    )
+
+    keep = is_ground | long_lived
+    filtered = df.filter(keep).sort(["Z", "A", "level_keV"])
+
+    # Within each (Z,A): first row is ground (state=''), subsequent rows are
+    # m, m2, m3, ... in ascending level_keV order.
+    state_idx = pl.int_range(0, pl.len()).over(["Z", "A"])
+    state_label = (
+        pl.when(state_idx == 0)
+        .then(pl.lit(""))
+        .when(state_idx == 1)
+        .then(pl.lit("m"))
+        .otherwise(pl.lit("m") + state_idx.cast(pl.String))
+    )
+    return filtered.with_columns(state_label.alias("state"))
+
+
+# ---------------------------------------------------------------------------
+# Build entry-point.
+# ---------------------------------------------------------------------------
+
+
+def _load_inputs(
+    data_dir: Path,
+    *,
+    strata_path: Path | None = None,
+    ame_path: Path | None = None,
+    iupac_path: Path | None = None,
+    elements_path: Path | None = None,
+) -> tuple[pl.DataFrame, pl.DataFrame, pl.DataFrame, pl.DataFrame]:
+    paths = {
+        "strata": strata_path or (data_dir / _STRATA_ENSDFSTATE),
+        "ame": ame_path or (data_dir / _AME2020),
+        "iupac": iupac_path or (data_dir / _IUPAC),
+        "elements": elements_path or (data_dir / _ELEMENTS),
+    }
+    missing = [str(p) for p in paths.values() if not p.exists()]
+    if missing:
+        raise FileNotFoundError(
+            "ensdfstate converter requires the following inputs:\n  "
+            + "\n  ".join(missing)
+            + "\nRun `uv run python scripts/fetch_strata_nuclear.py` first."
+        )
+    return (
+        pl.read_parquet(paths["strata"]),
+        pl.read_parquet(paths["ame"]),
+        pl.read_parquet(paths["iupac"]),
+        pl.read_parquet(paths["elements"]),
+    )
+
+
+def _build_states_frame(strata: pl.DataFrame, elements: pl.DataFrame) -> pl.DataFrame:
+    """Apply ADR-0002 transforms to the raw strata frame (without filtering)."""
+    converted = strata.rename({"z": "Z", "a": "A", "excitation_kev": "level_keV"}).with_columns(
+        Z=pl.col("Z").cast(pl.Int32),
+        A=pl.col("A").cast(pl.Int32),
+        # Pure-Polars half-life conversion mirroring `convert_mean_life`. We
+        # preserve NULL by checking is_not_null() first.
+        half_life_s=pl.when(pl.col("mean_life_ns").is_null())
+        .then(None)
+        .when(pl.col("mean_life_ns") == G4_STABLE_MEAN_LIFE_NS)
+        .then(pl.lit(math.inf))
+        .when(pl.col("mean_life_ns") == 0.0)
+        .then(pl.lit(0.0))
+        .otherwise(pl.col("mean_life_ns") * LN2 * 1e-9),
+        # jp encoding via map_elements — the per-row branching is awkward in
+        # pure-Polars and the row count (28 k) is small enough.
+        jp=pl.struct(["spin_x2", "floating_level_flag"]).map_elements(
+            lambda s: encode_jp(s["spin_x2"], s["floating_level_flag"]),
+            return_dtype=pl.String,
+        ),
+    )
+    return converted.join(elements.select(["Z", "symbol"]), on="Z", how="left")
+
+
+def build_nuclides(strata: pl.DataFrame, elements: pl.DataFrame) -> pl.DataFrame:
+    """Construct the v0.10.x-compatible ``nuclides.parquet`` frame."""
+    states = _build_states_frame(strata, elements)
+    labelled = assign_state_labels(states)
+
+    # decay_1 / decay_1_pct / decay_2 / decay_2_pct are populated by the
+    # downstream ``radioactive_decay`` converter (#71). At this layer we leave
+    # them NULL so the schema stays identical to v0.10.x.
+    return labelled.select(
+        pl.col("Z").cast(pl.Int32),
+        pl.col("A").cast(pl.Int32),
+        pl.col("state").cast(pl.String),
+        pl.col("symbol").cast(pl.String),
+        pl.col("jp").cast(pl.String),
+        pl.col("half_life_s").cast(pl.Float64),
+        pl.col("level_keV").cast(pl.Float64),
+        pl.lit(None, dtype=pl.String).alias("decay_1"),
+        pl.lit(None, dtype=pl.Float64).alias("decay_1_pct"),
+        pl.lit(None, dtype=pl.String).alias("decay_2"),
+        pl.lit(None, dtype=pl.Float64).alias("decay_2_pct"),
+        # Dual-carry per ADR-0002.
+        pl.col("spin_x2").cast(pl.Int16),
+        pl.col("floating_level_flag").cast(pl.String),
+        # Bonus.
+        pl.col("magnetic_moment_jt").cast(pl.Float64),
+    ).sort(["Z", "A", "level_keV"])
+
+
+def build_ground_states(
+    strata: pl.DataFrame,
+    ame: pl.DataFrame,
+    iupac: pl.DataFrame,
+    elements: pl.DataFrame,
+) -> pl.DataFrame:
+    """Construct the v0.10.x-compatible ``ground_states.parquet`` frame."""
+    states = _build_states_frame(strata, elements)
+    # Ground state := lowest level_keV per (Z, A). G4ENSDFSTATE always ships
+    # excitation_kev=0 for ground; we use min() to be defensive.
+    ground_only = states.sort(["Z", "A", "level_keV"]).group_by(["Z", "A"], maintain_order=True).first()
+
+    ame_proj = ame.select(
+        pl.col("Z").cast(pl.Int32),
+        pl.col("A").cast(pl.Int32),
+        pl.col("N").cast(pl.Int64),
+        "mass_excess_keV",
+        "mass_excess_unc_keV",
+        "binding_energy_per_A_keV",
+        "binding_energy_per_A_unc_keV",
+        "beta_decay_energy_keV",
+        "beta_decay_energy_unc_keV",
+        "atomic_mass_microu",
+        "atomic_mass_unc_microu",
+        pl.col("is_estimated").alias("ame_is_estimated"),
+    )
+    iupac_proj = iupac.select(
+        pl.col("Z").cast(pl.Int32),
+        pl.col("A").cast(pl.Int32),
+        pl.col("isotopic_composition").alias("abundance"),
+        pl.col("isotopic_composition_unc_last_digit").alias("unc_abundance"),
+        pl.col("relative_atomic_mass_u").alias("atomic_mass_u"),
+        pl.col("standard_atomic_weight"),
+    )
+
+    joined = ground_only.join(ame_proj, on=["Z", "A"], how="left").join(iupac_proj, on=["Z", "A"], how="left")
+
+    return joined.select(
+        pl.col("Z").cast(pl.Int32),
+        # Compute N from A - Z when AME doesn't supply it.
+        pl.coalesce([pl.col("N"), (pl.col("A") - pl.col("Z")).cast(pl.Int64)]).alias("N"),
+        pl.col("A").cast(pl.Int32),
+        pl.col("symbol").cast(pl.String),
+        pl.col("jp").cast(pl.String),
+        pl.col("half_life_s").cast(pl.Float64),
+        pl.col("level_keV").cast(pl.Float64),
+        pl.col("abundance").cast(pl.Float64),
+        pl.col("unc_abundance").cast(pl.Float64),
+        pl.col("standard_atomic_weight").cast(pl.Float64),
+        pl.col("atomic_mass_u").cast(pl.Float64),
+        pl.col("mass_excess_keV").cast(pl.Float64),
+        pl.col("mass_excess_unc_keV").cast(pl.Float64),
+        pl.col("binding_energy_per_A_keV").cast(pl.Float64),
+        pl.col("binding_energy_per_A_unc_keV").cast(pl.Float64),
+        pl.col("beta_decay_energy_keV").cast(pl.Float64),
+        pl.col("beta_decay_energy_unc_keV").cast(pl.Float64),
+        pl.col("atomic_mass_microu").cast(pl.Float64),
+        pl.col("atomic_mass_unc_microu").cast(pl.Float64),
+        pl.col("ame_is_estimated").cast(pl.Boolean),
+        # Dual-carry per ADR-0002.
+        pl.col("spin_x2").cast(pl.Int16),
+        pl.col("floating_level_flag").cast(pl.String),
+        # Bonus.
+        pl.col("magnetic_moment_jt").cast(pl.Float64),
+    ).sort(["Z", "A"])
+
+
+def build(
+    data_dir: Path | None = None,
+    *,
+    strata_path: Path | None = None,
+    ame_path: Path | None = None,
+    iupac_path: Path | None = None,
+    elements_path: Path | None = None,
+    nuclides_out: Path | None = None,
+    ground_states_out: Path | None = None,
+) -> tuple[Path, Path]:
+    """Build both parquet files.
+
+    Returns the (nuclides_path, ground_states_path) actually written.
+    """
+    if data_dir is None:
+        data_dir = _resolve_data_dir()
+    data_dir = Path(data_dir)
+
+    strata, ame, iupac, elements = _load_inputs(
+        data_dir,
+        strata_path=strata_path,
+        ame_path=ame_path,
+        iupac_path=iupac_path,
+        elements_path=elements_path,
+    )
+
+    nuclides = build_nuclides(strata, elements)
+    ground_states = build_ground_states(strata, ame, iupac, elements)
+
+    nuc_out = nuclides_out or (data_dir / _OUT_NUCLIDES)
+    gs_out = ground_states_out or (data_dir / _OUT_GROUND_STATES)
+    nuc_out.parent.mkdir(parents=True, exist_ok=True)
+    gs_out.parent.mkdir(parents=True, exist_ok=True)
+
+    nuclides.write_parquet(nuc_out, compression="zstd")
+    ground_states.write_parquet(gs_out, compression="zstd")
+    return nuc_out, gs_out
+
+
+def _main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--data-dir", type=Path, default=None)
+    args = parser.parse_args(argv)
+    nuc, gs = build(data_dir=args.data_dir)
+    print(f"wrote {nuc}")
+    print(f"wrote {gs}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/tests/test_g4_ensdfstate.py
+++ b/tests/test_g4_ensdfstate.py
@@ -1,0 +1,331 @@
+"""Tests for the G4 ensdfstate -> nuclides + ground_states converter.
+
+Two layers:
+
+1. **Pure transform unit tests** — exercise ``convert_mean_life`` and
+   ``encode_jp`` directly, including the ADR-0002 boundary conditions
+   (the ``-1`` G4 stable sentinel must yield ``+inf``, never a negative
+   half-life).
+2. **Integration spot checks** — build the parquet from the shipped strata
+   inputs and verify the canonical isotope set from issue #69. Marked
+   ``@pytest.mark.data`` so they auto-skip when raw data is absent.
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from nucl_parquet.g4.ensdfstate import (
+    G4_STABLE_MEAN_LIFE_NS,
+    G4_UNKNOWN_SPIN_X2,
+    LN2,
+    LONG_LIVED_MEAN_LIFE_NS_THRESHOLD,
+    assign_state_labels,
+    build,
+    convert_mean_life,
+    encode_jp,
+)
+
+# ---------------------------------------------------------------------------
+# Pure transform primitives — no I/O.
+# ---------------------------------------------------------------------------
+
+
+class TestConvertMeanLife:
+    """ADR-0002 transform spec: mean_life_ns -> half_life_s."""
+
+    def test_finite_positive(self) -> None:
+        # 1 ns mean life -> ln(2) * 1e-9 s half life.
+        assert convert_mean_life(1.0) == pytest.approx(LN2 * 1e-9)
+
+    def test_tc99m_canonical(self) -> None:
+        # G4 ENSDFSTATE Tc-99m mean_life_ns == 3.12e13 -> ~21630 s.
+        assert convert_mean_life(3.12e13) == pytest.approx(21626, rel=1e-3)
+
+    def test_g4_stable_sentinel_yields_positive_infinity(self) -> None:
+        """The most load-bearing test in this module.
+
+        The naive product ``-1 * ln(2) * 1e-9 ≈ -6.93e-10`` is *negative*
+        and would silently corrupt downstream queries. The converter MUST
+        intercept -1 *before* multiplying.
+        """
+        result = convert_mean_life(G4_STABLE_MEAN_LIFE_NS)
+        assert result == math.inf
+        assert result > 0  # paranoia — guard against any sign flip
+
+    def test_zero_is_prompt(self) -> None:
+        assert convert_mean_life(0.0) == 0.0
+
+    def test_none_passes_through(self) -> None:
+        assert convert_mean_life(None) is None
+
+    def test_no_negative_half_lives_for_any_canonical_input(self) -> None:
+        """Sweep ADR-0002's table values — none may produce a negative result."""
+        for value in (-1.0, 0.0, 1.0, 1e6, 3.12e13, 1.4114e18):
+            result = convert_mean_life(value)
+            assert result is None or result >= 0, f"{value!r} -> {result!r}"
+
+
+class TestEncodeJp:
+    """G4ENSDFSTATE has no parity column; jp is J-only."""
+
+    def test_integer_spin(self) -> None:
+        assert encode_jp(12) == "6"
+
+    def test_half_integer_spin(self) -> None:
+        assert encode_jp(3) == "3/2"
+
+    def test_zero_spin(self) -> None:
+        assert encode_jp(0) == "0"
+
+    def test_g4_unknown_sentinel(self) -> None:
+        assert encode_jp(G4_UNKNOWN_SPIN_X2) is None
+
+    def test_floating_level_flag_dash_dropped(self) -> None:
+        # '-' = "not floating", drop.
+        assert encode_jp(3, "-") == "3/2"
+
+    def test_floating_level_flag_token_preserved(self) -> None:
+        assert encode_jp(3, "+X") == "3/2(+X)"
+
+    def test_none_spin(self) -> None:
+        assert encode_jp(None) is None
+
+
+class TestAssignStateLabels:
+    """State-label synthesis: '' / 'm' / 'm2' ... in ascending level_keV."""
+
+    def _frame(self, rows: list[tuple[int, int, float, float]]) -> pl.DataFrame:
+        return pl.DataFrame(
+            {
+                "Z": [r[0] for r in rows],
+                "A": [r[1] for r in rows],
+                "level_keV": [r[2] for r in rows],
+                "mean_life_ns": [r[3] for r in rows],
+            }
+        )
+
+    def test_ground_only(self) -> None:
+        # Z=99, A=199, single ground (mean_life > threshold) -> state ''.
+        df = self._frame([(99, 199, 0.0, 1e10)])
+        out = assign_state_labels(df)
+        assert out["state"].to_list() == [""]
+
+    def test_short_lived_excited_filtered_out(self) -> None:
+        # Excited level below 1 ms threshold should NOT appear.
+        df = self._frame([(99, 199, 0.0, 1e10), (99, 199, 100.0, 1.0)])
+        out = assign_state_labels(df)
+        assert out["state"].to_list() == [""]
+        assert len(out) == 1
+
+    def test_eu152_pattern(self) -> None:
+        # ground + m + m2 — the canonical multi-isomer case.
+        df = self._frame(
+            [
+                (63, 152, 0.0, 6.154e17),  # ground (stable mean-life)
+                (63, 152, 45.6, 4.836e13),  # m
+                (63, 152, 147.86, 8.31e12),  # m2
+            ]
+        )
+        out = assign_state_labels(df).sort("level_keV")
+        assert out["state"].to_list() == ["", "m", "m2"]
+
+    def test_stable_sentinel_kept_as_ground(self) -> None:
+        # mean_life_ns = -1 (stable) must be retained: ground state of stable
+        # isotopes such as H-1 / Fe-56 / Pb-208 must appear.
+        df = self._frame([(1, 1, 0.0, G4_STABLE_MEAN_LIFE_NS)])
+        out = assign_state_labels(df)
+        assert out["state"].to_list() == [""]
+
+    def test_threshold_boundary(self) -> None:
+        # Level exactly at the long-lived threshold is excluded (strict >).
+        df = self._frame(
+            [
+                (1, 100, 0.0, 1e20),
+                (1, 100, 50.0, LONG_LIVED_MEAN_LIFE_NS_THRESHOLD),
+            ]
+        )
+        out = assign_state_labels(df)
+        assert out["state"].to_list() == [""]
+
+
+# ---------------------------------------------------------------------------
+# Integration spot checks against the shipped strata + AME + IUPAC inputs.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def built_artefacts(tmp_path_factory: pytest.TempPathFactory) -> tuple[Path, Path]:
+    """Build the converter once per test session, reuse across tests.
+
+    Snapshots the raw strata input into a session-scoped tempdir up front
+    so that *other* tests in the suite which exercise the fetcher and
+    accidentally pollute ``data/g4_raw/strata-nuclear/`` can't corrupt our
+    fixture mid-session (cf. ``test_fetch_from_local_missing_file_raises``).
+    """
+    repo_data = Path(__file__).parent.parent / "data"
+    raw_strata = repo_data / "g4_raw" / "strata-nuclear" / "ensdfstate.parquet"
+    if not raw_strata.exists() or raw_strata.stat().st_size < 1024:
+        pytest.skip("strata raw data not available — run scripts/fetch_strata_nuclear.py")
+    if not (repo_data / "auxiliary" / "ame2020.parquet").exists():
+        pytest.skip("auxiliary AME2020 not available")
+
+    import shutil
+
+    tmp = tmp_path_factory.mktemp("g4_ensdfstate")
+    snapshot = tmp / "ensdfstate.parquet"
+    shutil.copy2(raw_strata, snapshot)
+
+    nuc_out = tmp / "nuclides.parquet"
+    gs_out = tmp / "ground_states.parquet"
+    build(
+        data_dir=repo_data,
+        strata_path=snapshot,
+        nuclides_out=nuc_out,
+        ground_states_out=gs_out,
+    )
+    return nuc_out, gs_out
+
+
+@pytest.mark.data
+class TestNuclidesSpotChecks:
+    """Issue #69 acceptance criteria — canonical _validate() spot checks."""
+
+    @pytest.fixture()
+    def nuclides(self, built_artefacts: tuple[Path, Path]) -> pl.DataFrame:
+        return pl.read_parquet(built_artefacts[0])
+
+    @pytest.mark.parametrize(
+        ("z", "a", "state", "expected_hl_s", "expected_level_keV"),
+        [
+            # Issue #69 mandatory canonical set.
+            (43, 99, "m", 21630.0, 142.6836),  # Tc-99m
+            (21, 44, "m", 210600.0, 271.241),  # Sc-44m
+            (49, 113, "m", 5976.0, 391.699),  # In-113m
+            (47, 108, "m", 1.32e10, 109.466),  # Ag-108m
+            (63, 152, "m", 33390.0, 45.5998),  # Eu-152m
+            (56, 137, "m", 153.1, 661.659),  # Ba-137m
+            # Bonus cases.
+            (63, 152, "m2", 5760.0, 147.86),  # Eu-152m2
+            (72, 178, "m2", 9.78e8, 2446.09),  # Hf-178m2
+        ],
+    )
+    def test_isomer_half_life_and_level(
+        self,
+        nuclides: pl.DataFrame,
+        z: int,
+        a: int,
+        state: str,
+        expected_hl_s: float,
+        expected_level_keV: float,
+    ) -> None:
+        row = nuclides.filter((pl.col("Z") == z) & (pl.col("A") == a) & (pl.col("state") == state))
+        assert len(row) == 1, f"(Z={z},A={a},state={state!r}) not found / not unique"
+        assert row["half_life_s"][0] == pytest.approx(expected_hl_s, rel=0.05)
+        assert row["level_keV"][0] == pytest.approx(expected_level_keV, abs=0.01)
+
+    @pytest.mark.parametrize(
+        ("z", "a"),
+        [(1, 1), (2, 4), (26, 56), (82, 208)],
+    )
+    def test_stable_isotope_is_positive_infinity(self, nuclides: pl.DataFrame, z: int, a: int) -> None:
+        """Stable isotopes must have half_life_s = +inf, NOT NULL."""
+        row = nuclides.filter((pl.col("Z") == z) & (pl.col("A") == a) & (pl.col("state") == ""))
+        assert len(row) == 1
+        hl = row["half_life_s"][0]
+        assert hl is not None, f"({z},{a}) ground has NULL half_life_s — must be +inf"
+        assert math.isinf(hl) and hl > 0, f"({z},{a}) hl={hl!r}, expected +inf"
+
+    def test_no_negative_half_lives(self, nuclides: pl.DataFrame) -> None:
+        """The -1 G4 sentinel must never multiply through to a negative value."""
+        negs = nuclides.filter(pl.col("half_life_s") < 0)
+        assert len(negs) == 0, f"found {len(negs)} rows with negative half_life_s"
+
+    def test_schema_v0_10_x_compatible(self, nuclides: pl.DataFrame) -> None:
+        """v0.10.x consumers project these column names — additions OK, removals not."""
+        required = {
+            "Z",
+            "A",
+            "state",
+            "symbol",
+            "jp",
+            "half_life_s",
+            "level_keV",
+            "decay_1",
+            "decay_1_pct",
+            "decay_2",
+            "decay_2_pct",
+        }
+        missing = required - set(nuclides.columns)
+        assert not missing, f"v0.10.x columns missing: {missing}"
+
+    def test_dual_carry_columns_present(self, nuclides: pl.DataFrame) -> None:
+        """ADR-0002 requires spin_x2 + floating_level_flag + magnetic_moment_jt."""
+        for col in ("spin_x2", "floating_level_flag", "magnetic_moment_jt"):
+            assert col in nuclides.columns, f"dual-carry column {col!r} missing"
+
+
+@pytest.mark.data
+class TestGroundStatesAuxJoins:
+    """ground_states.parquet must populate AME mass-excess + IUPAC abundance."""
+
+    @pytest.fixture()
+    def gs(self, built_artefacts: tuple[Path, Path]) -> pl.DataFrame:
+        return pl.read_parquet(built_artefacts[1])
+
+    @pytest.mark.parametrize(
+        ("z", "a", "expected_mass_excess_keV"),
+        [
+            (1, 1, 7288.971),  # H-1
+            (6, 12, 0.0),  # C-12 (definition of u)
+            (26, 56, -60605.4),  # Fe-56
+        ],
+    )
+    def test_ame_mass_excess_populated(self, gs: pl.DataFrame, z: int, a: int, expected_mass_excess_keV: float) -> None:
+        row = gs.filter((pl.col("Z") == z) & (pl.col("A") == a))
+        assert len(row) == 1
+        me = row["mass_excess_keV"][0]
+        assert me is not None, f"({z},{a}) AME mass-excess not joined"
+        assert me == pytest.approx(expected_mass_excess_keV, abs=10.0)
+
+    @pytest.mark.parametrize(
+        ("z", "a", "expected_abundance"),
+        [
+            # H-1 and C-12 carry abundance directly; Fe ships only the
+            # element-level standard_atomic_weight (per-isotope abundance is
+            # NULL in the upstream IUPAC table). We assert that JOIN brings
+            # the value through wherever the source has one.
+            (1, 1, 0.999885),  # H-1
+            (6, 12, 0.9893),  # C-12
+        ],
+    )
+    def test_iupac_abundance_populated(self, gs: pl.DataFrame, z: int, a: int, expected_abundance: float) -> None:
+        row = gs.filter((pl.col("Z") == z) & (pl.col("A") == a))
+        assert len(row) == 1
+        ab = row["abundance"][0]
+        assert ab is not None, f"({z},{a}) IUPAC abundance not joined"
+        assert ab == pytest.approx(expected_abundance, rel=0.05)
+
+    def test_iupac_standard_atomic_weight_populated(self, gs: pl.DataFrame) -> None:
+        """Fe-56's per-isotope abundance is NULL in IUPAC, but element-level
+        standard_atomic_weight should be present."""
+        row = gs.filter((pl.col("Z") == 26) & (pl.col("A") == 56))
+        assert len(row) == 1
+        saw = row["standard_atomic_weight"][0]
+        assert saw == pytest.approx(55.845, rel=0.01)
+
+    def test_left_join_preserves_unmatched_rows(self, gs: pl.DataFrame) -> None:
+        """A non-IUPAC isotope (e.g. Tc-99) must still have a ground-state row,
+        even though no abundance is available."""
+        row = gs.filter((pl.col("Z") == 43) & (pl.col("A") == 99))
+        assert len(row) == 1
+        assert row["abundance"][0] is None
+
+    def test_one_ground_per_za(self, gs: pl.DataFrame) -> None:
+        """ground_states must be keyed exactly on (Z, A)."""
+        dup = gs.group_by(["Z", "A"]).len().filter(pl.col("len") > 1)
+        assert len(dup) == 0, f"duplicate (Z,A) rows: {dup}"


### PR DESCRIPTION
Implements the G4ENSDFSTATE3.0 -> ``meta/ensdf/nuclides.parquet`` + ``meta/ensdf/ground_states.parquet`` converter per ADR-0002, joined with the AME2020 (mass excess) and IUPAC (abundance) auxiliaries already shipped on this branch.

Closes #69. Refs #66, ADR-0002.

## Summary

- New module `nucl_parquet/g4/ensdfstate.py` with three pure-Python primitives (`convert_mean_life`, `encode_jp`, `assign_state_labels`) and a `build()` entry-point that emits both parquet artefacts.
- `convert_mean_life` intercepts the G4 `-1` stable sentinel **before** multiplying — naive `-1 * ln(2) * 1e-9` would yield a *negative* half-life and silently corrupt every stable nuclide. Mapped to `+inf` per ADR-0002.
- `encode_jp` is J-only: G4ENSDFSTATE has no parity column, only `floating_level_flag`. Non-trivial flag tokens (`+X`, `+Y`, ...) are preserved verbatim as a parens suffix.
- ADR-0002 dual-carry: every output row ships `spin_x2` (Int16) + `floating_level_flag` (str) alongside the legacy `jp` string for the v1.0 cleanup path. `magnetic_moment_jt` is a bonus column.
- `ground_states.parquet` is the strict ground-state filter LEFT-JOINed onto AME2020 (mass excess, atomic mass, binding energy, beta-decay energy) + IUPAC (isotopic composition, standard atomic weight) on (Z, A). NULLs preserved for unmatched rows.

## Acceptance items confirmed

- [x] Tc-99m T_1/2 ≈ 21626 s (target 21630)
- [x] Sc-44m T_1/2 ≈ 210996 s (target 210600)
- [x] In-113m T_1/2 ≈ 5969 s (target 5976)
- [x] Ag-108m T_1/2 ≈ 1.382e10 s (target 1.32e10)
- [x] Eu-152m T_1/2 ≈ 33518 s (target 33390)
- [x] Ba-137m T_1/2 ≈ 153.1 s (target 153.1)
- [x] Eu-152m2 present at level_keV=147.86, T_1/2 ≈ 5760 s
- [x] Hf-178m2 present at level_keV=2446.09, T_1/2 ≈ 9.78e8 s
- [x] H-1, He-4, Fe-56, Pb-208 ground states have `half_life_s = +inf` (NOT NULL)
- [x] `mean_life_ns = -1` boundary explicitly tested (sweep + dedicated assertion)
- [x] Zero rows with negative `half_life_s`
- [x] ground_states populated with AME mass-excess (H-1, C-12, Fe-56) + IUPAC abundance (H-1, C-12) + standard_atomic_weight (Fe element-level)
- [x] Existing `tests/test_state.py` and `tests/test_integrity.py` baseline preserved (3 unrelated pre-existing failures from a catalog-format `KeyError: 'path'` regression on this branch — out of scope for #69).

## Test plan

- [x] `uv run pytest tests/test_g4_ensdfstate.py -q` → 41/41 pass
- [x] Full suite: 79 pass, 23 skipped, 3 pre-existing failures unrelated to this PR
- [ ] Re-run on CI once branch is open
- [ ] Diff harness #75 will compare against v0.10.x reference set

## Notes

- The build script does NOT auto-overwrite `data/meta/ensdf/*.parquet` in CI's normal flow — that's the orchestrator's job (#75/#76).
- The integration fixture snapshots the strata input to a session tmpdir up front so it's robust against `test_fetch_from_local_missing_file_raises` writing a 4-byte stub to `data/g4_raw/strata-nuclear/ensdfstate.parquet` without isolating `DEST_DIR` (pre-existing test pollution; should be fixed defensively in `fetch_from_local` as a follow-up).