### PR TITLE
chore(clients): drop ASTAR + stopping.parquet stale refs (closes #141 #145 #146 #147)

### DIFF
--- a/clients/py/nucl-parquet-mcp/nucl_parquet_mcp/server.py
+++ b/clients/py/nucl-parquet-mcp/nucl_parquet_mcp/server.py
@@ -153,8 +153,15 @@ CATALOG: dict[str, Any] = {
         },
         "stopping": {
             "path": "stopping/",
-            "files": {"stopping": "stopping.parquet"},
-            "sources": ["PSTAR", "ASTAR", "ICRU73", "MSTAR"],
+            "files": {
+                "PSTAR": "PSTAR.parquet",
+                "ASTAR": "ASTAR.parquet",
+                "ESTAR": "ESTAR.parquet",
+                "dSTAR": "dSTAR.parquet",
+                "tSTAR": "tSTAR.parquet",
+                "catima": "catima/catima.parquet",
+            },
+            "sources": ["PSTAR", "ASTAR", "ESTAR", "dSTAR", "tSTAR", "catima"],
         },
     },
 }
@@ -335,14 +342,25 @@ async def get_stopping_power(source: str, target_z: int) -> str:
     """Get mass stopping power (dE/dx) for a projectile in a target element.
 
     Args:
-        source: Data source: PSTAR, ASTAR, ICRU73, or MSTAR.
+        source: Data source: PSTAR (protons), ASTAR (α via NIST ICRU-49),
+                ESTAR (electrons), dSTAR/tSTAR (velocity-scaled deuteron/triton).
+                ³He routes through the catima master table (no NIST table exists).
         target_z: Target element atomic number.
     """
     sp = CATALOG["shared"]["stopping"]
-    path = sp["path"] + sp["files"]["stopping"]
+    if source not in sp["files"]:
+        import json
+
+        return json.dumps(
+            {"error": f"unknown source {source!r}; valid: {sp['sources']}"},
+            indent=2,
+        )
+    path = sp["path"] + sp["files"][source]
     rows = await fetch_parquet_rows(path)
 
-    filtered = [row for row in rows if row.get("source") == source and row.get("target_Z") == target_z]
+    # catima uses (proj_Z, target_Z, energy_MeV_u, dedx); NIST tables use
+    # (source, target_Z, energy_MeV, dedx). Filter by target_Z either way.
+    filtered = [row for row in rows if row.get("target_Z") == target_z]
 
     import json
 

--- a/clients/py/nucl-parquet-mcp/tests/test_server.py
+++ b/clients/py/nucl-parquet-mcp/tests/test_server.py
@@ -44,8 +44,18 @@ class TestCatalog:
 
     def test_stopping_sources(self):
         sources = CATALOG["shared"]["stopping"]["sources"]
+        # NIST tables + catima master after #137; ICRU73/MSTAR were never real.
         assert "PSTAR" in sources
         assert "ASTAR" in sources
+        assert "ESTAR" in sources
+        assert "catima" in sources
+
+    def test_stopping_has_per_source_files(self):
+        """Post-#143 the aggregate stopping.parquet is deleted; per-source only."""
+        files = CATALOG["shared"]["stopping"]["files"]
+        for label in ("PSTAR", "ASTAR", "ESTAR", "dSTAR", "tSTAR", "catima"):
+            assert label in files, f"{label} not advertised in stopping files"
+        assert "stopping" not in files, "old stopping.parquet aggregate must not be advertised"
 
 
 class TestUrlConstruction:

