### PR TITLE
fix(ci): pass PAT to release-please so tag pushes trigger release.yml

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,5 +20,10 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
+          # PAT (or GitHub App token) is required so the tag push triggers
+          # release.yml. GITHUB_TOKEN-pushed tags are silently ignored by
+          # workflow triggers (GitHub security feature) — see #35 / #57 for
+          # the history. Falls back to GITHUB_TOKEN if the secret is unset.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary

Forward-ports unmerged PR #56 onto current main. Adds `token: \${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}` to the release-please action so PAT-pushed tags trigger \`release.yml\`. With the GITHUB_TOKEN fallback, the workflow keeps working even before the secret is set — but the secret is required for actual end-to-end releases.

## Why this is needed

GitHub silently ignores workflow triggers from tags pushed via GITHUB_TOKEN (security feature, prevents recursion). Since v0.10.0, every release-please tag has been a no-op for release.yml. Verified state:

| Tag | release.yml fired? | GH release assets | PyPI |
|---|---|---|---|
| v0.10.0 | partial (manually re-tagged) | ✅ data tarball, partial pkg publishes | ❌ stuck at 0.9.0 |
| v0.11.0 | ❌ never | ❌ no assets | ❌ |
| v0.12.0 | ❌ never | ❌ no assets | ❌ |
| v0.13.0 | ❌ never | ❌ no assets | ❌ |

## Required setup before this is effective

Create a PAT and save it as the repo secret \`RELEASE_PLEASE_TOKEN\`:

1. https://github.com/settings/personal-access-tokens/new
   - Resource owner: \`exoma-ch\`
   - Repository access: \`nucl-parquet\` only
   - Permissions: \`Contents: R/W\`, \`Pull requests: R/W\`, \`Workflows: R/W\`
   - Expiration: 1 year (set a calendar reminder to rotate)
2. Save at https://github.com/exoma-ch/nucl-parquet/settings/secrets/actions/new as \`RELEASE_PLEASE_TOKEN\`
3. Merge this PR

Without the secret, \`||\` falls back to GITHUB_TOKEN — same broken behavior as today, but no breakage. With it, the next release-please-tagged release triggers \`release.yml\` end-to-end.

## v0.13.0 backfill

This fix is forward-only. v0.13.0's release.yml never fired and won't re-fire from the existing tag. After this PR lands + the secret is set, manually backfill v0.13.0 by:
- Building \`nucl-parquet-data-v0.13.0.tar.zst\` locally from \`data/\` and uploading: \`gh release upload v0.13.0 nucl-parquet-data-v0.13.0.tar.zst\`, OR
- Deleting + re-tagging v0.13.0 with PAT-auth (riskier — touches the immutable tag history)

The PyPI/npm/Cargo backfill for v0.10-v0.13 is messy regardless (requires manual \`uv build && uv publish\`, \`npm publish\`, \`cargo publish --allow-dirty\` per package per version). Probably defer to v0.14.0 cycle and just publish that one cleanly.

## Long-term cleanup

Better than a PAT: install a GitHub App with the same scopes. App tokens don't expire on a calendar and aren't tied to a person. File as a future task; PAT is fine for now.

## Closes

Supersedes #56 (was open since March, now stale w.r.t. main — this PR is the rebase).

## Test plan

- [x] Diff is exactly the same fix as #56, with \`||\` fallback added so the action keeps running pre-secret
- [ ] After secret added + merge: next release-please PR opens normally (it will, as today)
- [ ] After that release PR merges: \`release.yml\` fires automatically with no manual intervention