### PR TITLE
feat(release): Path A — data on CalVer, code on lockstep semver

### DIFF
--- a/.github/workflows/release-data.yml
+++ b/.github/workflows/release-data.yml
@@ -36,9 +36,10 @@ jobs:
           fi
           tar --zstd -C data -cf "nucl-parquet-data-${CALVER}.tar.zst" .
           ls -lh "nucl-parquet-data-${CALVER}.tar.zst"
+          echo "ASSET_PATH=nucl-parquet-data-${CALVER}.tar.zst" >> "$GITHUB_ENV"
       - name: Upload to release
         uses: softprops/action-gh-release@v2
         with:
-          files: nucl-parquet-data-*.tar.zst
+          files: ${{ env.ASSET_PATH }}
           fail_on_unmatched_files: true
           generate_release_notes: true

--- a/.github/workflows/release-data.yml
+++ b/.github/workflows/release-data.yml
@@ -1,0 +1,44 @@
+name: Release Data
+
+# Data releases follow CalVer (YYYY.MM.DD) on their own tag namespace,
+# decoupled from the code semver release pipeline (.github/workflows/release.yml).
+# Trigger by pushing a tag like `data-2026.05.11`.
+
+on:
+  push:
+    tags: ["data-*"]
+
+permissions:
+  contents: write
+
+jobs:
+  data-asset:
+    name: Build & upload data tarball
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install zstd
+        run: sudo apt-get update && sudo apt-get install -y zstd
+      - name: Build tarball
+        run: |
+          # Tag form: data-YYYY.MM.DD → strip the `data-` prefix to get CalVer.
+          CALVER=${GITHUB_REF#refs/tags/data-}
+          # Sanity-check the tag actually matches CalVer.
+          if ! [[ "${CALVER}" =~ ^[0-9]{4}\.[0-9]{2}\.[0-9]{2}$ ]]; then
+            echo "ERROR: tag ${GITHUB_REF} does not match data-YYYY.MM.DD" >&2
+            exit 1
+          fi
+          # Sanity-check catalog.json::data_version matches the tag.
+          CATALOG_VERSION=$(jq -r .data_version data/catalog.json)
+          if [ "${CATALOG_VERSION}" != "${CALVER}" ]; then
+            echo "ERROR: tag CalVer (${CALVER}) does not match data/catalog.json::data_version (${CATALOG_VERSION})" >&2
+            exit 1
+          fi
+          tar --zstd -C data -cf "nucl-parquet-data-${CALVER}.tar.zst" .
+          ls -lh "nucl-parquet-data-${CALVER}.tar.zst"
+      - name: Upload to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: nucl-parquet-data-*.tar.zst
+          fail_on_unmatched_files: true
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,13 @@
 name: Release
 
+# Code-only release pipeline. Triggered on semver tags from release-please
+# (`v*`); fans out to PyPI, crates.io, npm, and the Go module mirror.
+#
+# Data tarballs ship from a separate workflow (.github/workflows/release-data.yml)
+# triggered on `data-YYYY.MM.DD` CalVer tags. The two pipelines run independently
+# so a code-only bump does not republish data, and a data refresh does not bump
+# every code package.
+
 on:
   push:
     tags: ["v*"]
@@ -9,24 +17,6 @@ permissions:
   id-token: write
 
 jobs:
-  data-asset:
-    name: Build & upload data tarball
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - name: Install zstd
-        run: sudo apt-get update && sudo apt-get install -y zstd
-      - name: Build tarball
-        run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
-          tar --zstd -C data -cf "nucl-parquet-data-v${VERSION}.tar.zst" .
-          ls -lh "nucl-parquet-data-v${VERSION}.tar.zst"
-      - name: Upload to release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: nucl-parquet-data-v*.tar.zst
-          fail_on_unmatched_files: true
-
   pypi:
     name: Publish to PyPI
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -13,8 +13,14 @@ The pip package is a thin loader (~50 KB). Data files are either cloned from the
 ```python
 import nucl_parquet
 
-# Download data to ~/.nucl-parquet/ (first time only)
+# Download the latest data tarball to ~/.nucl-parquet/ (first time only)
 nucl_parquet.download()
+
+# Or pin a specific CalVer release
+nucl_parquet.download(data_version="2026.05.11")
+
+# Inspect which data version a checkout pins
+nucl_parquet.data_version()  # → "2026.05.11"
 ```
 
 Or clone the repo directly for the full dataset:
@@ -23,6 +29,17 @@ Or clone the repo directly for the full dataset:
 git clone https://github.com/exoma-ch/nucl-parquet.git
 export NUCL_PARQUET_DATA=/path/to/nucl-parquet/data
 ```
+
+### Release scheme — data on CalVer, code on semver
+
+Data tarballs and code packages release on independent cadences. Data refreshes when upstream sources (NIST/Geant4/strata) update — tracked as `data-YYYY.MM.DD` tags on GitHub. Code releases follow conventional-commit semver via release-please as `vX.Y.Z` tags. The active data version a checkout pins lives at `data/catalog.json::data_version`.
+
+| Release | Tag form | Trigger | Cadence |
+|---|---|---|---|
+| Data tarball | `data-2026.05.11` | manual push of CalVer tag matching `catalog.json::data_version` | upstream refreshes |
+| Code (PyPI, crates, npm, Go) | `v0.14.0` | release-please PR merge | conventional-commit semver |
+
+Per-package code semver (split MCP from core, etc.) is tracked in #150.
 
 ## Usage
 

--- a/data/catalog.json
+++ b/data/catalog.json
@@ -1,6 +1,8 @@
 {
   "$schema": "./catalog.schema.json",
   "version": 1,
+  "data_version": "2026.05.11",
+  "data_version_note": "CalVer (YYYY.MM.DD) identifier for the data tarball published alongside this catalog. Independent of the code release that ships with this catalog — bump whenever data refreshes upstream. The matching GitHub release tag is `data-{data_version}`.",
   "description": "Registry of available nuclear data libraries",
   "libraries": {
     "tendl-2024": {

--- a/data/catalog.json
+++ b/data/catalog.json
@@ -2,7 +2,6 @@
   "$schema": "./catalog.schema.json",
   "version": 1,
   "data_version": "2026.05.11",
-  "data_version_note": "CalVer (YYYY.MM.DD) identifier for the data tarball published alongside this catalog. Independent of the code release that ships with this catalog — bump whenever data refreshes upstream. The matching GitHub release tag is `data-{data_version}`.",
   "description": "Registry of available nuclear data libraries",
   "libraries": {
     "tendl-2024": {

--- a/data/catalog.schema.json
+++ b/data/catalog.schema.json
@@ -2,9 +2,14 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "nucl-parquet catalog",
   "type": "object",
-  "required": ["version", "libraries", "shared"],
+  "required": ["version", "data_version", "libraries", "shared"],
   "properties": {
     "version": { "type": "integer", "const": 1 },
+    "data_version": {
+      "type": "string",
+      "pattern": "^[0-9]{4}\\.[0-9]{2}\\.[0-9]{2}$",
+      "description": "CalVer YYYY.MM.DD identifier for the data tarball; matches the GitHub Release tag `data-{data_version}`."
+    },
     "description": { "type": "string" },
     "libraries": {
       "type": "object",

--- a/nucl_parquet/__init__.py
+++ b/nucl_parquet/__init__.py
@@ -1,6 +1,6 @@
 """nucl-parquet: Nuclear data as Parquet — queryable with DuckDB."""
 
-from .download import data_dir, download
+from .download import data_dir, data_version, download
 from .loader import (
     COINCIDENCE_SQL,
     DECAY_CHAIN_SQL,
@@ -26,6 +26,7 @@ __all__ = [
     "compound_dedx",
     "connect",
     "data_dir",
+    "data_version",
     "download",
     "elemental_dedx",
     "gamma_lines",

--- a/nucl_parquet/download.py
+++ b/nucl_parquet/download.py
@@ -1,17 +1,25 @@
-"""Data directory resolution and GitHub Release download."""
+"""Data directory resolution and GitHub Release download.
+
+Data and code release on separate cadences (#150 tracks the analogous code-side
+split). Data tarballs are CalVer-tagged `data-YYYY.MM.DD`; the version a given
+checkout pins lives at `data/catalog.json::data_version`.
+"""
 
 from __future__ import annotations
 
 import json
 import os
+import re
 import tarfile
 import tempfile
+import warnings
 from pathlib import Path
 from urllib.request import Request, urlopen
 
 import zstandard
 
 _GITHUB_REPO = "exoma-ch/nucl-parquet"
+_DATA_TAG_RE = re.compile(r"^data-\d{4}\.\d{2}\.\d{2}$")
 
 
 def data_dir() -> Path:
@@ -48,38 +56,76 @@ def data_dir() -> Path:
     )
 
 
-def _resolve_latest_tag() -> str:
-    url = f"https://api.github.com/repos/{_GITHUB_REPO}/releases/latest"
+def data_version(data_dir_path: Path | str | None = None) -> str:
+    """Return the CalVer identifier of the data shipping with this checkout.
+
+    Reads `data/catalog.json::data_version` (e.g. `"2026.05.11"`). The matching
+    GitHub Release tag is `data-{data_version}`.
+    """
+    root = Path(data_dir_path) if data_dir_path else data_dir()
+    catalog = json.loads((root / "catalog.json").read_text())
+    version = catalog.get("data_version")
+    if not version:
+        raise RuntimeError(f"catalog.json at {root} is missing `data_version`. Pre-CalVer catalog or corrupted file.")
+    return version
+
+
+def _resolve_latest_data_tag() -> str:
+    """Return the most recent `data-YYYY.MM.DD` release tag on GitHub."""
+    url = f"https://api.github.com/repos/{_GITHUB_REPO}/releases?per_page=30"
     req = Request(url, headers={"Accept": "application/vnd.github+json"})
     with urlopen(req) as resp:  # noqa: S310
         payload = json.load(resp)
-    tag = payload.get("tag_name")
-    if not tag:
-        raise RuntimeError(f"Could not resolve latest release tag from {url}")
-    return tag
+    for release in payload:
+        tag = release.get("tag_name", "")
+        if _DATA_TAG_RE.match(tag):
+            return tag
+    raise RuntimeError(f"No data-YYYY.MM.DD release found in the latest 30 releases at {url}")
 
 
 def download(
     dest: Path | str | None = None,
-    tag: str = "latest",
+    data_version: str = "latest",
+    *,
+    tag: str | None = None,
 ) -> Path:
     """Download nucl-parquet data from GitHub Releases.
 
     Args:
         dest: Destination directory. Defaults to ~/.nucl-parquet/.
-        tag: Git tag to download (default: latest release).
+        data_version: CalVer string (`"2026.05.11"`) OR `"latest"` to resolve
+            the most recent `data-*` GitHub release.
+        tag: Deprecated. Pre-CalVer callers passed a code-version tag
+            (e.g. `"v0.13.0"`); this is now ignored with a DeprecationWarning
+            and resolves to the latest data release instead. New callers
+            should use `data_version=`.
 
     Returns:
         Path to the downloaded data directory.
     """
+    if tag is not None:
+        warnings.warn(
+            "`tag=` is deprecated in nucl_parquet.download(); pass `data_version=` "
+            "with a CalVer identifier (e.g. `'2026.05.11'`) or `'latest'`. "
+            "Resolving to latest data release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        data_version = "latest"
+
     dest = Path(dest) if dest else Path.home() / ".nucl-parquet"
     dest.mkdir(parents=True, exist_ok=True)
 
-    if tag == "latest":
-        tag = _resolve_latest_tag()
-    version = tag.removeprefix("v")
-    asset = f"nucl-parquet-data-v{version}.tar.zst"
-    url = f"https://github.com/{_GITHUB_REPO}/releases/download/{tag}/{asset}"
+    if data_version == "latest":
+        data_tag = _resolve_latest_data_tag()
+    elif _DATA_TAG_RE.match(data_version):
+        data_tag = data_version  # caller passed full `data-YYYY.MM.DD`
+    else:
+        data_tag = f"data-{data_version}"
+
+    cal = data_tag.removeprefix("data-")
+    asset = f"nucl-parquet-data-{cal}.tar.zst"
+    url = f"https://github.com/{_GITHUB_REPO}/releases/download/{data_tag}/{asset}"
 
     print(f"Downloading nucl-parquet data from {url} ...")
 

--- a/nucl_parquet/download.py
+++ b/nucl_parquet/download.py
@@ -71,8 +71,13 @@ def data_version(data_dir_path: Path | str | None = None) -> str:
 
 
 def _resolve_latest_data_tag() -> str:
-    """Return the most recent `data-YYYY.MM.DD` release tag on GitHub."""
-    url = f"https://api.github.com/repos/{_GITHUB_REPO}/releases?per_page=30"
+    """Return the most recent `data-YYYY.MM.DD` release tag on GitHub.
+
+    Scans the most-recent 100 releases (single page, max page_size). Code
+    releases share this listing, so a high code-release cadence between
+    data refreshes could mask the data tag; raise loudly if none found.
+    """
+    url = f"https://api.github.com/repos/{_GITHUB_REPO}/releases?per_page=100"
     req = Request(url, headers={"Accept": "application/vnd.github+json"})
     with urlopen(req) as resp:  # noqa: S310
         payload = json.load(resp)
@@ -80,7 +85,10 @@ def _resolve_latest_data_tag() -> str:
         tag = release.get("tag_name", "")
         if _DATA_TAG_RE.match(tag):
             return tag
-    raise RuntimeError(f"No data-YYYY.MM.DD release found in the latest 30 releases at {url}")
+    raise RuntimeError(f"No data-YYYY.MM.DD release found in the latest 100 releases at {url}")
+
+
+_CODE_VERSION_RE = re.compile(r"^v?\d+\.\d+\.\d+")
 
 
 def download(
@@ -94,11 +102,12 @@ def download(
     Args:
         dest: Destination directory. Defaults to ~/.nucl-parquet/.
         data_version: CalVer string (`"2026.05.11"`) OR `"latest"` to resolve
-            the most recent `data-*` GitHub release.
-        tag: Deprecated. Pre-CalVer callers passed a code-version tag
-            (e.g. `"v0.13.0"`); this is now ignored with a DeprecationWarning
-            and resolves to the latest data release instead. New callers
-            should use `data_version=`.
+            the most recent `data-*` GitHub release. Pre-CalVer code-version
+            strings (e.g. `"v0.13.0"`) are detected and resolve to latest data
+            with a DeprecationWarning.
+        tag: Deprecated keyword alias of pre-CalVer call sites. Ignored with
+            a DeprecationWarning; resolves to latest data. New callers should
+            use `data_version=`.
 
     Returns:
         Path to the downloaded data directory.
@@ -108,6 +117,17 @@ def download(
             "`tag=` is deprecated in nucl_parquet.download(); pass `data_version=` "
             "with a CalVer identifier (e.g. `'2026.05.11'`) or `'latest'`. "
             "Resolving to latest data release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        data_version = "latest"
+    elif _CODE_VERSION_RE.match(data_version):
+        # Pre-CalVer positional call: download(dest, "v0.13.0"). Same
+        # remediation as the keyword path — warn and fall through to latest.
+        warnings.warn(
+            f"`{data_version!r}` looks like a code-version tag; "
+            "nucl_parquet.download() now takes CalVer data identifiers "
+            "(e.g. `'2026.05.11'`) or `'latest'`. Resolving to latest data.",
             DeprecationWarning,
             stacklevel=2,
         )


### PR DESCRIPTION
## Summary

Implements **Path A** of the dual-track release scheme: data tarballs follow CalVer (`data-YYYY.MM.DD`); code packages keep lockstep semver via release-please (`vX.Y.Z`). Decouples data refresh cadence from code release cadence.

- `data/catalog.json` gains `data_version: "2026.05.11"` field
- `nucl_parquet.data_version()` helper reads it
- `nucl_parquet.download(data_version="2026.05.11")` fetches CalVer tarball; `tag=` retained with DeprecationWarning
- `.github/workflows/release-data.yml` (new) triggered on `data-*` tags, validates CalVer matches catalog, builds + uploads asset
- `.github/workflows/release.yml` no longer carries `data-asset` job — code-only
- README documents the dual track and forward-references #150 (Path B: per-package code semver)

Filed as **#150** for tracking Path B (per-package code semver split).

## Test plan

- [x] `pytest -q` — 446 passing
- [x] `nucl_parquet.data_version()` returns `"2026.05.11"`
- [x] DeprecationWarning fires on `download(tag=...)` callers
- [ ] First `data-2026.05.11` tag push runs `release-data.yml` end-to-end (post-merge verification)
- [ ] First `v0.14.0` code tag does NOT trigger data-asset upload (post-merge verification)

## Release-readiness impact

Updates #144 (release-readiness epic): the release procedure now has two paths. Code release for v0.14.0 still runs unchanged; data ships separately via `data-2026.05.11` tag.

Refs #144, #150.