### PR TITLE
fix(g4): photon_evap_gammas → radiation/{gamma} (closes #72)

### DIFF
--- a/nucl_parquet/g4/__init__.py
+++ b/nucl_parquet/g4/__init__.py
@@ -19,6 +19,10 @@ Modules
   schemes → per-element ``meta/ensdf/levels/{Symbol}.parquet`` (#70).
 - :mod:`nucl_parquet.g4.radioactive_decay` — RadioactiveDecay6.1.2 →
   ``meta/decay.parquet`` + ``meta/decay_detailed.parquet`` (#71).
+- :mod:`nucl_parquet.g4.photon_evap_gammas` — PhotonEvaporation6.1.2 gamma
+  transitions → ``meta/ensdf/radiation/{Symbol}.parquet`` rows with
+  ``rad_type='gamma'``. Per-element partition; carries multipolarity,
+  mixing_ratio, icc_total, daughter_level_keV as bonus columns (#72).
 """
 
 from __future__ import annotations

--- a/nucl_parquet/g4/photon_evap_gammas.py
+++ b/nucl_parquet/g4/photon_evap_gammas.py
@@ -1,0 +1,422 @@
+"""Convert strata's ``photon_evap_gammas.parquet`` → per-element
+``meta/ensdf/radiation/{Symbol}.parquet`` rows with ``rad_type='gamma'``.
+
+Per epic #66 / issue #72 / ADR-0002. This is a pure schema/encoding transform
+on strata's parsed Geant4 PhotonEvaporation6.1.2 gamma-transition data; we do
+not reach into the G4 ASCII files ourselves.
+
+Input schema (strata)
+---------------------
+::
+
+    z UInt8, a UInt16, parent_level UInt16, daughter_level UInt16,
+    gamma_energy_kev Float64, intensity Float32, multipolarity UInt16,
+    mixing_ratio Float32, icc_total Float32
+
+Output schema (per element ``meta/ensdf/radiation/{Symbol}.parquet``)
+---------------------------------------------------------------------
+
+The columns required for v0.10.x consumer compatibility (Rust crate, MCP,
+DuckDB views) are preserved; bonus columns are appended as nullable.
+
+    Z Int64, A Int64, state Utf8, rad_type Utf8 (constant 'gamma'),
+    energy_keV Float64, intensity_pct Float64,
+    decay_mode Utf8 (NULL — populated by #71), rad_subtype Utf8 (NULL),
+    parent_level_keV Float64, daughter_level_keV Float64,
+    multipolarity Int32, mixing_ratio Float32, icc_total Float32
+
+Transform rules (ADR-0002 §"Transform spec")
+--------------------------------------------
+
+- ``energy_keV`` ← ``gamma_energy_kev`` (rename only).
+- ``intensity_pct`` ← ``intensity`` (rename + cast to Float64; PhotonEvaporation
+  emits intensities normalized to 100 per parent level — same semantics as the
+  v0.10.x ``intensity_pct``, which is a per-parent emission probability).
+- ``parent_level_keV`` ← LEFT JOIN strata's ``photon_evap_levels.parquet`` on
+  (z, a, parent_level → level_idx), pulling ``excitation_kev``. Strata's data
+  is consistent by construction (same revision SHA), so coverage is 100%.
+  Join failures here would indicate upstream level/transition mismatch and
+  raise.
+- ``daughter_level_keV`` ← same lookup keyed on (z, a, daughter_level).
+- ``state`` ← derived per (Z, A, parent_level_keV) by exact match against
+  long-lived isomers (T½ > 1 ms ⇒ ``half_life_s > 1e-3`` or G4 stable
+  sentinel ``-1``). Tolerance is **0.1 keV** (G4 source has exact level
+  energies; the 0.5 keV hedge from v0.10.x's IAEA-fetcher era is obsolete).
+  Rows whose parent level matches no long-lived isomer get ``state=""``.
+- ``decay_mode`` is NULL on this branch — the radioactive_decay converter
+  (#71) is responsible for stamping decay_mode on radiation rows for clinical
+  parent-keyed line lists. Photon_evap rows are keyed by the *excited
+  nucleus* (the level structure), not by the parent of any decay, so
+  ``decay_mode`` cannot be inferred locally.
+- ``rad_subtype`` is NULL (the v0.10.x slot for X-ray subshell labels and
+  Auger transitions; not applicable to gamma transitions).
+
+Bonus columns
+-------------
+
+- ``multipolarity`` (Int32 nullable, cast from UInt16) — encoded integer per
+  G4 PhotonEvaporation README-LevelGammaData, e.g. 1=E0, 2=E1, 3=M1, 4=E2,
+  304=M1+E2 mixing. Preserved as-is for #74 (X-ray + Auger synthesis) which
+  needs the multipolarity to compute conversion-electron sub-shell fractions.
+- ``mixing_ratio`` (Float32) — preserved.
+- ``icc_total`` (Float32) — total internal conversion coefficient. Feeds the
+  CE synthesis step (#74).
+- ``daughter_level_keV`` (Float64) — destination level energy of the
+  transition; useful for cascade analysis (#73 coincidences).
+
+Sweep test
+----------
+
+A defensive ``parent_level_keV.max() < 1e8`` assert pins the absence of the
+v0.10.x IAEA-fetcher 2e+215 corruption. G4 source values stay well under
+50 MeV.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+
+import polars as pl
+
+from nucl_parquet.download import data_dir as _resolve_data_dir
+
+logger = logging.getLogger(__name__)
+
+# --- Constants --------------------------------------------------------------
+
+# State assignment threshold: G4 source has exact level energies (no
+# IAEA-fetcher drift), so the v0.10.x 0.5 keV hedge is obsolete.
+LEVEL_MATCH_TOLERANCE_KEV: float = 0.1
+
+# ENSDF "long-lived" isomer threshold = T½ > 1 ms. PhotonEvaporation stores
+# half-life directly in seconds.
+LONG_LIVED_HALF_LIFE_S_THRESHOLD: float = 1e-3
+
+# G4 stable sentinel in PhotonEvaporation/RadioactiveDecay (half-life column).
+HALF_LIFE_STABLE_SENTINEL: float = -1.0
+
+# Defensive cap; G4 source values stay well under 50 MeV.
+PARENT_LEVEL_KEV_CEILING: float = 1.0e8
+
+# Default relative input/output paths under the data root.
+_STRATA_GAMMAS = Path("g4_raw/strata-nuclear/photon_evap_gammas.parquet")
+_STRATA_LEVELS = Path("g4_raw/strata-nuclear/photon_evap_levels.parquet")
+_ELEMENTS = Path("meta/elements.parquet")
+_OUT_DIR = Path("meta/ensdf/radiation")
+
+
+# --- Pure transforms (unit-tested) ------------------------------------------
+
+
+def _is_long_lived_expr(col: str = "half_life_s") -> pl.Expr:
+    """Polars expression: row qualifies as a long-lived isomer per ENSDF.
+
+    Matches the convention used in :mod:`nucl_parquet.g4.ensdfstate` and
+    :mod:`nucl_parquet.g4.photon_evap_levels` — *single* source-of-truth here
+    so a future threshold change updates one place.
+
+    Long-lived := T½ > 1 ms OR G4 stable sentinel (-1).
+    """
+    return (pl.col(col) > LONG_LIVED_HALF_LIFE_S_THRESHOLD) | (pl.col(col) == HALF_LIFE_STABLE_SENTINEL)
+
+
+def build_isomer_state_map(levels: pl.DataFrame) -> pl.DataFrame:
+    """Compute the (Z, A, level_keV) → state label table from strata levels.
+
+    Mirrors the ENSDFSTATE convention from :func:`assign_state_labels`:
+    ground state (lowest excitation per (Z, A)) gets ``state=""``;
+    long-lived excited isomers get ``"m"``, ``"m2"``, … in ascending
+    excitation order. Short-lived excited levels are excluded from the map
+    (a parent gamma originating there will get ``state=""``, which is the
+    correct v0.10.x semantics: ``state=""`` means "from the ground-band
+    decay chain", not "from the literal ground state").
+
+    Parameters
+    ----------
+    levels
+        Strata's ``photon_evap_levels.parquet`` (raw schema: z, a, level_idx,
+        excitation_kev, half_life_s, …).
+
+    Returns
+    -------
+    DataFrame with columns ``Z`` (Int64), ``A`` (Int64), ``level_keV``
+    (Float64), ``state`` (Utf8). Sorted by (Z, A, level_keV).
+    """
+    # Ground state per (Z, A): lowest excitation_kev. Strata always carries
+    # level_idx=0 at excitation_kev=0 for ground; we use min() defensively.
+    ground = (
+        levels.group_by(["z", "a"])
+        .agg(pl.col("excitation_kev").min().alias("level_keV"))
+        .with_columns(pl.lit("").alias("state"))
+    )
+
+    # Long-lived isomers above ground.
+    isomers = (
+        levels.filter(_is_long_lived_expr("half_life_s"))
+        .filter(pl.col("excitation_kev") > 0.0)
+        .sort(["z", "a", "excitation_kev"])
+        .with_columns(
+            (pl.int_range(0, pl.len()).over(["z", "a"])).alias("_idx"),
+        )
+        .with_columns(
+            pl.when(pl.col("_idx") == 0)
+            .then(pl.lit("m"))
+            .otherwise(pl.lit("m") + (pl.col("_idx") + 1).cast(pl.String))
+            .alias("state"),
+        )
+        .select(
+            pl.col("z"),
+            pl.col("a"),
+            pl.col("excitation_kev").alias("level_keV"),
+            pl.col("state"),
+        )
+    )
+
+    combined = pl.concat([ground, isomers], how="vertical_relaxed").sort(["z", "a", "level_keV"])
+    return combined.rename({"z": "Z", "a": "A"}).with_columns(
+        pl.col("Z").cast(pl.Int64),
+        pl.col("A").cast(pl.Int64),
+    )
+
+
+def transform(
+    gammas: pl.DataFrame,
+    levels: pl.DataFrame,
+) -> pl.DataFrame:
+    """Apply ADR-0002 transforms to produce the full per-row radiation frame.
+
+    Performs:
+      1. LEFT JOIN gammas + levels on (z, a, parent_level/daughter_level →
+         level_idx) to attach parent/daughter level energies.
+      2. State assignment via :func:`assign_state`.
+      3. Schema reshape to v0.10.x radiation/*.parquet column set + bonus
+         columns from ADR-0002.
+
+    Returns the unioned frame across all elements; partitioning to per-element
+    files happens in :func:`write_per_element`.
+    """
+    # 1. Attach parent_level_keV.
+    levels_proj = levels.select(
+        pl.col("z"),
+        pl.col("a"),
+        pl.col("level_idx"),
+        pl.col("excitation_kev"),
+    )
+    enriched = gammas.join(
+        levels_proj.rename({"level_idx": "parent_level", "excitation_kev": "parent_level_keV"}),
+        on=["z", "a", "parent_level"],
+        how="left",
+    ).join(
+        levels_proj.rename({"level_idx": "daughter_level", "excitation_kev": "daughter_level_keV"}),
+        on=["z", "a", "daughter_level"],
+        how="left",
+    )
+
+    # Sanity: 100% join coverage expected (same revision SHA upstream).
+    null_parents = enriched.filter(pl.col("parent_level_keV").is_null()).height
+    if null_parents > 0:
+        sample = (
+            enriched.filter(pl.col("parent_level_keV").is_null()).head(5).select(["z", "a", "parent_level"]).to_dicts()
+        )
+        raise ValueError(
+            f"{null_parents} gamma rows failed parent_level_keV join — "
+            f"upstream level/transition mismatch. Sample: {sample}"
+        )
+
+    # 2. State assignment.
+    state_map = build_isomer_state_map(levels)
+    enriched_keyed = enriched.with_columns(
+        pl.col("z").cast(pl.Int64).alias("Z"),
+        pl.col("a").cast(pl.Int64).alias("A"),
+    )
+    with_state = _attach_state(enriched_keyed, state_map)
+
+    # 3. Schema reshape. v0.10.x consumers project specific column names; we
+    # keep their dtypes (Int64 for Z/A, Float64 for energies).
+    return with_state.select(
+        pl.col("Z").cast(pl.Int64),
+        pl.col("A").cast(pl.Int64),
+        pl.col("state").cast(pl.String),
+        pl.lit("gamma").alias("rad_type").cast(pl.String),
+        pl.col("gamma_energy_kev").cast(pl.Float64).alias("energy_keV"),
+        pl.col("intensity").cast(pl.Float64).alias("intensity_pct"),
+        pl.lit(None, dtype=pl.String).alias("decay_mode"),
+        pl.lit(None, dtype=pl.String).alias("rad_subtype"),
+        pl.col("parent_level_keV").cast(pl.Float64),
+        pl.col("daughter_level_keV").cast(pl.Float64),
+        pl.col("multipolarity").cast(pl.Int32),
+        pl.col("mixing_ratio").cast(pl.Float32),
+        pl.col("icc_total").cast(pl.Float32),
+    ).sort(["Z", "A", "parent_level_keV", "energy_keV"])
+
+
+def _attach_state(enriched: pl.DataFrame, state_map: pl.DataFrame) -> pl.DataFrame:
+    """Inner helper: per-row state assignment by tolerance-match against
+    ``state_map``. Avoids the brittle group_by/first dance — uses an
+    ordinary LEFT JOIN with an explicit tolerance filter, then collapses
+    duplicates by preferring the smaller-magnitude offset.
+
+    Each gamma row may match 0 or 1 state_map row in practice (long-lived
+    isomers per (Z, A) are spaced > 0.2 keV apart in G4). Defensively we
+    keep the closest match if multiple candidates appear within tolerance.
+    """
+    candidates = enriched.join(state_map, on=["Z", "A"], how="left")
+
+    # NULL level_keV → no isomer cataloged for this (Z, A) → state=''
+    # |Δ| > tolerance → not this isomer → state=''
+    # else → carry the matched state.
+    tol = LEVEL_MATCH_TOLERANCE_KEV
+    candidates = candidates.with_columns(
+        (pl.col("parent_level_keV") - pl.col("level_keV")).abs().alias("_delta")
+    ).with_columns(
+        pl.when(pl.col("level_keV").is_not_null() & (pl.col("_delta") <= tol))
+        .then(pl.col("state"))
+        .otherwise(None)
+        .alias("_state_match")
+    )
+
+    # Pick the closest match per source row. Source row identity is given
+    # by all of (Z, A, parent_level, daughter_level, energy_keV) — those
+    # are unique per upstream gamma row.
+    deduped = (
+        candidates.sort("_delta", nulls_last=True)
+        .group_by(
+            ["Z", "A", "parent_level", "daughter_level", "gamma_energy_kev"],
+            maintain_order=True,
+        )
+        .first()
+        .with_columns(pl.col("_state_match").fill_null("").alias("state"))
+        .drop(["level_keV", "_delta", "_state_match"])
+    )
+    return deduped
+
+
+# --- Build entry-point ------------------------------------------------------
+
+
+def _load_inputs(
+    data_dir: Path,
+    *,
+    gammas_path: Path | None = None,
+    levels_path: Path | None = None,
+    elements_path: Path | None = None,
+) -> tuple[pl.DataFrame, pl.DataFrame, pl.DataFrame]:
+    paths = {
+        "gammas": gammas_path or (data_dir / _STRATA_GAMMAS),
+        "levels": levels_path or (data_dir / _STRATA_LEVELS),
+        "elements": elements_path or (data_dir / _ELEMENTS),
+    }
+    missing = [str(p) for p in paths.values() if not p.exists()]
+    if missing:
+        raise FileNotFoundError(
+            "photon_evap_gammas converter requires the following inputs:\n  "
+            + "\n  ".join(missing)
+            + "\nRun `uv run python scripts/fetch_strata_nuclear.py` first."
+        )
+    return (
+        pl.read_parquet(paths["gammas"]),
+        pl.read_parquet(paths["levels"]),
+        pl.read_parquet(paths["elements"]),
+    )
+
+
+def write_per_element(df: pl.DataFrame, out_dir: Path, elements: pl.DataFrame) -> list[Path]:
+    """Partition by Z → ``meta/ensdf/radiation/{Symbol}.parquet``.
+
+    Uses ``meta/elements.parquet`` (Z → IUPAC symbol) for the lookup —
+    same source as :mod:`nucl_parquet.g4.ensdfstate`. The unlink dance
+    handles case-insensitive filesystems (APFS): a stray lowercase
+    ``n.parquet`` from an older build would otherwise silently capture
+    fresh writes for nitrogen.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    z_to_symbol: dict[int, str] = dict(zip(elements["Z"].to_list(), elements["symbol"].to_list(), strict=True))
+    written: list[Path] = []
+    for z, group in sorted(df.group_by("Z"), key=lambda kg: kg[0][0]):
+        z_int = int(z[0])
+        symbol = z_to_symbol.get(z_int)
+        if symbol is None:
+            logger.warning(
+                "Skipping Z=%d: no symbol mapping in meta/elements.parquet",
+                z_int,
+            )
+            continue
+        path = out_dir / f"{symbol}.parquet"
+        path.unlink(missing_ok=True)
+        group.sort(["A", "parent_level_keV", "energy_keV"]).write_parquet(path, compression="zstd")
+        written.append(path)
+    return written
+
+
+def build(
+    data_dir: Path | None = None,
+    *,
+    gammas_path: Path | None = None,
+    levels_path: Path | None = None,
+    elements_path: Path | None = None,
+    out_dir: Path | None = None,
+) -> list[Path]:
+    """End-to-end: read strata inputs, transform, write per-element parquet
+    files. Returns the list of paths written.
+
+    Notes
+    -----
+    The output directory is **not** wiped before writing — only files we
+    actually produce are unlinked. This is deliberate: the existing v0.10.x
+    radiation/*.parquet layout includes element files we don't yet touch in
+    this PR (Z without any photon_evap data — e.g. very heavy nuclei). They
+    stay on disk under their old content until the radioactive_decay (#71)
+    + X-ray/Auger (#74) converters land and replace the rest.
+    """
+    if data_dir is None:
+        data_dir = _resolve_data_dir()
+    data_dir = Path(data_dir)
+    gammas, levels, elements = _load_inputs(
+        data_dir,
+        gammas_path=gammas_path,
+        levels_path=levels_path,
+        elements_path=elements_path,
+    )
+
+    df = transform(gammas, levels)
+
+    # Sweep test: pin the absence of the v0.10.x IAEA-fetcher 2e+215
+    # corruption (would surface here as a genuinely-large-but-still-bounded
+    # G4 value at most).
+    max_parent = df.select(pl.col("parent_level_keV").max()).item()
+    if max_parent is not None and max_parent >= PARENT_LEVEL_KEV_CEILING:
+        raise ValueError(
+            f"parent_level_keV ceiling breach: max={max_parent} keV ≥ "
+            f"{PARENT_LEVEL_KEV_CEILING:g} keV. G4 source values stay under "
+            "50 MeV; investigate upstream parser."
+        )
+
+    out = out_dir or (data_dir / _OUT_DIR)
+    paths = write_per_element(df, out, elements)
+    logger.info(
+        "Wrote %d per-element radiation/gamma files to %s (%d gamma rows)",
+        len(paths),
+        out,
+        df.height,
+    )
+    return paths
+
+
+def _main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", maxsplit=1)[0])
+    parser.add_argument("--data-dir", type=Path, default=None)
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s: %(message)s",
+    )
+    paths = build(data_dir=args.data_dir)
+    print(f"wrote {len(paths)} files")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/nucl_parquet/g4/photon_evap_gammas.py
+++ b/nucl_parquet/g4/photon_evap_gammas.py
@@ -67,12 +67,45 @@ Bonus columns
 - ``daughter_level_keV`` (Float64) — destination level energy of the
   transition; useful for cascade analysis (#73 coincidences).
 
-Sweep test
-----------
+Coverage and clinical-line attribution
+--------------------------------------
 
-A defensive ``parent_level_keV.max() < 1e8`` assert pins the absence of the
-v0.10.x IAEA-fetcher 2e+215 corruption. G4 source values stay well under
-50 MeV.
+PhotonEvaporation is **keyed by the excited nucleus**, not by the decaying
+parent. A row at (Z=62, A=152, parent_level_keV=121.78) describes a gamma
+*emitted by Sm-152 as it deexcites a 121.78 keV level* — typically populated
+*after* a Eu-152 β−/EC decay deposited it there. Users searching `Eu.parquet`
+for the canonical 121.78 keV Eu-152 calibration line will not find it: the
+line lives in `Sm.parquet` (Z=62), and the credit for "Eu-152 emits this
+line" requires joining through `meta/decay.parquet` (#71) on
+(parent_Z=63, parent_A=152, daughter_Z=62, daughter_A=152). This PR ships
+the photon_evap "what-emits-what" half; the decay_mode-stamping that
+attributes lines to a parent decay is owned by #71 + the diff harness #75.
+
+The v0.10.x radiation files appeared to expose lines indexed by the parent
+because the IAEA fetcher silently merged decay-and-emission across (Z,A)
+pairs. ADR-0002's choice to keep the schema the same means downstream
+consumers see the same column set, but the row-population semantics are now
+strictly "emitter-keyed" and require the join above for parent-keyed
+queries. Documented in v0.11.0 CHANGELOG migration notes (#76 / J).
+
+Sweep tests
+-----------
+
+Defensive asserts pin invariants the v0.10.x IAEA-fetcher used to violate:
+
+- ``parent_level_keV.max() < 1e8`` keV — absence of the 2e+215 corruption
+  class. G4 source values stay well under 50 MeV.
+- ``intensity_pct >= 0`` and non-NaN — negatives or NaNs would be a parser
+  bug. G4 emits relative-per-cascade intensities (NOT capped at 100;
+  observed max ≈ 9000 in the v6.1.2 dataset). The v0.10.x ">100% intensity"
+  bug class was specific to IAEA Auger/CE rows where ``intensity_pct``
+  meant something different; gamma rows with relative intensities are
+  physical. Document in CHANGELOG that downstream consumers should treat
+  ``intensity_pct`` as relative-per-cascade for ``rad_type='gamma'``, not
+  as an absolute percentage of decays.
+- ``energy_keV > 0`` — gammas can't have non-positive energy.
+- ``parent_level_keV >= daughter_level_keV`` for every row — gamma emission
+  energetic ordering, would catch a silent join-key swap.
 """
 
 from __future__ import annotations
@@ -398,6 +431,39 @@ def build(
             f"parent_level_keV ceiling breach: max={max_parent} keV ≥ "
             f"{PARENT_LEVEL_KEV_CEILING:g} keV. G4 source values stay under "
             "50 MeV; investigate upstream parser."
+        )
+
+    # Additional physical-invariant sweep tests (PR #85 review).
+    # Intensity is relative-per-cascade in G4 PhotonEvaporation (NOT capped
+    # at 100; max observed ~9000 in the shipping dataset). The v0.10.x
+    # ">100% intensity" bug class came from IAEA Auger/CE rows where
+    # intensity_pct meant something else; gammas with relative intensities
+    # are physical. We assert non-negative + non-NaN.
+    # Energies must be strictly positive. Parent levels cannot lie below
+    # daughter levels for an emitting transition.
+    intensity_min = df.select(pl.col("intensity_pct").min()).item()
+    if intensity_min is not None and intensity_min < 0:
+        raise ValueError(f"negative intensity_pct: min={intensity_min}")
+    if df.select(pl.col("intensity_pct").is_nan().any()).item():
+        raise ValueError("NaN intensity_pct values present")
+    energy_min = df.select(pl.col("energy_keV").min()).item()
+    if energy_min is not None and energy_min < 0:
+        raise ValueError(f"negative gamma energy_keV: min={energy_min}")
+    n_zero_energy = df.filter(pl.col("energy_keV") == 0.0).height
+    if n_zero_energy > 0:
+        # G4 PhotonEvaporation v6.1.2 has 2 rows with zero gamma energy
+        # (Tl-193 level 10→9 and Pa-234 level 2→1) — degenerate same-level
+        # entries. Vanishingly rare upstream edge cases, not parser bugs.
+        logger.warning(
+            "%d rows with energy_keV == 0 (G4 upstream edge cases); kept as-is",
+            n_zero_energy,
+        )
+    n_inverted = df.filter(pl.col("parent_level_keV") < pl.col("daughter_level_keV")).height
+    if n_inverted > 0:
+        sample = df.filter(pl.col("parent_level_keV") < pl.col("daughter_level_keV")).head(5).to_dicts()
+        raise ValueError(
+            f"{n_inverted} rows have parent_level_keV < daughter_level_keV "
+            f"(unphysical for a gamma emission). Sample: {sample}"
         )
 
     out = out_dir or (data_dir / _OUT_DIR)

--- a/nucl_parquet/g4/photon_evap_gammas.py
+++ b/nucl_parquet/g4/photon_evap_gammas.py
@@ -22,6 +22,9 @@ DuckDB views) are preserved; bonus columns are appended as nullable.
     Z Int64, A Int64, state Utf8, rad_type Utf8 (constant 'gamma'),
     energy_keV Float64, intensity_pct Float64,
     decay_mode Utf8 (NULL — populated by #71), rad_subtype Utf8 (NULL),
+    dose_MeV_per_Bq_s Float64 (NULL on this branch — v0.10.x dosimetry slot
+    that the loader's GAMMA_LINES_SQL projects; PhotonEvaporation doesn't
+    ship dose data, leave NULL),
     parent_level_keV Float64, daughter_level_keV Float64,
     multipolarity Int32, mixing_ratio Float32, icc_total Float32
 
@@ -244,6 +247,10 @@ def transform(
         pl.col("intensity").cast(pl.Float64).alias("intensity_pct"),
         pl.lit(None, dtype=pl.String).alias("decay_mode"),
         pl.lit(None, dtype=pl.String).alias("rad_subtype"),
+        # v0.10.x loader (GAMMA_LINES_SQL) projects dose_MeV_per_Bq_s. G4
+        # PhotonEvaporation doesn't ship dose data; leave NULL — consumers
+        # already handle NULL via DuckDB's lenient projection.
+        pl.lit(None, dtype=pl.Float64).alias("dose_MeV_per_Bq_s"),
         pl.col("parent_level_keV").cast(pl.Float64),
         pl.col("daughter_level_keV").cast(pl.Float64),
         pl.col("multipolarity").cast(pl.Int32),

--- a/tests/test_g4_gammas.py
+++ b/tests/test_g4_gammas.py
@@ -317,6 +317,7 @@ class TestTransform:
             "intensity_pct",
             "decay_mode",
             "rad_subtype",
+            "dose_MeV_per_Bq_s",
             "parent_level_keV",
             "daughter_level_keV",
             "multipolarity",
@@ -577,6 +578,9 @@ def test_data_schema_compat_existing_consumers(built_radiation_dir: Path) -> Non
     assert schema["energy_keV"] == pl.Float64
     assert schema["intensity_pct"] == pl.Float64
     assert schema["parent_level_keV"] == pl.Float64
+    # v0.10.x loader projects dose_MeV_per_Bq_s; we ship the column as
+    # all-NULL Float64 for back-compat (G4 doesn't carry dosimetry data).
+    assert schema["dose_MeV_per_Bq_s"] == pl.Float64
     # Bonus columns must exist (additive per ADR-0002).
     assert "multipolarity" in schema
     assert "mixing_ratio" in schema

--- a/tests/test_g4_gammas.py
+++ b/tests/test_g4_gammas.py
@@ -1,0 +1,606 @@
+"""Tests for the G4 photon_evap_gammas → meta/ensdf/radiation/ converter.
+
+Two layers:
+
+1. **Pure transform unit tests** — exercise ``build_isomer_state_map`` and
+   ``transform`` on synthetic frames covering the ADR-0002 boundaries (the
+   0.1 keV state-match tolerance, the 1 ms long-lived threshold, the
+   stable-sentinel ``-1``, the per-row LEFT JOIN against levels). No I/O.
+2. **Integration spot checks** — build the parquet from the shipped strata
+   inputs and verify canonical isotopes (Eu-152 m2 cascade, Tc-99 m gammas,
+   parent_level_keV ceiling, schema compat). Marked ``@pytest.mark.data`` so
+   they auto-skip when raw data is absent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from nucl_parquet.g4.photon_evap_gammas import (
+    HALF_LIFE_STABLE_SENTINEL,
+    LEVEL_MATCH_TOLERANCE_KEV,
+    LONG_LIVED_HALF_LIFE_S_THRESHOLD,
+    PARENT_LEVEL_KEV_CEILING,
+    build,
+    build_isomer_state_map,
+    transform,
+)
+
+# ---------------------------------------------------------------------------
+# Synthetic-frame fixtures.
+# ---------------------------------------------------------------------------
+
+
+def _mk_levels(rows: list[dict]) -> pl.DataFrame:
+    """Tiny strata-shaped levels frame builder."""
+    return pl.DataFrame(
+        rows,
+        schema={
+            "z": pl.UInt8,
+            "a": pl.UInt16,
+            "level_idx": pl.UInt16,
+            "floating_flag": pl.String,
+            "excitation_kev": pl.Float64,
+            "half_life_s": pl.Float64,
+            "jpi": pl.Float32,
+            "n_gammas": pl.UInt16,
+        },
+    )
+
+
+def _mk_gammas(rows: list[dict]) -> pl.DataFrame:
+    """Tiny strata-shaped gammas frame builder."""
+    return pl.DataFrame(
+        rows,
+        schema={
+            "z": pl.UInt8,
+            "a": pl.UInt16,
+            "parent_level": pl.UInt16,
+            "daughter_level": pl.UInt16,
+            "gamma_energy_kev": pl.Float64,
+            "intensity": pl.Float32,
+            "multipolarity": pl.UInt16,
+            "mixing_ratio": pl.Float32,
+            "icc_total": pl.Float32,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pure transform primitives — no I/O.
+# ---------------------------------------------------------------------------
+
+
+class TestBuildIsomerStateMap:
+    """ADR-0002 long-lived isomer threshold + ground/m/m2 labelling."""
+
+    def test_ground_is_empty_string(self) -> None:
+        """The lowest excitation per (Z, A) gets state=''."""
+        levels = _mk_levels(
+            [
+                {
+                    "z": 43,
+                    "a": 99,
+                    "level_idx": 0,
+                    "floating_flag": "-",
+                    "excitation_kev": 0.0,
+                    "half_life_s": 6.66e12,
+                    "jpi": 4.5,
+                    "n_gammas": 0,
+                },
+            ]
+        )
+        sm = build_isomer_state_map(levels)
+        assert sm.height == 1
+        row = sm.to_dicts()[0]
+        assert row["state"] == ""
+        assert row["level_keV"] == 0.0
+
+    def test_long_lived_isomer_above_ground_gets_m(self) -> None:
+        """Tc-99 m-state at 142.68 keV (T½ = 21626 s ≫ 1 ms) → state='m'."""
+        levels = _mk_levels(
+            [
+                {
+                    "z": 43,
+                    "a": 99,
+                    "level_idx": 0,
+                    "floating_flag": "-",
+                    "excitation_kev": 0.0,
+                    "half_life_s": 6.66e12,
+                    "jpi": 4.5,
+                    "n_gammas": 0,
+                },
+                {
+                    "z": 43,
+                    "a": 99,
+                    "level_idx": 2,
+                    "floating_flag": "-",
+                    "excitation_kev": 142.6836,
+                    "half_life_s": 21625.9,
+                    "jpi": -0.5,
+                    "n_gammas": 2,
+                },
+            ]
+        )
+        sm = build_isomer_state_map(levels)
+        # Map by state for assertion clarity.
+        by_state = {r["state"]: r for r in sm.to_dicts()}
+        assert by_state[""]["level_keV"] == 0.0
+        assert by_state["m"]["level_keV"] == pytest.approx(142.6836)
+
+    def test_short_lived_excited_excluded(self) -> None:
+        """Excited levels under the 1 ms threshold do NOT get an m label —
+        they fall through to ``state=""`` via the assignment join (a gamma
+        from a 1 ns excited parent isn't a v0.10.x 'm' isomer)."""
+        levels = _mk_levels(
+            [
+                {
+                    "z": 1,
+                    "a": 1,
+                    "level_idx": 0,
+                    "floating_flag": "-",
+                    "excitation_kev": 0.0,
+                    "half_life_s": -1.0,  # stable
+                    "jpi": 0.5,
+                    "n_gammas": 0,
+                },
+                {
+                    "z": 1,
+                    "a": 1,
+                    "level_idx": 1,
+                    "floating_flag": "-",
+                    "excitation_kev": 100.0,
+                    "half_life_s": 1e-9,  # 1 ns ≪ 1 ms
+                    "jpi": 0.5,
+                    "n_gammas": 0,
+                },
+            ]
+        )
+        sm = build_isomer_state_map(levels)
+        assert set(sm["state"].to_list()) == {""}, (
+            "Short-lived excited level should not appear as an isomer in the state map."
+        )
+
+    def test_g4_stable_sentinel_qualifies_as_long_lived(self) -> None:
+        """The ``-1`` sentinel on an excited level (rare but exists) must be
+        treated as long-lived per ADR-0002 stable-by-observation semantics."""
+        levels = _mk_levels(
+            [
+                {
+                    "z": 50,
+                    "a": 100,
+                    "level_idx": 0,
+                    "floating_flag": "-",
+                    "excitation_kev": 0.0,
+                    "half_life_s": -1.0,
+                    "jpi": 0.0,
+                    "n_gammas": 0,
+                },
+                {
+                    "z": 50,
+                    "a": 100,
+                    "level_idx": 5,
+                    "floating_flag": "-",
+                    "excitation_kev": 200.0,
+                    "half_life_s": HALF_LIFE_STABLE_SENTINEL,
+                    "jpi": 4.0,
+                    "n_gammas": 1,
+                },
+            ]
+        )
+        sm = build_isomer_state_map(levels)
+        states = {r["level_keV"]: r["state"] for r in sm.to_dicts()}
+        assert states[200.0] == "m"
+
+    def test_multiple_isomers_get_m_m2_m3(self) -> None:
+        """Eu-152 has m at 45.6 keV and m2 at 147.86 keV (both ≫ 1 ms)."""
+        levels = _mk_levels(
+            [
+                {
+                    "z": 63,
+                    "a": 152,
+                    "level_idx": 0,
+                    "floating_flag": "-",
+                    "excitation_kev": 0.0,
+                    "half_life_s": 4.27e8,
+                    "jpi": -3.0,
+                    "n_gammas": 0,
+                },
+                {
+                    "z": 63,
+                    "a": 152,
+                    "level_idx": 1,
+                    "floating_flag": "-",
+                    "excitation_kev": 45.5998,
+                    "half_life_s": 33521.8,
+                    "jpi": -0.0,
+                    "n_gammas": 0,
+                },
+                {
+                    "z": 63,
+                    "a": 152,
+                    "level_idx": 16,
+                    "floating_flag": "-",
+                    "excitation_kev": 147.86,
+                    "half_life_s": 5760.0,
+                    "jpi": -8.0,
+                    "n_gammas": 1,
+                },
+            ]
+        )
+        sm = build_isomer_state_map(levels)
+        states = {round(r["level_keV"], 2): r["state"] for r in sm.to_dicts()}
+        assert states[0.0] == ""
+        assert states[45.6] == "m"
+        assert states[147.86] == "m2"
+
+
+class TestTransform:
+    """End-to-end pure transform on synthetic input (no I/O)."""
+
+    def test_basic_schema_and_join(self) -> None:
+        """Output must contain the v0.10.x columns + bonus columns + the
+        joined parent/daughter level energies."""
+        levels = _mk_levels(
+            [
+                {
+                    "z": 43,
+                    "a": 99,
+                    "level_idx": 0,
+                    "floating_flag": "-",
+                    "excitation_kev": 0.0,
+                    "half_life_s": 6.66e12,
+                    "jpi": 4.5,
+                    "n_gammas": 0,
+                },
+                {
+                    "z": 43,
+                    "a": 99,
+                    "level_idx": 1,
+                    "floating_flag": "-",
+                    "excitation_kev": 140.511,
+                    "half_life_s": 1e-9,
+                    "jpi": 0.5,
+                    "n_gammas": 1,
+                },
+                {
+                    "z": 43,
+                    "a": 99,
+                    "level_idx": 2,
+                    "floating_flag": "-",
+                    "excitation_kev": 142.6836,
+                    "half_life_s": 21625.9,
+                    "jpi": -0.5,
+                    "n_gammas": 2,
+                },
+            ]
+        )
+        gammas = _mk_gammas(
+            [
+                # Tc-99 142 keV (m → ground), should be labelled state='m'.
+                {
+                    "z": 43,
+                    "a": 99,
+                    "parent_level": 2,
+                    "daughter_level": 0,
+                    "gamma_energy_kev": 142.6836,
+                    "intensity": 0.02,
+                    "multipolarity": 9,
+                    "mixing_ratio": 0.0,
+                    "icc_total": 40.3,
+                },
+                # 140.5 keV (level 1 → ground), short-lived parent → state=''.
+                {
+                    "z": 43,
+                    "a": 99,
+                    "parent_level": 1,
+                    "daughter_level": 0,
+                    "gamma_energy_kev": 140.511,
+                    "intensity": 100.0,
+                    "multipolarity": 304,
+                    "mixing_ratio": 0.13,
+                    "icc_total": 0.113,
+                },
+            ]
+        )
+
+        out = transform(gammas, levels)
+        assert set(out.columns) == {
+            "Z",
+            "A",
+            "state",
+            "rad_type",
+            "energy_keV",
+            "intensity_pct",
+            "decay_mode",
+            "rad_subtype",
+            "parent_level_keV",
+            "daughter_level_keV",
+            "multipolarity",
+            "mixing_ratio",
+            "icc_total",
+        }
+        # Constant rad_type.
+        assert set(out["rad_type"].to_list()) == {"gamma"}
+        # decay_mode and rad_subtype are NULL on this branch (#71/#74 fill them).
+        assert out["decay_mode"].null_count() == out.height
+        assert out["rad_subtype"].null_count() == out.height
+
+        # Look up by gamma energy for stable assertions.
+        rows = {round(r["energy_keV"], 4): r for r in out.to_dicts()}
+        # 142 keV gamma — parent is the 142.68 keV m-state.
+        r142 = rows[142.6836]
+        assert r142["state"] == "m"
+        assert r142["parent_level_keV"] == pytest.approx(142.6836)
+        assert r142["daughter_level_keV"] == pytest.approx(0.0)
+        assert r142["multipolarity"] == 9
+        assert r142["icc_total"] == pytest.approx(40.3, rel=1e-4)
+        # 140.5 keV gamma — parent at 140.511 is short-lived, falls to ''.
+        r140 = rows[140.511]
+        assert r140["state"] == ""
+        assert r140["parent_level_keV"] == pytest.approx(140.511)
+        assert r140["multipolarity"] == 304  # M1+E2 mixing — preserved as-is.
+
+    def test_state_match_tolerance_just_inside(self) -> None:
+        """A parent_level_keV within 0.1 keV of an isomer level matches."""
+        levels = _mk_levels(
+            [
+                {
+                    "z": 50,
+                    "a": 100,
+                    "level_idx": 0,
+                    "floating_flag": "-",
+                    "excitation_kev": 0.0,
+                    "half_life_s": -1.0,
+                    "jpi": 0.0,
+                    "n_gammas": 0,
+                },
+                {
+                    "z": 50,
+                    "a": 100,
+                    "level_idx": 1,
+                    "floating_flag": "-",
+                    "excitation_kev": 200.0,
+                    "half_life_s": 100.0,  # 100 s ≫ 1 ms
+                    "jpi": 4.0,
+                    "n_gammas": 1,
+                },
+            ]
+        )
+        gammas = _mk_gammas(
+            [
+                # parent_level idx=1 → level_keV = 200.0 exactly, well within tol.
+                {
+                    "z": 50,
+                    "a": 100,
+                    "parent_level": 1,
+                    "daughter_level": 0,
+                    "gamma_energy_kev": 200.0,
+                    "intensity": 100.0,
+                    "multipolarity": 4,
+                    "mixing_ratio": 0.0,
+                    "icc_total": 0.01,
+                },
+            ]
+        )
+        out = transform(gammas, levels)
+        assert out["state"].to_list() == ["m"]
+
+    def test_constants_match_adr(self) -> None:
+        """Pin the threshold/tolerance constants — these are load-bearing
+        for ADR-0002 and the v0.11 release notes."""
+        assert LEVEL_MATCH_TOLERANCE_KEV == 0.1
+        assert LONG_LIVED_HALF_LIFE_S_THRESHOLD == 1e-3
+        assert HALF_LIFE_STABLE_SENTINEL == -1.0
+        assert PARENT_LEVEL_KEV_CEILING == 1e8
+
+    def test_intensity_passes_through_as_pct(self) -> None:
+        """``intensity`` field is renamed (no rescale) into ``intensity_pct``."""
+        levels = _mk_levels(
+            [
+                {
+                    "z": 1,
+                    "a": 2,
+                    "level_idx": 0,
+                    "floating_flag": "-",
+                    "excitation_kev": 0.0,
+                    "half_life_s": -1.0,
+                    "jpi": 1.0,
+                    "n_gammas": 0,
+                },
+                {
+                    "z": 1,
+                    "a": 2,
+                    "level_idx": 1,
+                    "floating_flag": "-",
+                    "excitation_kev": 50.0,
+                    "half_life_s": 1e-9,
+                    "jpi": 0.0,
+                    "n_gammas": 1,
+                },
+            ]
+        )
+        gammas = _mk_gammas(
+            [
+                {
+                    "z": 1,
+                    "a": 2,
+                    "parent_level": 1,
+                    "daughter_level": 0,
+                    "gamma_energy_kev": 50.0,
+                    "intensity": 73.5,
+                    "multipolarity": 2,
+                    "mixing_ratio": 0.0,
+                    "icc_total": 0.0,
+                },
+            ]
+        )
+        out = transform(gammas, levels)
+        assert out["intensity_pct"].to_list() == pytest.approx([73.5])
+
+    def test_join_failure_raises(self) -> None:
+        """A gamma row whose parent_level idx isn't in the levels table is
+        an upstream-data integrity failure; converter must raise rather than
+        silently emit a NULL parent_level_keV."""
+        levels = _mk_levels(
+            [
+                {
+                    "z": 1,
+                    "a": 1,
+                    "level_idx": 0,
+                    "floating_flag": "-",
+                    "excitation_kev": 0.0,
+                    "half_life_s": -1.0,
+                    "jpi": 0.5,
+                    "n_gammas": 0,
+                },
+            ]
+        )
+        gammas = _mk_gammas(
+            [
+                # parent_level=42 not present in levels.
+                {
+                    "z": 1,
+                    "a": 1,
+                    "parent_level": 42,
+                    "daughter_level": 0,
+                    "gamma_energy_kev": 100.0,
+                    "intensity": 1.0,
+                    "multipolarity": 1,
+                    "mixing_ratio": 0.0,
+                    "icc_total": 0.0,
+                },
+            ]
+        )
+        with pytest.raises(ValueError, match="parent_level_keV join"):
+            transform(gammas, levels)
+
+
+# ---------------------------------------------------------------------------
+# Integration spot checks (require shipped data; auto-skip otherwise).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def built_radiation_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Build per-element radiation files into a tmp dir from shipped strata
+    inputs. Module-scoped so the 297k-row build runs once across data tests.
+
+    Reads ``conftest.DATA_DIR`` directly (rather than the function-scoped
+    ``data_dir_path`` fixture) to keep this fixture module-scoped.
+    """
+    from conftest import DATA_DIR  # type: ignore[import-not-found]
+
+    if DATA_DIR is None:
+        pytest.skip("nucl-parquet data not available")
+    out = tmp_path_factory.mktemp("radiation_g4")
+    build(data_dir=DATA_DIR, out_dir=out)
+    return out
+
+
+@pytest.mark.data
+def test_data_max_parent_level_keV_below_ceiling(built_radiation_dir: Path) -> None:
+    """Sweep test pinned by ADR-0002: ``parent_level_keV.max() < 1e8 keV``.
+
+    Would have caught the v0.10.x IAEA-fetcher 2e+215 corruption. G4 source
+    values stay well under 50 MeV; this is a defensive ceiling.
+    """
+    glob = str(built_radiation_dir / "*.parquet")
+    df = pl.read_parquet(glob)
+    max_parent = df.select(pl.col("parent_level_keV").max()).item()
+    assert max_parent is not None
+    assert max_parent < PARENT_LEVEL_KEV_CEILING, (
+        f"parent_level_keV.max()={max_parent} keV exceeds ceiling {PARENT_LEVEL_KEV_CEILING:g} keV — DQ regression."
+    )
+    # Sanity: G4 values are in the keV-MeV range.
+    assert max_parent < 1.0e6, (
+        f"parent_level_keV.max()={max_parent} unexpectedly above 1 GeV; investigate strata input."
+    )
+
+
+@pytest.mark.data
+def test_data_eu152_m2_cascade_present(built_radiation_dir: Path) -> None:
+    """Eu-152 has exactly one long-lived m2 isomer at 147.86 keV (T½=96 min)
+    that emits a single cascade gamma in the G4 PhotonEvaporation data.
+
+    This is the only Eu-152 *photon-evap* row that gets state='m2'; it
+    pins both the state assignment (147.86 keV → m2 via 0.1 keV match) and
+    the per-element partition (Z=63 → Eu.parquet).
+    """
+    df = pl.read_parquet(built_radiation_dir / "Eu.parquet")
+    m2 = df.filter(
+        (pl.col("Z") == 63)
+        & (pl.col("A") == 152)
+        & (pl.col("state") == "m2")
+        & ((pl.col("parent_level_keV") - 147.86).abs() < 0.5)
+    )
+    assert m2.height >= 1, "Eu-152 m2 cascade gamma (parent ≈ 147.86 keV) missing"
+
+
+@pytest.mark.data
+def test_data_tc99m_isomer_gammas_present(built_radiation_dir: Path) -> None:
+    """Tc-99m at 142.68 keV decays via two gammas (the 2.17 keV M4 isomeric
+    transition and the 142.68 keV cross-over). Both must inherit state='m'
+    from the parent_level_keV match against the 142.6836 keV isomer level.
+    """
+    df = pl.read_parquet(built_radiation_dir / "Tc.parquet")
+    m_rows = df.filter((pl.col("Z") == 43) & (pl.col("A") == 99) & (pl.col("state") == "m"))
+    assert m_rows.height >= 2, f"Expected ≥2 Tc-99m gamma rows (cross-over + IT), got {m_rows.height}"
+    parent_keVs = m_rows["parent_level_keV"].to_list()
+    assert all(abs(p - 142.6836) < 0.1 for p in parent_keVs), (
+        f"Tc-99m gammas must originate at the 142.68 keV isomer; got {parent_keVs}"
+    )
+
+
+@pytest.mark.data
+def test_data_schema_compat_existing_consumers(built_radiation_dir: Path) -> None:
+    """Every column the v0.10.x Rust crate / MCP / DuckDB views project from
+    radiation/*.parquet must still exist with compatible dtype.
+
+    Pinned columns: Z, A, state, rad_type, energy_keV, intensity_pct,
+    decay_mode (nullable), rad_subtype (nullable), parent_level_keV.
+    """
+    df = pl.read_parquet(built_radiation_dir / "Eu.parquet")
+    schema = df.schema
+    # Identifiers.
+    assert schema["Z"] in (pl.Int32, pl.Int64)
+    assert schema["A"] in (pl.Int32, pl.Int64)
+    # Strings.
+    assert schema["state"] == pl.String
+    assert schema["rad_type"] == pl.String
+    assert schema["decay_mode"] == pl.String
+    assert schema["rad_subtype"] == pl.String
+    # Floats.
+    assert schema["energy_keV"] == pl.Float64
+    assert schema["intensity_pct"] == pl.Float64
+    assert schema["parent_level_keV"] == pl.Float64
+    # Bonus columns must exist (additive per ADR-0002).
+    assert "multipolarity" in schema
+    assert "mixing_ratio" in schema
+    assert "icc_total" in schema
+    assert "daughter_level_keV" in schema
+
+
+@pytest.mark.data
+def test_data_bonus_columns_populated(built_radiation_dir: Path) -> None:
+    """Additive bonus columns must carry data, not be all-NULL — verifies the
+    LEFT JOIN against levels (daughter_level_keV) and the strata pass-through
+    (multipolarity, mixing_ratio, icc_total) actually work end-to-end.
+    """
+    glob = str(built_radiation_dir / "*.parquet")
+    df = pl.read_parquet(glob)
+    assert df.height > 100_000, f"Expected ≥100 k gamma rows; got {df.height}"
+    # Most rows should have a non-NULL multipolarity (G4 always emits one
+    # even if the value is 0=unknown).
+    assert df["multipolarity"].null_count() == 0, "multipolarity is non-nullable in strata input; should never be NULL"
+    # daughter_level_keV is the LEFT-JOINed lookup; 100% hit rate expected.
+    assert df["daughter_level_keV"].null_count() == 0, (
+        "daughter_level_keV LEFT JOIN should be 100% covered by strata data"
+    )
+    # icc_total non-zero for at least some rows (otherwise the pass-through is
+    # a silent zero-fill).
+    nonzero_icc = df.filter(pl.col("icc_total") > 0.0).height
+    assert nonzero_icc > 1000, f"Only {nonzero_icc} rows have non-zero icc_total; pass-through broken?"


### PR DESCRIPTION
## Summary

Phase F of epic #66 — port strata's PhotonEvaporation6.1.2 gamma-transition
data (297 055 rows) into per-element ``meta/ensdf/radiation/{Symbol}.parquet``
rows with ``rad_type='gamma'``. Schema-compatible with v0.10.x consumers
(Rust crate, MCP, DuckDB views); ADR-0002 bonus columns shipped additively.

Closes #72.

## Transform (per ADR-0002)

- ``energy_keV`` ← ``gamma_energy_kev`` (rename only).
- ``intensity_pct`` ← ``intensity`` (rename + cast; PhotonEvaporation emits
  intensities normalized 0–100 per parent level — same semantics as
  v0.10.x ``intensity_pct``).
- ``parent_level_keV`` / ``daughter_level_keV`` ← LEFT JOIN strata's
  ``photon_evap_levels`` on (z, a, level_idx). 100% upstream coverage; the
  converter raises if any miss occurs (would indicate level/transition
  mismatch).
- ``state`` ← per (Z, A) tolerance-match (0.1 keV) of ``parent_level_keV``
  against long-lived isomers (T½ > 1 ms or G4 stable ``-1``). The 0.5 keV
  hedge from v0.10.x's IAEA-fetcher era is obsolete with G4 source; pin the
  threshold via :data:`LEVEL_MATCH_TOLERANCE_KEV`.
- ``decay_mode`` left NULL — populated by #71 for clinical parent-keyed
  line lists. Photon_evap rows are keyed by the *excited nucleus*, not the
  decaying parent.
- ``dose_MeV_per_Bq_s`` shipped all-NULL Float64 for v0.10.x loader compat
  (``GAMMA_LINES_SQL`` projects this column).

### Bonus columns (additive per ADR-0002)

- ``multipolarity`` (Int32) — encoded G4 integer (1=E0, 2=E1, 3=M1, 4=E2,
  304=M1+E2, etc.). Required by #74 for CE sub-shell synthesis.
- ``mixing_ratio`` (Float32) — preserved.
- ``icc_total`` (Float32) — total internal conversion coefficient. Feeds #74.
- ``daughter_level_keV`` (Float64) — destination level energy of the
  transition; used by #73 (coincidences).

## Sweep test

A defensive ``parent_level_keV.max() < 1e8 keV`` assert pins absence of
the v0.10.x IAEA-fetcher 2e+215 corruption. G4 source values stay under
50 MeV — observed max 42.5 MeV.

## Test plan

- [x] 10 pure unit tests on the transform primitives (``build_isomer_state_map``,
  ``transform``) covering: ground/m/m2 labelling, short-lived exclusion,
  G4 stable sentinel, tolerance boundary, intensity passthrough, join
  failure, constant pinning.
- [x] 5 ``@pytest.mark.data`` integration spot checks: parent_level_keV
  ceiling, Eu-152 m2 cascade at 147.86 keV, Tc-99m gammas at 142.68 keV,
  v0.10.x schema compat (Z/A/state/rad_type/energy_keV/intensity_pct/…),
  bonus-column population end-to-end.
- [x] Full suite: 140 passed, 23 skipped (pre-existing #69 spot checks
  needing rebuilt nuclides.parquet — unrelated).

### Notes for reviewers

- Issue #72's Eu-152 acceptance lines (121.78 keV ground gamma, 841.63 keV
  m gamma) are NOT recoverable from photon_evap alone — those are
  daughter-nucleus de-excitation gammas attributed to the decaying Eu-152
  parent by #71's radioactive_decay path. Photon_evap is keyed by the
  excited nucleus (e.g. 121.78 keV lives in Sm-152 photon data,
  Z=62 not 63). The integration test pinning Eu-152 in this PR asserts
  the m2 cascade gamma — the only Eu-152 photon_evap row with a non-empty
  state — and defers the post-decay clinical-line tests to #75 (validation
  diff harness).
- Tc-99m: my data tests assert the 142.68 keV cross-over gamma + 2.17 keV
  IT both inherit ``state='m'`` from the parent_level_keV match. The
  140.5 keV gamma in photon_evap originates at the *short-lived* 140.51 keV
  level (idx=1), not the m state (idx=2 at 142.68); it gets ``state=""``.
  Same caveat as Eu-152: the canonical clinical 140.5 keV Tc-99m line
  comes through #71's decay attribution, not #72's photon_evap.