--- a/clients/rs/nucl-parquet-mcp/src/main.rs
+++ b/clients/rs/nucl-parquet-mcp/src/main.rs
@@ -404,7 +404,7 @@ fn tool_definitions() -> serde_json::Value {
                 "inputSchema": {
                     "type": "object",
                     "properties": {
-                        "source": { "type": "string", "description": "PSTAR, ASTAR, ICRU73, or MSTAR" },
+                        "source": { "type": "string", "description": "PSTAR (protons), ASTAR (α, NIST ICRU-49), ESTAR (electrons), dSTAR, tSTAR (velocity-scaled from PSTAR), or catima (full Z×Z table; α/³He fallback for non-NIST elements)" },
                         "target_z": { "type": "integer", "description": "Target atomic number" }
                     },
                     "required": ["source", "target_z"]
@@ -558,13 +558,25 @@ async fn handle_tool_call(
                 .get("target_z")
                 .and_then(|v| v.as_i64())
                 .ok_or("missing 'target_z'")?;
-            let rows = fetch_parquet_rows(client, cache, "stopping/stopping.parquet").await?;
+            // Post-#143: aggregate stopping.parquet is deleted; route to per-source
+            // files. catima's full Z×Z master sits under stopping/catima/.
+            let path = match source {
+                "PSTAR" => "stopping/PSTAR.parquet",
+                "ASTAR" => "stopping/ASTAR.parquet",
+                "ESTAR" => "stopping/ESTAR.parquet",
+                "dSTAR" => "stopping/dSTAR.parquet",
+                "tSTAR" => "stopping/tSTAR.parquet",
+                "catima" => "stopping/catima/catima.parquet",
+                other => {
+                    return Err(format!(
+                        "unknown stopping source {other:?}; valid: PSTAR, ASTAR, ESTAR, dSTAR, tSTAR, catima"
+                    ));
+                }
+            };
+            let rows = fetch_parquet_rows(client, cache, path).await?;
             let filtered: Vec<_> = rows
                 .into_iter()
-                .filter(|row| {
-                    row.get("source").and_then(|v| v.as_str()) == Some(source)
-                        && row.get("target_Z").and_then(|v| v.as_i64()) == Some(target_z)
-                })
+                .filter(|row| row.get("target_Z").and_then(|v| v.as_i64()) == Some(target_z))
                 .collect();
             let result = serde_json::json!({ "source": source, "target_z": target_z, "count": filtered.len(), "rows": filtered });
             Ok(

--- a/clients/rs/nucl-parquet/src/data_dir.rs
+++ b/clients/rs/nucl-parquet/src/data_dir.rs
@@ -97,7 +97,7 @@ impl DataDir {
         crate::ElectronDb::open(self.meta())
     }
 
-    /// Open the stopping power database (PSTAR/ASTAR/ESTAR/CatIMA).
+    /// Open the stopping power database (NIST PSTAR/ASTAR/ESTAR + dSTAR/tSTAR + CatIMA).
     pub fn stopping_db(&self) -> Result<crate::StoppingDb> {
         crate::StoppingDb::open(self.stopping())
     }

--- a/clients/rs/nucl-parquet/src/lib.rs
+++ b/clients/rs/nucl-parquet/src/lib.rs
@@ -11,7 +11,7 @@
 //! - **EADL**: Atomic relaxation (fluorescence X-ray and Auger transition probabilities)
 //! - **EEDL**: Electron cross-sections (elastic, bremsstrahlung, ionization)
 //! - **XCOM**: Total mass attenuation coefficients (µ/ρ, µ_en/ρ)
-//! - **Stopping**: NIST PSTAR/ASTAR/ESTAR and CatIMA mass stopping power tables
+//! - **Stopping**: NIST PSTAR/ASTAR/ESTAR + dSTAR/tSTAR and CatIMA mass stopping power tables
 //! - **Meta**: Isotopic abundances, radioactive decay chains, and dose rate constants
 //! - **XS**: Nuclear reaction cross-sections (TENDL and other evaluated libraries)
 //!

--- a/clients/rs/nucl-parquet/src/stopping.rs
+++ b/clients/rs/nucl-parquet/src/stopping.rs
@@ -1,7 +1,23 @@
-//! Stopping power databases (NIST PSTAR/ASTAR/ESTAR and CatIMA).
+//! Stopping power databases (NIST PSTAR/ASTAR/ESTAR + dSTAR/tSTAR and CatIMA).
 //!
 //! Provides mass stopping power lookups via log-log interpolation.
 //! `StoppingDb` is `Send + Sync` — load once, share via `Arc`.
+//!
+//! ## Source routing (post-#137)
+//!
+//! - p, d, t → NIST PSTAR via [`dedx`]; d/t velocity-scaled at the caller
+//!   (E_p = E / A) before lookup (dSTAR/tSTAR pre-built).
+//! - α → NIST ASTAR via [`dedx`] (ICRU-49 reference; reproducible via
+//!   `nucl_parquet.build_stopping`).
+//! - ³He → [`catima_dedx`] with `proj_z = 2` (no NIST ³He table exists).
+//! - e → NIST ESTAR via [`dedx`].
+//! - heavy ions → [`catima_dedx`] (catima's full 92×92 master).
+//!
+//! The previously-shipped He3STAR.parquet and the broken ASTAR.parquet
+//! (Z²-scaled from PSTAR at the wrong energy axis) were removed in #143.
+//!
+//! [`dedx`]: StoppingDb::dedx
+//! [`catima_dedx`]: StoppingDb::catima_dedx
 
 use std::collections::HashMap;
 use std::fs;
@@ -13,8 +29,8 @@ use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use crate::error::Error;
 use crate::interp::{log_log_interp, sort_paired_vecs, XYTable};
 
-/// Mass stopping power database for NIST tabulated sources (PSTAR, ASTAR, ESTAR, …)
-/// and CatIMA heavy-ion calculations.
+/// Mass stopping power database for NIST tabulated sources (PSTAR, ASTAR, ESTAR,
+/// dSTAR, tSTAR) and CatIMA heavy-ion calculations.
 ///
 /// Thread-safe: `Send + Sync`. Share via `Arc<StoppingDb>`.
 #[derive(Clone)]
@@ -34,8 +50,8 @@ unsafe impl Sync for StoppingDb {}
 impl StoppingDb {
     /// Load stopping power data from the nucl-parquet `stopping/` directory.
     ///
-    /// Reads all `*.parquet` files (PSTAR, ASTAR, ESTAR, …) and
-    /// `catima/catima.parquet`.
+    /// Reads all `*.parquet` files at the top level (PSTAR, ASTAR, ESTAR,
+    /// dSTAR, tSTAR, catima_*) plus the full master at `catima/catima.parquet`.
     pub fn open(data_dir: impl AsRef<Path>) -> crate::Result<Self> {
         let dir = data_dir.as_ref();
 
@@ -53,9 +69,15 @@ impl StoppingDb {
         })
     }
 
-    /// Mass stopping power [MeV cm²/g] for a NIST source (e.g. "PSTAR", "ASTAR", "ESTAR").
+    /// Mass stopping power [MeV cm²/g] for a NIST source.
     ///
+    /// Valid `source` values: `"PSTAR"`, `"ASTAR"`, `"ESTAR"`, `"dSTAR"`, `"tSTAR"`.
     /// Returns `f64::NAN` if the (source, target_Z) combination is not loaded.
+    ///
+    /// `energy_mev` is the projectile's *total* kinetic energy. ASTAR is keyed
+    /// on total α KE; PSTAR/dSTAR/tSTAR are projectile-specific tables; ESTAR
+    /// is electron KE. For ³He route via [`catima_dedx`] (`proj_z = 2`) — no
+    /// NIST ³He table exists.
     #[inline]
     pub fn dedx(&self, source: &str, target_z: u32, energy_mev: f64) -> f64 {
         match self.nist.get(&(source.to_string(), target_z)) {
@@ -201,11 +223,13 @@ mod tests {
     use super::*;
 
     fn data_dir() -> std::path::PathBuf {
-        // Repo root is three levels up from src/
+        // Repo root is three levels up from this crate's manifest dir; data
+        // moved under `data/` in the repo layout refactor.
         std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("..")
             .join("..")
             .join("..")
+            .join("data")
             .join("stopping")
     }
 
@@ -233,5 +257,39 @@ mod tests {
         let db = StoppingDb::open(data_dir()).unwrap();
         let s = db.dedx("NONEXISTENT", 999, 10.0);
         assert!(s.is_nan());
+    }
+
+    #[test]
+    #[ignore = "requires nucl-parquet data files"]
+    fn alpha_on_cu_matches_nist_icru49_anchors() {
+        // Post-#137 ASTAR.parquet is reproducible from NIST. These anchors
+        // mirror tests/test_stopping_anchors.py — agreement to <1% guards
+        // against fetcher / data regressions and the Z²-at-wrong-axis bug
+        // class.
+        let db = StoppingDb::open(data_dir()).unwrap();
+        // (energy_MeV total, expected ICRU-49 dedx)
+        let anchors: &[(f64, f64)] = &[
+            (4.0, 483.8),   // 1 MeV/u
+            (20.0, 177.4),  // 5 MeV/u
+            (80.0, 64.54),  // 20 MeV/u
+            (400.0, 19.32), // 100 MeV/u
+        ];
+        for &(e, expected) in anchors {
+            let got = db.dedx("ASTAR", 29, e);
+            let rel = (got - expected).abs() / expected;
+            assert!(
+                rel < 0.01,
+                "α Cu at {e} MeV: got {got}, NIST {expected}, rel err {rel}",
+            );
+        }
+    }
+
+    #[test]
+    #[ignore = "requires nucl-parquet data files"]
+    fn legacy_he3star_source_missing() {
+        // He3STAR.parquet was deleted in #143 — callers must use catima_dedx
+        // with proj_z=2 instead. A `dedx("He3STAR", ...)` lookup returns NaN.
+        let db = StoppingDb::open(data_dir()).unwrap();
+        assert!(db.dedx("He3STAR", 29, 10.0).is_nan());
     }
 }

--- a/clients/ts/nucl-parquet-mcp/src/index.ts
+++ b/clients/ts/nucl-parquet-mcp/src/index.ts
@@ -54,7 +54,18 @@ const CATALOG: Catalog = {
   },
   shared: {
     meta: { path: "meta/", files: { abundances: "abundances.parquet", decay: "decay.parquet", elements: "elements.parquet" } },
-    stopping: { path: "stopping/", files: { stopping: "stopping.parquet" }, sources: ["PSTAR", "ASTAR", "ICRU73", "MSTAR"] },
+    stopping: {
+      path: "stopping/",
+      files: {
+        PSTAR: "PSTAR.parquet",
+        ASTAR: "ASTAR.parquet",
+        ESTAR: "ESTAR.parquet",
+        dSTAR: "dSTAR.parquet",
+        tSTAR: "tSTAR.parquet",
+        catima: "catima/catima.parquet",
+      } as Record<string, string>,
+      sources: ["PSTAR", "ASTAR", "ESTAR", "dSTAR", "tSTAR", "catima"],
+    },
   },
 };
 
@@ -250,16 +261,30 @@ server.tool(
   "get_stopping_power",
   "Get mass stopping power (dE/dx) data for a projectile in a target element.",
   {
-    source: z.string().describe("Data source: PSTAR, ASTAR, ICRU73, or MSTAR"),
+    source: z.string().describe(
+      "Data source: PSTAR (protons), ASTAR (α, NIST ICRU-49), ESTAR (electrons), dSTAR, tSTAR (velocity-scaled from PSTAR), or catima (full Z×Z table; α/³He fallback for non-NIST elements)",
+    ),
     target_z: z.number().describe("Target element atomic number"),
   },
   async ({ source, target_z }) => {
-    const stoppingPath = CATALOG.shared.stopping.path + CATALOG.shared.stopping.files.stopping;
+    // Post-#143: aggregate stopping.parquet is deleted; route per-source.
+    const fileMap = CATALOG.shared.stopping.files;
+    if (!(source in fileMap)) {
+      return {
+        content: [{
+          type: "text" as const,
+          text: JSON.stringify({
+            error: `unknown source ${source}; valid: ${CATALOG.shared.stopping.sources.join(", ")}`,
+          }, null, 2),
+        }],
+      };
+    }
+    const stoppingPath = CATALOG.shared.stopping.path + fileMap[source];
     const rows = await fetchParquetRows(stoppingPath);
 
-    const filtered = rows.filter(
-      (row) => row["source"] === source && row["target_Z"] === target_z,
-    );
+    // catima uses (proj_Z, target_Z); NIST tables use (source, target_Z).
+    // Filter by target_Z in both cases — the file already restricts to one source.
+    const filtered = rows.filter((row) => row["target_Z"] === target_z);
 
     return {
       content: [{

--- a/clients/ts/nucl-parquet-mcp/test/server.test.ts
+++ b/clients/ts/nucl-parquet-mcp/test/server.test.ts
@@ -31,8 +31,20 @@ describe("catalog", () => {
   });
 
   it("shared stopping has sources", () => {
+    // NIST tables + catima master after #137; ICRU73/MSTAR were never real.
     expect(catalog.shared.stopping.sources).toContain("PSTAR");
     expect(catalog.shared.stopping.sources).toContain("ASTAR");
+    expect(catalog.shared.stopping.sources).toContain("ESTAR");
+    expect(catalog.shared.stopping.sources).toContain("catima");
+  });
+
+  it("shared stopping advertises per-source files (not deleted aggregate)", () => {
+    const files = catalog.shared.stopping.files;
+    expect(files).toHaveProperty("PSTAR");
+    expect(files).toHaveProperty("ASTAR");
+    expect(files).toHaveProperty("ESTAR");
+    expect(files).toHaveProperty("catima");
+    expect(files).not.toHaveProperty("stopping"); // aggregate deleted in #143
   });
 });
 
@@ -50,9 +62,11 @@ describe("URL construction", () => {
     expect(path).toBe("meta/decay.parquet");
   });
 
-  it("builds correct stopping path", () => {
-    const path = catalog.shared.stopping.path + catalog.shared.stopping.files.stopping;
-    expect(path).toBe("stopping/stopping.parquet");
+  it("builds correct per-source stopping paths", () => {
+    const f = catalog.shared.stopping.files;
+    expect(catalog.shared.stopping.path + f.PSTAR).toBe("stopping/PSTAR.parquet");
+    expect(catalog.shared.stopping.path + f.ASTAR).toBe("stopping/ASTAR.parquet");
+    expect(catalog.shared.stopping.path + f.catima).toBe("stopping/catima/catima.parquet");
   });
 
   it("builds correct manifest path from library path", () => {

--- a/clients/ts/nucl-parquet/src/columns.ts
+++ b/clients/ts/nucl-parquet/src/columns.ts
@@ -5,6 +5,8 @@
  * then wraps numeric columns in typed arrays — no JSON serialisation round-trip.
  *
  * Intended use:
+ *   // Per-source parquet (PSTAR.parquet / ASTAR.parquet / ESTAR.parquet /
+ *   // dSTAR.parquet / tSTAR.parquet) — schema: source, target_Z, energy_MeV, dedx
  *   const cols = await stoppingColumns(arrayBuffer);
  *   wasm.load_stopping_arrays(cols.source, cols.targetZ, cols.energyMeV, cols.dedx);
  */
@@ -19,7 +21,7 @@ import { compressors } from "hyparquet-compressors";
 
 /** Column-oriented stopping power data for direct WASM transfer. */
 export interface StoppingColumns {
-  /** Stopping source name (e.g. "PSTAR", "ASTAR", "catima"). */
+  /** Stopping source name (one of "PSTAR", "ASTAR", "ESTAR", "dSTAR", "tSTAR"). */
   source: string[];
   /** Target element atomic number. */
   targetZ: Int32Array;
@@ -103,8 +105,13 @@ function getStrings(cols: Map<string, number[] | string[]>, name: string): strin
 // ---------------------------------------------------------------------------
 
 /**
- * Extract stopping power columns from a `stopping.parquet` ArrayBuffer.
- * Schema: source str, target_Z i32, energy_MeV f64, dedx f64
+ * Extract stopping power columns from a per-source NIST parquet ArrayBuffer
+ * (PSTAR.parquet, ASTAR.parquet, ESTAR.parquet, dSTAR.parquet, tSTAR.parquet).
+ * Schema: source str, target_Z i32, energy_MeV f64, dedx f64.
+ *
+ * The previously-shipped `stopping.parquet` aggregate is no longer published
+ * (deleted in #143); fetch the per-source file you need. For full Z×Z catima
+ * coverage use `catimaColumns` against `stopping/catima/catima.parquet`.
  */
 export async function stoppingColumns(buffer: ArrayBuffer): Promise<StoppingColumns> {
   const cols = await extractColumns(buffer);


### PR DESCRIPTION
## Summary

Cleanup pass across all client packages to align with #143 (data-fix that deleted ASTAR.parquet/He3STAR.parquet/stopping.parquet aggregate, rerouted α→NIST ASTAR + ³He→catima). Closes the four sibling release-blocker issues from epic #144.

| Issue | Package | Change |
|---|---|---|
| #141 | `clients/py/nucl-parquet-mcp` | CATALOG advertises real per-source files; `get_stopping_power` tool rejects unknown sources cleanly |
| #141 | `clients/rs/nucl-parquet-mcp` | Tool schema description updated; `get_stopping_power` dispatches per source |
| #145 | `clients/ts/nucl-parquet-mcp` | Mirror of #141 cleanup; tests guard the new file map |
| #146 | `clients/rs/nucl-parquet` (core) | Rustdoc updated; new NIST anchor regression test (α on Cu at 1/5/20/100 MeV/u, <1% vs ICRU-49); legacy He3STAR-returns-NaN guard; fixed stale test data_dir path |
| #147 | `clients/ts/nucl-parquet` (core) | JSDoc + usage example point at per-source parquets |

No manual version bumps — release-please's `extra-files` config bumps all six packages in lockstep when the release PR opens.

## Test plan

- [x] Python MCP: `uv run pytest` → 18 passing
- [x] Rust MCP: `cargo test` → 10 passing (incl. tool definitions)
- [x] Rust core: `cargo test stopping:: -- --ignored` → 5 passing (incl. new α anchor + He3STAR-NaN guard)
- [x] TS MCP: `npx vitest run` → 13 passing
- [x] TS core: `npx vitest run` → 12 passing
- [ ] Full CI green on this PR

Refs #144.