### PR TITLE
fix(release): bump-minor-pre-major on all 7 packages (refs #150)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "separate-pull-requests": false,
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
   "plugins": ["sentence-case"],
   "packages": {
     ".": {
@@ -9,6 +11,8 @@
       "component": "nucl-parquet-py",
       "include-component-in-tag": true,
       "tag-separator": "-",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
       "exclude-paths": [
         "clients/py/nucl-parquet-mcp",
         "clients/rs/nucl-parquet",
@@ -23,42 +27,54 @@
       "package-name": "nucl-parquet-mcp",
       "component": "nucl-parquet-mcp-py",
       "include-component-in-tag": true,
-      "tag-separator": "-"
+      "tag-separator": "-",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true
     },
     "clients/rs/nucl-parquet": {
       "release-type": "rust",
       "package-name": "nucl-parquet",
       "component": "nucl-parquet-rs",
       "include-component-in-tag": true,
-      "tag-separator": "-"
+      "tag-separator": "-",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true
     },
     "clients/rs/nucl-parquet-mcp": {
       "release-type": "rust",
       "package-name": "nucl-parquet-mcp",
       "component": "nucl-parquet-mcp-rs",
       "include-component-in-tag": true,
-      "tag-separator": "-"
+      "tag-separator": "-",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true
     },
     "clients/ts/nucl-parquet": {
       "release-type": "node",
       "package-name": "@nucl-parquet/core",
       "component": "nucl-parquet-ts",
       "include-component-in-tag": true,
-      "tag-separator": "-"
+      "tag-separator": "-",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true
     },
     "clients/ts/nucl-parquet-mcp": {
       "release-type": "node",
       "package-name": "@nucl-parquet/mcp",
       "component": "nucl-parquet-mcp-ts",
       "include-component-in-tag": true,
-      "tag-separator": "-"
+      "tag-separator": "-",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true
     },
     "clients/go/nucl-parquet": {
       "release-type": "go",
       "package-name": "github.com/exoma-ch/nucl-parquet/clients/go/nucl-parquet",
       "component": "clients/go/nucl-parquet",
       "include-component-in-tag": true,
-      "tag-separator": "/"
+      "tag-separator": "/",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
## Summary

Path B's release-please run after #153 merged proposed jumping the TS core package from 0.13.0 to **1.0.0** because the prior `fix(stopping)!:` commit (a release-please breaking-change marker) triggers a major bump by default. None of the seven packages is ready for a 1.0.0 cut — they should all stay on 0.x for the foreseeable future.

`bump-minor-pre-major: true` (with the patch-pair) keeps every 0.x package's breaking-change commits on the minor track until each package explicitly cuts its own 1.0.0.

## Test plan

- [x] JSON valid (prek passed via pre-commit hooks)
- [ ] Next release-please run proposes `0.14.0` (or `0.13.x`) per package, no 1.0.0 — pending PAT permission fix (see PR description; out of scope for this PR)

## Companion cleanup

Three orphan branches deleted from `origin` so the next release-please run starts fresh:

- `release-please--branches--main` (left behind by #153's failed run)
- `release-please--branches--main--components--nucl-parquet` (stale from pre-Path B era)
- `fix/release-please-pat` (leftover from #136)

## Out of scope — but related

Release-please ref-update API calls are failing for the post-#136 PAT setup. Three consecutive `main` merges have triggered the same `Error updating ref heads/release-please--branches--main` failure. The fix is to update the `RELEASE_PLEASE_TOKEN` permissions: needs **Contents: read+write, Pull requests: read+write, Issues: read+write, Metadata: read** at https://github.com/settings/tokens?type=beta. Once the PAT is rotated/rescoped, the next push to `main` will trigger a clean release-please PR using the bump-minor-pre-major config from this PR.

Refs #144, #150.