### PR TITLE
ci: bump Actions to Node 24-compatible majors (closes #94)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
     name: prek hooks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
@@ -31,8 +31,8 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v6
       - run: uv python install ${{ matrix.python-version }}
       - run: uv sync --dev
       - run: uv run pytest tests/test_loader.py -v
@@ -44,7 +44,7 @@ jobs:
       run:
         working-directory: clients/rs/nucl-parquet
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
@@ -58,8 +58,8 @@ jobs:
       run:
         working-directory: clients/ts/nucl-parquet
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
       - run: npm ci
@@ -73,7 +73,7 @@ jobs:
       run:
         working-directory: clients/go/nucl-parquet
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
           go-version: "1.22"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,12 @@ permissions:
   contents: write
   pull-requests: write
 
+# release-please-action@v4 hadn't shipped a Node 24 release as of 2026-05.
+# Opt-in early via FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 so we surface any
+# breakage now rather than at the Jun 2 2026 forced switch.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   release-please:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     name: Build & upload data tarball
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install zstd
         run: sudo apt-get update && sudo apt-get install -y zstd
       - name: Build tarball
@@ -32,8 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v6
       - run: uv build
       - uses: pypa/gh-action-pypi-publish@release/v1
 
@@ -48,8 +48,8 @@ jobs:
       run:
         working-directory: clients/ts/nucl-parquet
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
@@ -66,7 +66,7 @@ jobs:
       run:
         working-directory: clients/rs/nucl-parquet
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo publish --allow-dirty
         env:
@@ -80,8 +80,8 @@ jobs:
       run:
         working-directory: clients/py/nucl-parquet-mcp
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v6
       - run: uv build
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -98,8 +98,8 @@ jobs:
       run:
         working-directory: clients/ts/nucl-parquet-mcp
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
@@ -116,7 +116,7 @@ jobs:
       run:
         working-directory: clients/rs/nucl-parquet-mcp
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo publish --allow-dirty
         env:
@@ -126,7 +126,7 @@ jobs:
     name: Mirror Go module tag
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Create Go module tag
         run: |
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
## Summary
- Node 20 hard kill date: 2026-09-16. Forced switch to Node 24: 2026-06-02.
- Bumped all four Node-20-pinned actions:
  - `actions/checkout@v4` → `v5`
  - `astral-sh/setup-uv@v5` → `v6`
  - `actions/setup-node@v4` → `v5`
  - `googleapis/release-please-action@v4`: no Node-24 release yet, so opt-in via workflow-level env `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` to surface any incompatibility now.

## Test plan
- [x] All three workflows must pass on this PR
- [x] No deprecation warnings in CI logs
- [x] release-please continues to function (next release-please PR opens normally)

Closes #94.