### PR TITLE
feat(release): Path B — per-package semver across 7 code packages (closes #150)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo publish --allow-dirty
+      - run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
@@ -74,7 +74,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo publish --allow-dirty
+      - run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,22 @@
 name: Release
 
-# Code-only release pipeline. Triggered on semver tags from release-please
-# (`v*`); fans out to PyPI, crates.io, npm, and the Go module mirror.
+# Per-package code release pipeline. Each tag prefix routes to exactly one
+# publish job; an MCP-only fix no longer pushes a no-op release on the core
+# packages. See release-please-config.json for the package-to-tag mapping.
 #
-# Data tarballs ship from a separate workflow (.github/workflows/release-data.yml)
-# triggered on `data-YYYY.MM.DD` CalVer tags. The two pipelines run independently
-# so a code-only bump does not republish data, and a data refresh does not bump
-# every code package.
+# Data tarballs ship from a separate workflow (release-data.yml) on
+# `data-YYYY.MM.DD` CalVer tags. Data and code release independently.
 
 on:
   push:
-    tags: ["v*"]
+    tags:
+      - "nucl-parquet-py-v*"
+      - "nucl-parquet-mcp-py-v*"
+      - "nucl-parquet-rs-v*"
+      - "nucl-parquet-mcp-rs-v*"
+      - "nucl-parquet-ts-v*"
+      - "nucl-parquet-mcp-ts-v*"
+      - "clients/go/nucl-parquet/v*"
 
 permissions:
   contents: write
@@ -18,7 +24,8 @@ permissions:
 
 jobs:
   pypi:
-    name: Publish to PyPI
+    name: Publish nucl-parquet to PyPI
+    if: startsWith(github.ref, 'refs/tags/nucl-parquet-py-v')
     runs-on: ubuntu-latest
     environment: pypi
     steps:
@@ -27,8 +34,53 @@ jobs:
       - run: uv build
       - uses: pypa/gh-action-pypi-publish@release/v1
 
+  pypi-mcp:
+    name: Publish nucl-parquet-mcp to PyPI
+    if: startsWith(github.ref, 'refs/tags/nucl-parquet-mcp-py-v')
+    runs-on: ubuntu-latest
+    environment: pypi-mcp
+    defaults:
+      run:
+        working-directory: clients/py/nucl-parquet-mcp
+    steps:
+      - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v6
+      - run: uv build
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: clients/py/nucl-parquet-mcp/dist
+
+  cargo:
+    name: Publish nucl-parquet to crates.io
+    if: startsWith(github.ref, 'refs/tags/nucl-parquet-rs-v')
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: clients/rs/nucl-parquet
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo publish --allow-dirty
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  cargo-mcp:
+    name: Publish nucl-parquet-mcp to crates.io
+    if: startsWith(github.ref, 'refs/tags/nucl-parquet-mcp-rs-v')
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: clients/rs/nucl-parquet-mcp
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo publish --allow-dirty
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
   npm:
-    name: Publish to npm
+    name: Publish @nucl-parquet/core to npm
+    if: startsWith(github.ref, 'refs/tags/nucl-parquet-ts-v')
     runs-on: ubuntu-latest
     environment: npm
     permissions:
@@ -49,36 +101,9 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-  cargo:
-    name: Publish to crates.io
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: clients/rs/nucl-parquet
-    steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
-      - run: cargo publish --allow-dirty
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
-  pypi-mcp:
-    name: Publish nucl-parquet-mcp to PyPI
-    runs-on: ubuntu-latest
-    environment: pypi-mcp
-    defaults:
-      run:
-        working-directory: clients/py/nucl-parquet-mcp
-    steps:
-      - uses: actions/checkout@v5
-      - uses: astral-sh/setup-uv@v6
-      - run: uv build
-      - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: clients/py/nucl-parquet-mcp/dist
-
   npm-mcp:
     name: Publish @nucl-parquet/mcp to npm
+    if: startsWith(github.ref, 'refs/tags/nucl-parquet-mcp-ts-v')
     runs-on: ubuntu-latest
     environment: npm
     permissions:
@@ -99,28 +124,14 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-  cargo-mcp:
-    name: Publish nucl-parquet-mcp to crates.io
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: clients/rs/nucl-parquet-mcp
-    steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
-      - run: cargo publish --allow-dirty
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
-  go-tag:
-    name: Mirror Go module tag
+  # Go does not need a publish job: release-please tags `clients/go/nucl-parquet/v*`
+  # directly, which is the form the Go module proxy resolves. The tag's
+  # existence on GitHub *is* the publish. We keep a noop step on the Go tag
+  # purely so the workflow run shows up in the release record.
+  go-noop:
+    name: Acknowledge Go module tag
+    if: startsWith(github.ref, 'refs/tags/clients/go/nucl-parquet/v')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - name: Create Go module tag
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          VERSION=${GITHUB_REF#refs/tags/v}
-          git tag -a "clients/go/nucl-parquet/v${VERSION}" -m "Go v${VERSION}"
-          git push origin "clients/go/nucl-parquet/v${VERSION}"
+      - run: |
+          echo "Go module tag $GITHUB_REF pushed; Go module proxy resolves it directly."

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,9 @@
 {
-  ".": "0.13.0"
+  ".": "0.13.0",
+  "clients/py/nucl-parquet-mcp": "0.13.0",
+  "clients/rs/nucl-parquet": "0.13.0",
+  "clients/rs/nucl-parquet-mcp": "0.13.0",
+  "clients/ts/nucl-parquet": "0.13.0",
+  "clients/ts/nucl-parquet-mcp": "0.13.0",
+  "clients/go/nucl-parquet": "0.13.0"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,3 +31,69 @@ prek run --all-files --hook-stage pre-push  # clippy
 Commit-stage hooks are cheap; pre-push runs `cargo clippy -- -D warnings` on both `clients/rs/nucl-parquet` and `clients/rs/nucl-parquet-mcp`.
 
 If you must bypass, use `git commit --no-verify` or `git push --no-verify` — CI will still catch you.
+
+## Conventional Commits and per-package releases
+
+This repo runs [release-please](https://github.com/googleapis/release-please) in **per-package** mode (see `release-please-config.json`). Each code package has its own semver track, its own tag prefix, and its own CHANGELOG. The commit's *file paths* decide which package(s) get bumped; the commit's *scope* is for human readability and changelog filtering.
+
+### Package map
+
+| Package | Path | Release-please component | Tag prefix |
+|---|---|---|---|
+| `nucl-parquet` (Python) | `.` | `nucl-parquet-py` | `nucl-parquet-py-v` |
+| `nucl-parquet-mcp` (Python) | `clients/py/nucl-parquet-mcp/` | `nucl-parquet-mcp-py` | `nucl-parquet-mcp-py-v` |
+| `nucl-parquet` (Rust) | `clients/rs/nucl-parquet/` | `nucl-parquet-rs` | `nucl-parquet-rs-v` |
+| `nucl-parquet-mcp` (Rust) | `clients/rs/nucl-parquet-mcp/` | `nucl-parquet-mcp-rs` | `nucl-parquet-mcp-rs-v` |
+| `@nucl-parquet/core` (TS) | `clients/ts/nucl-parquet/` | `nucl-parquet-ts` | `nucl-parquet-ts-v` |
+| `@nucl-parquet/mcp` (TS) | `clients/ts/nucl-parquet-mcp/` | `nucl-parquet-mcp-ts` | `nucl-parquet-mcp-ts-v` |
+| `nucl-parquet-go` | `clients/go/nucl-parquet/` | `clients/go/nucl-parquet` | `clients/go/nucl-parquet/v` |
+
+### Recommended commit scopes
+
+Scopes are conventional, not strictly enforced — but consistent scopes make the changelog readable:
+
+| Scope | Meaning | Likely bumps |
+|---|---|---|
+| `py`, `py-core` | Python core (loader, builders, tests) | `nucl-parquet-py` |
+| `py-mcp` | Python MCP server | `nucl-parquet-mcp-py` |
+| `rs`, `rs-core` | Rust core crate | `nucl-parquet-rs` |
+| `rs-mcp` | Rust MCP server | `nucl-parquet-mcp-rs` |
+| `ts`, `ts-core` | TypeScript core | `nucl-parquet-ts` |
+| `ts-mcp` | TypeScript MCP server | `nucl-parquet-mcp-ts` |
+| `go` | Go module | `clients/go/nucl-parquet` |
+| domain (e.g. `stopping`, `em`, `nudex`) | Cross-cutting nuclear-data work that touches the Python core + tests + data | usually `nucl-parquet-py` (and any client whose tests/docs were updated) |
+| `release`, `ci`, `data` | Build/release plumbing | usually no bump (chore-equivalent) |
+
+The path-detection logic is authoritative: if your commit touches files inside `clients/py/nucl-parquet-mcp/`, that package bumps regardless of scope.
+
+### Examples
+
+```text
+fix(stopping)!: route α through NIST ASTAR
+# Touches nucl_parquet/, tests/, data/, README.md.
+# → Bumps nucl-parquet-py only.
+
+chore(rs-mcp): drop ASTAR refs from tool schema
+# Touches clients/rs/nucl-parquet-mcp/src/main.rs.
+# → Bumps nucl-parquet-mcp-rs only.
+
+docs(release): document the dual-track scheme
+# Touches README.md only.
+# → Bumps nucl-parquet-py only (root-owned README).
+
+feat(em): add Seltzer-Berger bremsstrahlung DCS
+# Touches nucl_parquet/, tests/, data/.
+# → Bumps nucl-parquet-py only.
+```
+
+### Cross-package changes
+
+If a single change has to touch multiple packages (e.g. you add a new column to the parquet schema and update every client), prefer **separate commits per scope** so each package's CHANGELOG describes the change in package-relevant language. Squash-merge into `main` keeps the topology clean.
+
+### Breaking changes
+
+A `!` after the scope (or a `BREAKING CHANGE:` footer) signals a major bump. In a 0.x repo this manifests as a minor bump per release-please's defaults. Use it.
+
+### Data releases
+
+Data lives outside the per-package code semver. Bumping data means editing `data/catalog.json::data_version` and pushing a `data-YYYY.MM.DD` tag manually — see `.github/workflows/release-data.yml`. Conventional-commit scopes for data work (`feat(data)`, etc.) do not trigger any code-package bump.

--- a/clients/go/nucl-parquet/CHANGELOG.md
+++ b/clients/go/nucl-parquet/CHANGELOG.md
@@ -1,7 +1,4 @@
 # Changelog
 
-Per-package release-please CHANGELOG; populated automatically on release.
-The first entry will land when this package next ships.
-
-For project-wide release history prior to per-package semver, see the
-top-level [CHANGELOG.md](/CHANGELOG.md).
+<!-- release-please prepends new release entries here. -->
+<!-- Pre-per-package-semver history lives in the top-level /CHANGELOG.md. -->

--- a/clients/go/nucl-parquet/CHANGELOG.md
+++ b/clients/go/nucl-parquet/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+Per-package release-please CHANGELOG; populated automatically on release.
+The first entry will land when this package next ships.
+
+For project-wide release history prior to per-package semver, see the
+top-level [CHANGELOG.md](/CHANGELOG.md).

--- a/clients/py/nucl-parquet-mcp/CHANGELOG.md
+++ b/clients/py/nucl-parquet-mcp/CHANGELOG.md
@@ -1,7 +1,4 @@
 # Changelog
 
-Per-package release-please CHANGELOG; populated automatically on release.
-The first entry will land when this package next ships.
-
-For project-wide release history prior to per-package semver, see the
-top-level [CHANGELOG.md](/CHANGELOG.md).
+<!-- release-please prepends new release entries here. -->
+<!-- Pre-per-package-semver history lives in the top-level /CHANGELOG.md. -->

--- a/clients/py/nucl-parquet-mcp/CHANGELOG.md
+++ b/clients/py/nucl-parquet-mcp/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+Per-package release-please CHANGELOG; populated automatically on release.
+The first entry will land when this package next ships.
+
+For project-wide release history prior to per-package semver, see the
+top-level [CHANGELOG.md](/CHANGELOG.md).

--- a/clients/rs/nucl-parquet-mcp/CHANGELOG.md
+++ b/clients/rs/nucl-parquet-mcp/CHANGELOG.md
@@ -1,7 +1,4 @@
 # Changelog
 
-Per-package release-please CHANGELOG; populated automatically on release.
-The first entry will land when this package next ships.
-
-For project-wide release history prior to per-package semver, see the
-top-level [CHANGELOG.md](/CHANGELOG.md).
+<!-- release-please prepends new release entries here. -->
+<!-- Pre-per-package-semver history lives in the top-level /CHANGELOG.md. -->

--- a/clients/rs/nucl-parquet-mcp/CHANGELOG.md
+++ b/clients/rs/nucl-parquet-mcp/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+Per-package release-please CHANGELOG; populated automatically on release.
+The first entry will land when this package next ships.
+
+For project-wide release history prior to per-package semver, see the
+top-level [CHANGELOG.md](/CHANGELOG.md).

--- a/clients/rs/nucl-parquet/CHANGELOG.md
+++ b/clients/rs/nucl-parquet/CHANGELOG.md
@@ -1,7 +1,4 @@
 # Changelog
 
-Per-package release-please CHANGELOG; populated automatically on release.
-The first entry will land when this package next ships.
-
-For project-wide release history prior to per-package semver, see the
-top-level [CHANGELOG.md](/CHANGELOG.md).
+<!-- release-please prepends new release entries here. -->
+<!-- Pre-per-package-semver history lives in the top-level /CHANGELOG.md. -->

--- a/clients/rs/nucl-parquet/CHANGELOG.md
+++ b/clients/rs/nucl-parquet/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+Per-package release-please CHANGELOG; populated automatically on release.
+The first entry will land when this package next ships.
+
+For project-wide release history prior to per-package semver, see the
+top-level [CHANGELOG.md](/CHANGELOG.md).

--- a/clients/ts/nucl-parquet-mcp/CHANGELOG.md
+++ b/clients/ts/nucl-parquet-mcp/CHANGELOG.md
@@ -1,7 +1,4 @@
 # Changelog
 
-Per-package release-please CHANGELOG; populated automatically on release.
-The first entry will land when this package next ships.
-
-For project-wide release history prior to per-package semver, see the
-top-level [CHANGELOG.md](/CHANGELOG.md).
+<!-- release-please prepends new release entries here. -->
+<!-- Pre-per-package-semver history lives in the top-level /CHANGELOG.md. -->

--- a/clients/ts/nucl-parquet-mcp/CHANGELOG.md
+++ b/clients/ts/nucl-parquet-mcp/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+Per-package release-please CHANGELOG; populated automatically on release.
+The first entry will land when this package next ships.
+
+For project-wide release history prior to per-package semver, see the
+top-level [CHANGELOG.md](/CHANGELOG.md).

--- a/clients/ts/nucl-parquet/CHANGELOG.md
+++ b/clients/ts/nucl-parquet/CHANGELOG.md
@@ -1,7 +1,4 @@
 # Changelog
 
-Per-package release-please CHANGELOG; populated automatically on release.
-The first entry will land when this package next ships.
-
-For project-wide release history prior to per-package semver, see the
-top-level [CHANGELOG.md](/CHANGELOG.md).
+<!-- release-please prepends new release entries here. -->
+<!-- Pre-per-package-semver history lives in the top-level /CHANGELOG.md. -->

--- a/clients/ts/nucl-parquet/CHANGELOG.md
+++ b/clients/ts/nucl-parquet/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+Per-package release-please CHANGELOG; populated automatically on release.
+The first entry will land when this package next ships.
+
+For project-wide release history prior to per-package semver, see the
+top-level [CHANGELOG.md](/CHANGELOG.md).

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,37 +1,64 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "separate-pull-requests": false,
+  "plugins": ["sentence-case"],
   "packages": {
     ".": {
       "release-type": "python",
       "package-name": "nucl-parquet",
-      "include-component-in-tag": false,
-      "extra-files": [
-        {
-          "type": "toml",
-          "path": "clients/rs/nucl-parquet/Cargo.toml",
-          "jsonpath": "$.package.version"
-        },
-        {
-          "type": "toml",
-          "path": "clients/rs/nucl-parquet-mcp/Cargo.toml",
-          "jsonpath": "$.package.version"
-        },
-        {
-          "type": "toml",
-          "path": "clients/py/nucl-parquet-mcp/pyproject.toml",
-          "jsonpath": "$.project.version"
-        },
-        {
-          "type": "json",
-          "path": "clients/ts/nucl-parquet/package.json",
-          "jsonpath": "$.version"
-        },
-        {
-          "type": "json",
-          "path": "clients/ts/nucl-parquet-mcp/package.json",
-          "jsonpath": "$.version"
-        }
+      "component": "nucl-parquet-py",
+      "include-component-in-tag": true,
+      "tag-separator": "-",
+      "exclude-paths": [
+        "clients/py/nucl-parquet-mcp",
+        "clients/rs/nucl-parquet",
+        "clients/rs/nucl-parquet-mcp",
+        "clients/ts/nucl-parquet",
+        "clients/ts/nucl-parquet-mcp",
+        "clients/go/nucl-parquet"
       ]
+    },
+    "clients/py/nucl-parquet-mcp": {
+      "release-type": "python",
+      "package-name": "nucl-parquet-mcp",
+      "component": "nucl-parquet-mcp-py",
+      "include-component-in-tag": true,
+      "tag-separator": "-"
+    },
+    "clients/rs/nucl-parquet": {
+      "release-type": "rust",
+      "package-name": "nucl-parquet",
+      "component": "nucl-parquet-rs",
+      "include-component-in-tag": true,
+      "tag-separator": "-"
+    },
+    "clients/rs/nucl-parquet-mcp": {
+      "release-type": "rust",
+      "package-name": "nucl-parquet-mcp",
+      "component": "nucl-parquet-mcp-rs",
+      "include-component-in-tag": true,
+      "tag-separator": "-"
+    },
+    "clients/ts/nucl-parquet": {
+      "release-type": "node",
+      "package-name": "@nucl-parquet/core",
+      "component": "nucl-parquet-ts",
+      "include-component-in-tag": true,
+      "tag-separator": "-"
+    },
+    "clients/ts/nucl-parquet-mcp": {
+      "release-type": "node",
+      "package-name": "@nucl-parquet/mcp",
+      "component": "nucl-parquet-mcp-ts",
+      "include-component-in-tag": true,
+      "tag-separator": "-"
+    },
+    "clients/go/nucl-parquet": {
+      "release-type": "go",
+      "package-name": "github.com/exoma-ch/nucl-parquet/clients/go/nucl-parquet",
+      "component": "clients/go/nucl-parquet",
+      "include-component-in-tag": true,
+      "tag-separator": "/"
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
## Summary

Implements **Path B** of the dual-track release plan (#150): each of the 7 code packages now has its own release-please component, its own tag prefix, its own CHANGELOG.md, and its own publish job. An MCP-only fix no longer forces a no-op Rust/Python/Go bump.

### Tag scheme

| Package | Path | Tag prefix |
|---|---|---|
| `nucl-parquet` (Python) | `.` | `nucl-parquet-py-v` |
| `nucl-parquet-mcp` (Python) | `clients/py/nucl-parquet-mcp/` | `nucl-parquet-mcp-py-v` |
| `nucl-parquet` (Rust) | `clients/rs/nucl-parquet/` | `nucl-parquet-rs-v` |
| `nucl-parquet-mcp` (Rust) | `clients/rs/nucl-parquet-mcp/` | `nucl-parquet-mcp-rs-v` |
| `@nucl-parquet/core` (TS) | `clients/ts/nucl-parquet/` | `nucl-parquet-ts-v` |
| `@nucl-parquet/mcp` (TS) | `clients/ts/nucl-parquet-mcp/` | `nucl-parquet-mcp-ts-v` |
| Go module | `clients/go/nucl-parquet/` | `clients/go/nucl-parquet/v` |

Go's full-path tag form is mandated by the Go module proxy.

### Changes

- `release-please-config.json`: 7-package config; root has `exclude-paths` on every `clients/` subfolder.
- `.release-please-manifest.json`: seeded with all 7 packages at 0.13.0 (current source-of-truth).
- `.github/workflows/release.yml`: each publish job gates on `if: startsWith(github.ref, 'refs/tags/<prefix>-v')`. `go-tag` mirror job removed (release-please now tags the Go module path directly).
- `CONTRIBUTING.md`: documents the scope-to-package mapping, with worked examples.
- Per-client `CHANGELOG.md` stubs (`# Changelog` header + HTML comments) — release-please's prepend mode plays nicely with this.

### Migration safety

7 bootstrap tags pushed manually to remote pointing at the `v0.13.0` SHA (`90ba544`):
- `nucl-parquet-py-v0.13.0`
- `nucl-parquet-mcp-py-v0.13.0`
- `nucl-parquet-rs-v0.13.0`
- `nucl-parquet-mcp-rs-v0.13.0`
- `nucl-parquet-ts-v0.13.0`
- `nucl-parquet-mcp-ts-v0.13.0`
- `clients/go/nucl-parquet/v0.13.0`

These are functionally no-ops (the new release.yml tag triggers aren't active on `main` yet) but tell release-please where to start its diff for each component. Without them, the first per-package PR's CHANGELOGs would include the entire repo history. The Go module's existing `clients/go/nucl-parquet/v0.10.0` tag is left untouched — Go consumers will see v0.10.0 → v0.13.0 as next on the module proxy (we don't backfill 0.11/0.12 because no separate Go release was actually published for those code versions).

### Two review rounds

Spike review (#150) + implementation-match review on the diff. Reviewer's HOLD on bootstrap tags was the load-bearing finding; both blockers are now resolved.

## Test plan

- [x] `uv run pytest -q` — 446 passing (config changes don't touch loader code)
- [x] YAML/JSON valid (`prek` passed via pre-commit hooks)
- [x] Bootstrap tags pushed and visible via `git ls-remote --tags origin`
- [ ] First release-please PR after merge proposes per-package bumps (verify the bot opens 1 PR with 7 sections)
- [ ] First per-package tag push fires only its matching job (manual verify on first real release)

Closes #150. Refs #144 (release-readiness epic — no longer blocks v0.14.0; merging Path B before v0.14 means v0.14 ships as 7 separate tags).