### PR TITLE
feat(em): atomic_relaxation + fluorescence views (closes #100)

### DIFF
--- a/nucl_parquet/loader.py
+++ b/nucl_parquet/loader.py
@@ -241,7 +241,14 @@ def connect(data_dir: Path | str | None = None) -> duckdb.DuckDBPyConnection:
     _register_glob(db, data_dir / "meta" / "epdl97" / "subshell_pe", "epdl_subshell_pe")
 
     # --- EADL atomic relaxation / fluorescence ---
-    _register_glob(db, data_dir / "meta" / "eadl", "eadl_transitions")
+    # Canonical name: atomic_relaxation. eadl_transitions kept as an alias for
+    # callers from v0.11 and earlier. fluorescence is the radiative subset;
+    # Auger lines stay in atomic_relaxation, query `WHERE transition_type='auger'`.
+    eadl_dir = data_dir / "meta" / "eadl"
+    if eadl_dir.exists() and list(eadl_dir.glob("*.parquet")):
+        _register_glob(db, eadl_dir, "atomic_relaxation")
+        db.execute("CREATE VIEW eadl_transitions AS SELECT * FROM atomic_relaxation")
+        db.execute("CREATE VIEW fluorescence AS SELECT * FROM atomic_relaxation WHERE transition_type = 'radiative'")
 
     # --- EEDL electron interaction data ---
     _register_glob(db, data_dir / "meta" / "eedl", "eedl_electron_xs")

--- a/tests/test_em_atomic_relaxation.py
+++ b/tests/test_em_atomic_relaxation.py
@@ -1,0 +1,109 @@
+"""Tests for the atomic_relaxation / fluorescence DuckDB views (issue #100).
+
+Promotes EADL relaxation data from internal-only (consumed by g4/xray_auger.py)
+to first-class DuckDB views: ``atomic_relaxation`` (full vacancy cascade) and
+``fluorescence`` (radiative subset only).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nucl_parquet.loader import connect
+
+_REPO_ROOT = Path(__file__).parent.parent
+_EADL_DIR = _REPO_ROOT / "data" / "meta" / "eadl"
+
+# Hubbell & Trehan (1985) / Krause (1979) tabulation of K-shell fluorescence
+# yields ω_K. Used as the reference for the sweep invariant — EADL agrees with
+# these to ~2% across the range.
+_HUBBELL_OMEGA_K = {
+    20: 0.163,  # Ca
+    26: 0.347,  # Fe
+    29: 0.443,  # Cu
+    47: 0.831,  # Ag
+    50: 0.859,  # Sn
+    74: 0.946,  # W
+    82: 0.961,  # Pb
+}
+
+
+@pytest.fixture(scope="module")
+def db():
+    return connect()
+
+
+@pytest.mark.data
+class TestAtomicRelaxationView:
+    def test_atomic_relaxation_view_exists(self, db) -> None:
+        n = db.execute("SELECT COUNT(*) FROM atomic_relaxation").fetchone()[0]
+        assert n > 0
+
+    def test_eadl_transitions_alias_matches(self, db) -> None:
+        a = db.execute("SELECT COUNT(*) FROM atomic_relaxation").fetchone()[0]
+        b = db.execute("SELECT COUNT(*) FROM eadl_transitions").fetchone()[0]
+        assert a == b
+
+    def test_transition_types_are_radiative_or_auger(self, db) -> None:
+        kinds = {row[0] for row in db.execute("SELECT DISTINCT transition_type FROM atomic_relaxation").fetchall()}
+        assert kinds <= {"radiative", "auger"}
+
+    def test_z_range_matches_eadl_coverage(self, db) -> None:
+        z_min, z_max = db.execute("SELECT MIN(Z), MAX(Z) FROM atomic_relaxation").fetchone()
+        # EADL covers Z=6 through Z=100.
+        assert z_min >= 6
+        assert z_max >= 92
+
+
+@pytest.mark.data
+class TestFluorescenceView:
+    def test_fluorescence_is_radiative_subset(self, db) -> None:
+        kinds = {row[0] for row in db.execute("SELECT DISTINCT transition_type FROM fluorescence").fetchall()}
+        assert kinds == {"radiative"}
+
+    def test_fluorescence_count_matches_radiative_subset(self, db) -> None:
+        a = db.execute("SELECT COUNT(*) FROM atomic_relaxation WHERE transition_type='radiative'").fetchone()[0]
+        b = db.execute("SELECT COUNT(*) FROM fluorescence").fetchone()[0]
+        assert a == b
+
+
+@pytest.mark.data
+class TestKShellFluorescenceYield:
+    """ω_K = sum of probabilities for radiative transitions filling a K-vacancy.
+
+    EADL is normalized so radiative + auger probabilities for a given vacancy
+    sum to 1; therefore ω_K = SUM(probability) for radiative K-vacancy rows.
+    Validate against Hubbell-Trehan / Krause within 5% across the range
+    Z=20..82.
+    """
+
+    @pytest.mark.parametrize("z, omega_ref", sorted(_HUBBELL_OMEGA_K.items()))
+    def test_omega_k_matches_hubbell(self, db, z: int, omega_ref: float) -> None:
+        omega = db.execute(
+            "SELECT COALESCE(SUM(probability), 0) FROM fluorescence WHERE Z = ? AND vacancy_shell = 'K'",
+            [z],
+        ).fetchone()[0]
+        # 5% absolute tolerance for low-Z (where ω is small and the relative
+        # error noise dominates), 5% relative tolerance for high-Z.
+        tol = max(0.05 * omega_ref, 0.02)
+        assert abs(omega - omega_ref) < tol, f"Z={z}: ω_K={omega:.4f}, Hubbell-Trehan ref={omega_ref:.4f}"
+
+
+@pytest.mark.data
+class TestVacancyNormalization:
+    """Sum of probabilities over all transitions filling a given vacancy ≈ 1.
+
+    EADL ships per-vacancy normalized cascades; this is the sweep invariant
+    that downstream consumers rely on. Allow 5% slack — EADL doesn't always
+    sum to exactly 1 due to omitted minor branches.
+    """
+
+    @pytest.mark.parametrize("z", [26, 50, 82])
+    def test_k_vacancy_sums_to_unity(self, db, z: int) -> None:
+        total = db.execute(
+            "SELECT SUM(probability) FROM atomic_relaxation WHERE Z = ? AND vacancy_shell = 'K'",
+            [z],
+        ).fetchone()[0]
+        assert 0.95 <= total <= 1.05, f"Z={z}: K-vacancy sum = {total:.4f}"

--- a/uv.lock
+++ b/uv.lock
@@ -368,7 +368,7 @@ wheels = [
 
 [[package]]
 name = "nucl-parquet"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
## Summary
- Promotes EADL relaxation data from internal-only consumption (by `g4/xray_auger.py`) to first-class DuckDB views.
- Adds `atomic_relaxation` (full vacancy cascade), `fluorescence` (radiative subset), and `eadl_transitions` (v0.11 backwards-compat alias).
- 16 new tests pass. Validates against Hubbell-Trehan / Krause K-shell fluorescence yields ω_K for Z = 20, 26, 29, 47, 50, 74, 82 within 5% (most within 2%).
- First deliverable of the v0.12 photon-matter interaction epic (#95). No data files added — EADL parquet shipped in v0.11.

## Worked SQL example

```sql
-- Lines emerging after K-shell ionization in iodine:
SELECT vacancy_shell, filling_shell, transition_type,
       energy_keV, ROUND(probability, 4) AS prob
  FROM atomic_relaxation
 WHERE Z = 53 AND vacancy_shell = 'K'
 ORDER BY probability DESC
 LIMIT 10;

-- K-shell fluorescence yield for Pb (≈ 0.96):
SELECT SUM(probability) AS omega_K
  FROM fluorescence
 WHERE Z = 82 AND vacancy_shell = 'K';
```

## Test plan
- [x] 16 new tests pass (`tests/test_em_atomic_relaxation.py`)
- [x] Existing v0.11 test suite passes — no regression in `xray_auger.py` consumer
- [x] ω_K vs Hubbell-Trehan reference for 7 elements
- [x] Per-vacancy probability normalization for Fe / Sn / Pb

Closes #100. Part of epic #95.