### PR TITLE
feat(data): PR-gated data-release flow + auto-tag on merge (refs #144)

### DIFF
--- a/.github/workflows/auto-tag-data.yml
+++ b/.github/workflows/auto-tag-data.yml
@@ -1,0 +1,75 @@
+name: Auto-tag data release
+
+# When a push to main changes `data/catalog.json::data_version`, automatically
+# create + push the matching `data-<version>` tag. That tag push fires
+# release-data.yml, which validates the tag-vs-catalog match and publishes
+# the tarball to a GitHub Release. The PR review is the human gate; this
+# workflow removes the manual `git tag` step entirely — `data/catalog.json`
+# is the single source of truth.
+#
+# Belt-and-suspenders: release-data.yml re-validates tag CalVer vs catalog
+# at build time. If this workflow ever produces a mismatched tag (it
+# shouldn't — it derives the tag from catalog.json itself), release-data.yml
+# fails loudly rather than publishing the bad tarball.
+
+on:
+  push:
+    branches: [main]
+    paths: [data/catalog.json]
+
+permissions:
+  contents: write
+
+jobs:
+  auto-tag:
+    name: Auto-tag data-${{ steps.detect.outputs.version }} on data_version change
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 2
+
+      - id: detect
+        name: Detect data_version change
+        run: |
+          OLD=$(git show HEAD~1:data/catalog.json 2>/dev/null | jq -r '.data_version // empty')
+          NEW=$(jq -r '.data_version // empty' data/catalog.json)
+
+          if [ -z "$NEW" ]; then
+            echo "ERROR: data/catalog.json::data_version is empty on HEAD" >&2
+            exit 1
+          fi
+
+          if [ "$OLD" = "$NEW" ]; then
+            echo "data_version unchanged ($NEW) — nothing to tag"
+            echo "tag=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if ! [[ "$NEW" =~ ^[0-9]{4}\.[0-9]+\.[0-9]+$ ]]; then
+            echo "ERROR: new data_version ($NEW) is not valid CalVer YYYY.MM.MICRO" >&2
+            exit 1
+          fi
+
+          echo "data_version: $OLD -> $NEW"
+          echo "tag=data-${NEW}" >> "$GITHUB_OUTPUT"
+          echo "version=${NEW}" >> "$GITHUB_OUTPUT"
+
+      - name: Push data tag
+        if: steps.detect.outputs.tag != ''
+        env:
+          TAG: ${{ steps.detect.outputs.tag }}
+        run: |
+          # Fail loudly if the tag already exists — never silently overwrite.
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "ERROR: tag ${TAG} already exists; refusing to re-tag" >&2
+            exit 1
+          fi
+          if git ls-remote --tags origin "refs/tags/${TAG}" | grep -q "${TAG}"; then
+            echo "ERROR: tag ${TAG} already exists on origin; refusing to re-tag" >&2
+            exit 1
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "${TAG}" -m "Auto-tagged from data/catalog.json::data_version on merge"
+          git push origin "${TAG}"

--- a/.github/workflows/release-data.yml
+++ b/.github/workflows/release-data.yml
@@ -1,8 +1,9 @@
 name: Release Data
 
-# Data releases follow CalVer (YYYY.MM.DD) on their own tag namespace,
+# Data releases follow CalVer (YYYY.MM.MICRO) on their own tag namespace,
 # decoupled from the code semver release pipeline (.github/workflows/release.yml).
-# Trigger by pushing a tag like `data-2026.05.11`.
+# Trigger by pushing a tag like `data-2026.5.0` (or via auto-tag-data.yml on
+# merge to main when data/catalog.json::data_version changes).
 
 on:
   push:
@@ -21,11 +22,11 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y zstd
       - name: Build tarball
         run: |
-          # Tag form: data-YYYY.MM.DD → strip the `data-` prefix to get CalVer.
+          # Tag form: data-YYYY.MM.MICRO → strip the `data-` prefix to get CalVer.
           CALVER=${GITHUB_REF#refs/tags/data-}
           # Sanity-check the tag actually matches CalVer.
-          if ! [[ "${CALVER}" =~ ^[0-9]{4}\.[0-9]{2}\.[0-9]{2}$ ]]; then
-            echo "ERROR: tag ${GITHUB_REF} does not match data-YYYY.MM.DD" >&2
+          if ! [[ "${CALVER}" =~ ^[0-9]{4}\.[0-9]+\.[0-9]+$ ]]; then
+            echo "ERROR: tag ${GITHUB_REF} does not match data-YYYY.MM.MICRO" >&2
             exit 1
           fi
           # Sanity-check catalog.json::data_version matches the tag.

--- a/data/catalog.json
+++ b/data/catalog.json
@@ -1,7 +1,8 @@
 {
   "$schema": "./catalog.schema.json",
   "version": 1,
-  "data_version": "2026.05.11",
+  "data_version": "2026.5.12",
+  "data_sha256": "c18ff3d96e527b2cd68f6ebd4a5271653a0bd8170586948f06f422f97663afae",
   "description": "Registry of available nuclear data libraries",
   "libraries": {
     "tendl-2024": {

--- a/data/catalog.json
+++ b/data/catalog.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./catalog.schema.json",
   "version": 1,
-  "data_version": "2026.5.12",
+  "data_version": "2026.5.0",
   "data_sha256": "c18ff3d96e527b2cd68f6ebd4a5271653a0bd8170586948f06f422f97663afae",
   "description": "Registry of available nuclear data libraries",
   "libraries": {

--- a/data/catalog.schema.json
+++ b/data/catalog.schema.json
@@ -2,29 +2,45 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "nucl-parquet catalog",
   "type": "object",
-  "required": ["version", "data_version", "libraries", "shared"],
+  "required": ["version", "data_version", "data_sha256", "libraries", "shared"],
   "properties": {
     "version": { "type": "integer", "const": 1 },
     "data_version": {
       "type": "string",
-      "pattern": "^[0-9]{4}\\.[0-9]{2}\\.[0-9]{2}$",
-      "description": "CalVer YYYY.MM.DD identifier for the data tarball; matches the GitHub Release tag `data-{data_version}`."
+      "pattern": "^[0-9]{4}\\.[0-9]+\\.[0-9]+$",
+      "description": "CalVer YYYY.MM.MICRO identifier for the data tarball (e.g. `2026.5.0`, `2026.5.1` for an in-month iteration); matches the GitHub Release tag `data-{data_version}`."
+    },
+    "data_sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$",
+      "description": "Deterministic SHA-256 tree hash of all data/**/*.parquet files. Recompute via `nucl_parquet.compute_data_sha256()`. PR CI gates on hash matching the on-disk tree; data_version must change iff data_sha256 changes."
     },
     "description": { "type": "string" },
     "libraries": {
       "type": "object",
       "additionalProperties": {
         "type": "object",
-        "required": ["name", "projectiles", "data_type", "version", "path"],
+        "description": "Two shapes supported: (1) evaluated cross-section libraries with `projectiles`, `version`, `path`; (2) external-dataset references (e.g. strata-data on HF) with `revision`, `fetcher`, `files`. The common required minimum is `name` + `data_type`.",
+        "required": ["name", "data_type"],
         "properties": {
           "name": { "type": "string" },
           "description": { "type": "string" },
           "source_url": { "type": "string", "format": "uri" },
           "projectiles": {
             "type": "array",
-            "items": { "type": "string", "enum": ["p", "d", "t", "h", "a"] }
+            "items": { "type": "string" },
+            "description": "Light-ion shorthand (n/p/d/t/h/a/g) for evaluated libraries; heavy-ion identifiers (e.g. c12, fe56) for production / total-reaction libraries."
           },
-          "data_type": { "type": "string", "enum": ["cross_sections"] },
+          "data_type": {
+            "type": "string",
+            "enum": [
+              "cross_sections",
+              "production_cross_sections",
+              "total_reaction_cross_sections",
+              "experimental_cross_sections",
+              "nuclear_structure"
+            ]
+          },
           "version": { "type": "string" },
           "path": { "type": "string" }
         }
@@ -43,11 +59,14 @@
         },
         "stopping": {
           "type": "object",
-          "required": ["path", "files"],
+          "required": ["path", "sources"],
           "properties": {
             "path": { "type": "string" },
-            "files": { "type": "object", "additionalProperties": { "type": "string" } },
-            "sources": { "type": "array", "items": { "type": "string" } }
+            "layout": { "type": "string" },
+            "catima_full_matrix": { "type": "string" },
+            "sources": { "type": "array", "items": { "type": "string" } },
+            "sources_note": { "type": "string" },
+            "catima": { "type": "object" }
           }
         }
       }

--- a/nucl_parquet/__init__.py
+++ b/nucl_parquet/__init__.py
@@ -1,6 +1,6 @@
 """nucl-parquet: Nuclear data as Parquet — queryable with DuckDB."""
 
-from .download import data_dir, data_version, download
+from .download import compute_data_sha256, data_dir, data_sha256, data_version, download
 from .loader import (
     COINCIDENCE_SQL,
     DECAY_CHAIN_SQL,
@@ -24,8 +24,10 @@ __all__ = [
     "IDENTIFY_GAMMA_ALL_SQL",
     "IDENTIFY_GAMMA_SQL",
     "compound_dedx",
+    "compute_data_sha256",
     "connect",
     "data_dir",
+    "data_sha256",
     "data_version",
     "download",
     "elemental_dedx",

--- a/nucl_parquet/download.py
+++ b/nucl_parquet/download.py
@@ -1,12 +1,16 @@
 """Data directory resolution and GitHub Release download.
 
 Data and code release on separate cadences (#150 tracks the analogous code-side
-split). Data tarballs are CalVer-tagged `data-YYYY.MM.DD`; the version a given
-checkout pins lives at `data/catalog.json::data_version`.
+split). Data tarballs are CalVer-tagged `data-YYYY.MM.MICRO` (e.g. `data-2026.5.0`,
+`data-2026.5.1` for an in-month iteration); the version a given checkout pins
+lives at `data/catalog.json::data_version`. A deterministic SHA-256 tree hash
+of the parquets ships alongside in `data/catalog.json::data_sha256` so PR CI
+can gate on "data changed ⇔ version changed".
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
@@ -19,7 +23,8 @@ from urllib.request import Request, urlopen
 import zstandard
 
 _GITHUB_REPO = "exoma-ch/nucl-parquet"
-_DATA_TAG_RE = re.compile(r"^data-\d{4}\.\d{2}\.\d{2}$")
+_DATA_TAG_RE = re.compile(r"^data-\d{4}\.\d+\.\d+$")
+_DATA_VERSION_RE = re.compile(r"^\d{4}\.\d+\.\d+$")
 
 
 def data_dir() -> Path:
@@ -59,7 +64,7 @@ def data_dir() -> Path:
 def data_version(data_dir_path: Path | str | None = None) -> str:
     """Return the CalVer identifier of the data shipping with this checkout.
 
-    Reads `data/catalog.json::data_version` (e.g. `"2026.05.11"`). The matching
+    Reads `data/catalog.json::data_version` (e.g. `"2026.5.0"`). The matching
     GitHub Release tag is `data-{data_version}`.
     """
     root = Path(data_dir_path) if data_dir_path else data_dir()
@@ -70,8 +75,49 @@ def data_version(data_dir_path: Path | str | None = None) -> str:
     return version
 
 
+def compute_data_sha256(data_dir_path: Path | str | None = None) -> str:
+    """Deterministic SHA-256 tree hash of every `data/**/*.parquet` file.
+
+    The hash digests, in sorted POSIX-relpath order, lines of the form
+    `<relpath>\\0<per-file sha256>\\n`. Reproducible across machines and
+    independent of filesystem mtimes / inode order. PR CI compares this
+    to `data/catalog.json::data_sha256` to detect:
+      - parquets changed but `data_version` did not (silent drift)
+      - `data_version` changed but parquets did not (cosmetic bump)
+
+    The hash deliberately ignores non-parquet files (manifests, schemas,
+    catalog itself) — those are descriptors, not data. Changes to them
+    do not require a data release.
+    """
+    root = Path(data_dir_path) if data_dir_path else data_dir()
+    h = hashlib.sha256()
+    for path in sorted(root.rglob("*.parquet")):
+        rel = path.relative_to(root).as_posix().encode("utf-8")
+        fh = hashlib.sha256()
+        with open(path, "rb") as f:
+            for chunk in iter(lambda f=f: f.read(1 << 20), b""):
+                fh.update(chunk)
+        h.update(rel + b"\0" + fh.hexdigest().encode("ascii") + b"\n")
+    return h.hexdigest()
+
+
+def data_sha256(data_dir_path: Path | str | None = None) -> str:
+    """Return the cached SHA-256 declared in `catalog.json::data_sha256`.
+
+    Use `compute_data_sha256()` to recompute from the on-disk tree.
+    Use this helper to read the value the catalog *claims* matches the
+    tree. PR CI compares the two.
+    """
+    root = Path(data_dir_path) if data_dir_path else data_dir()
+    catalog = json.loads((root / "catalog.json").read_text())
+    declared = catalog.get("data_sha256")
+    if not declared:
+        raise RuntimeError(f"catalog.json at {root} is missing `data_sha256` field.")
+    return declared
+
+
 def _resolve_latest_data_tag() -> str:
-    """Return the most recent `data-YYYY.MM.DD` release tag on GitHub.
+    """Return the most recent `data-YYYY.MM.MICRO` release tag on GitHub.
 
     Scans the most-recent 100 releases (single page, max page_size). Code
     releases share this listing, so a high code-release cadence between
@@ -85,7 +131,7 @@ def _resolve_latest_data_tag() -> str:
         tag = release.get("tag_name", "")
         if _DATA_TAG_RE.match(tag):
             return tag
-    raise RuntimeError(f"No data-YYYY.MM.DD release found in the latest 100 releases at {url}")
+    raise RuntimeError(f"No data-YYYY.MM.MICRO release found in the latest 100 releases at {url}")
 
 
 _CODE_VERSION_RE = re.compile(r"^v?\d+\.\d+\.\d+")
@@ -101,7 +147,7 @@ def download(
 
     Args:
         dest: Destination directory. Defaults to ~/.nucl-parquet/.
-        data_version: CalVer string (`"2026.05.11"`) OR `"latest"` to resolve
+        data_version: CalVer string (`"2026.5.0"`) OR `"latest"` to resolve
             the most recent `data-*` GitHub release. Pre-CalVer code-version
             strings (e.g. `"v0.13.0"`) are detected and resolve to latest data
             with a DeprecationWarning.
@@ -115,7 +161,7 @@ def download(
     if tag is not None:
         warnings.warn(
             "`tag=` is deprecated in nucl_parquet.download(); pass `data_version=` "
-            "with a CalVer identifier (e.g. `'2026.05.11'`) or `'latest'`. "
+            "with a CalVer identifier (e.g. `'2026.5.0'`) or `'latest'`. "
             "Resolving to latest data release.",
             DeprecationWarning,
             stacklevel=2,
@@ -127,7 +173,7 @@ def download(
         warnings.warn(
             f"`{data_version!r}` looks like a code-version tag; "
             "nucl_parquet.download() now takes CalVer data identifiers "
-            "(e.g. `'2026.05.11'`) or `'latest'`. Resolving to latest data.",
+            "(e.g. `'2026.5.0'`) or `'latest'`. Resolving to latest data.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/nucl_parquet/download.py
+++ b/nucl_parquet/download.py
@@ -75,6 +75,13 @@ def data_version(data_dir_path: Path | str | None = None) -> str:
     return version
 
 
+_HASH_EXCLUDE_DIRS = frozenset(
+    {
+        "g4_raw",  # build-time cache (gitignored)
+    }
+)
+
+
 def compute_data_sha256(data_dir_path: Path | str | None = None) -> str:
     """Deterministic SHA-256 tree hash of every `data/**/*.parquet` file.
 
@@ -85,13 +92,19 @@ def compute_data_sha256(data_dir_path: Path | str | None = None) -> str:
       - parquets changed but `data_version` did not (silent drift)
       - `data_version` changed but parquets did not (cosmetic bump)
 
-    The hash deliberately ignores non-parquet files (manifests, schemas,
-    catalog itself) — those are descriptors, not data. Changes to them
-    do not require a data release.
+    The hash deliberately ignores:
+      - non-parquet files (manifests, schemas, catalog itself) — descriptors,
+        not data; changes don't require a data release
+      - any path under a top-level directory in `_HASH_EXCLUDE_DIRS` (e.g.
+        `data/g4_raw/`, which is a gitignored build cache populated by
+        `scripts/fetch_strata_nuclear.py`)
     """
     root = Path(data_dir_path) if data_dir_path else data_dir()
     h = hashlib.sha256()
     for path in sorted(root.rglob("*.parquet")):
+        rel_parts = path.relative_to(root).parts
+        if rel_parts and rel_parts[0] in _HASH_EXCLUDE_DIRS:
+            continue
         rel = path.relative_to(root).as_posix().encode("utf-8")
         fh = hashlib.sha256()
         with open(path, "rb") as f:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dev = ["polars>=1.0", "pytest>=8.0", "requests>=2.31"]
 dev = [
     "endf>=0.1.12",
     "huggingface-hub>=0.30",
+    "jsonschema>=4.0",
     "polars>=1.0",
     "pytest>=8.0",
     "requests>=2.31",

--- a/tests/test_data_release.py
+++ b/tests/test_data_release.py
@@ -1,0 +1,215 @@
+"""Gates against drift between `data/**/*.parquet` and `data/catalog.json`.
+
+The PR that changes data IS the data-release PR — these checks make sure
+the version identifier and the actual data move together. Failure modes
+this catches:
+
+1. Silent drift — parquets changed, `data_version` did not (consumers fetch
+   the same tag and get different bytes).
+2. Cosmetic bump — `data_version` changed, parquets did not (breaks
+   reproducibility; consumers re-download for nothing).
+3. Version regression — `data_version` not valid CalVer, or moves backwards.
+
+The first two collapse into a single check thanks to `data_sha256`: if the
+on-disk SHA-256 tree hash disagrees with the catalog's claim, something is
+out of sync regardless of which side moved.
+
+Tests are *not* marked `@pytest.mark.data` — they must run in every PR's
+CI regardless of whether `--no-data` is passed.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+import nucl_parquet
+
+_REPO_ROOT = Path(__file__).parent.parent
+_DATA_DIR = _REPO_ROOT / "data"
+_CATALOG = _DATA_DIR / "catalog.json"
+_SCHEMA = _DATA_DIR / "catalog.schema.json"
+_CALVER_RE = re.compile(r"^[0-9]{4}\.[0-9]+\.[0-9]+$")
+
+
+# -- Layer 1.a: catalog.json conforms to its own schema ----------------------
+
+
+def test_catalog_validates_against_schema() -> None:
+    """catalog.json must satisfy catalog.schema.json.
+
+    Catches: missing required fields, malformed `data_version`, bad
+    `data_sha256` shape, schema-breaking edits that ship without
+    catalog update.
+    """
+    catalog = json.loads(_CATALOG.read_text())
+    schema = json.loads(_SCHEMA.read_text())
+    jsonschema.validate(catalog, schema)
+
+
+# -- Layer 1.b: data_version is valid CalVer ---------------------------------
+
+
+def test_data_version_is_calver() -> None:
+    """`data_version` must match YYYY.MM.MICRO (e.g. `2026.5.0`)."""
+    version = nucl_parquet.data_version(_DATA_DIR)
+    assert _CALVER_RE.match(version), (
+        f"data_version={version!r} not YYYY.MM.MICRO; bumps should look like '2026.5.0' or '2026.5.1'"
+    )
+
+
+# -- Layer 1.c: SHA anchor matches the on-disk tree --------------------------
+
+
+def test_data_sha256_matches_on_disk_tree() -> None:
+    """The catalog's `data_sha256` must match the recomputed tree hash.
+
+    This is the load-bearing gate. It catches:
+      - silent drift: parquet edited, sha not updated
+      - cosmetic bump: sha edited without a real data change
+    If you intentionally changed parquets, also bump `data_version` AND
+    update `data_sha256` to the new tree hash. Recompute via:
+        uv run python -c 'import nucl_parquet; print(nucl_parquet.compute_data_sha256())'
+    """
+    declared = nucl_parquet.data_sha256(_DATA_DIR)
+    actual = nucl_parquet.compute_data_sha256(_DATA_DIR)
+    assert declared == actual, (
+        f"data_sha256 mismatch:\n  declared (catalog.json): {declared}\n"
+        f"  actual   (on-disk tree): {actual}\n\n"
+        "Either:\n"
+        "  (a) you changed parquet files — bump data_version AND set data_sha256 to the actual value above\n"
+        "  (b) you set data_sha256 by hand — recompute with:\n"
+        "      uv run python -c 'import nucl_parquet; print(nucl_parquet.compute_data_sha256())'"
+    )
+
+
+# -- Layer 1.d: version and sha co-change in PR diffs ------------------------
+
+
+def _git_changed_files(base: str) -> list[str]:
+    """Return paths that differ between `base` and HEAD. Tolerates the
+    base being absent locally (returns [] so the test no-ops outside CI)."""
+    try:
+        out = subprocess.check_output(
+            ["git", "diff", "--name-only", f"{base}...HEAD"],
+            cwd=_REPO_ROOT,
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+    except subprocess.CalledProcessError:
+        return []
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+def _git_value_at(ref: str, path: str, jsonpath_key: str) -> str | None:
+    """Read a top-level key from `path` as it existed at git ref `ref`.
+
+    Returns None if the file or key wasn't present at `ref` (e.g. first
+    introduction of the field).
+    """
+    try:
+        blob = subprocess.check_output(
+            ["git", "show", f"{ref}:{path}"],
+            cwd=_REPO_ROOT,
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+    except subprocess.CalledProcessError:
+        return None
+    try:
+        return json.loads(blob).get(jsonpath_key)
+    except json.JSONDecodeError:
+        return None
+
+
+def test_version_and_sha_co_change_in_pr() -> None:
+    """If parquets changed in this PR, `data_version` AND `data_sha256` must change too.
+
+    Symmetric: if `data_version` OR `data_sha256` changed but no parquet
+    files did, that's a cosmetic bump — also a fail.
+
+    Skips outside a PR context (no `origin/main` to diff against), and
+    silently passes if the SHA anchor itself wasn't yet introduced on
+    `origin/main` (the very first PR adding it).
+    """
+    # Determine the merge base. In CI under PR builds, GITHUB_BASE_REF is
+    # the target branch (e.g. "main"); locally we fall back to `origin/main`.
+    import os
+
+    base_ref = os.environ.get("GITHUB_BASE_REF") or "main"
+    base = f"origin/{base_ref}"
+
+    changed = _git_changed_files(base)
+    if not changed:
+        pytest.skip(f"No diff against {base} (running outside PR context, or branch is up-to-date).")
+
+    parquet_changed = any(f.startswith("data/") and f.endswith(".parquet") for f in changed)
+    catalog_changed = "data/catalog.json" in changed
+
+    if not (parquet_changed or catalog_changed):
+        pytest.skip("PR does not touch data/ or catalog.json — gate not applicable.")
+
+    base_version = _git_value_at(base, "data/catalog.json", "data_version")
+    base_sha = _git_value_at(base, "data/catalog.json", "data_sha256")
+    current_version = nucl_parquet.data_version(_DATA_DIR)
+    current_sha = nucl_parquet.data_sha256(_DATA_DIR)
+
+    version_moved = base_version is not None and base_version != current_version
+    sha_moved = base_sha is not None and base_sha != current_sha
+
+    if parquet_changed:
+        # Real data change: both must move.
+        assert version_moved, (
+            f"Parquet files changed but data_version did not (still {current_version!r}). "
+            "Bump it to today's CalVer (e.g. 2026.5.X) in the same PR."
+        )
+        assert sha_moved, (
+            "Parquet files changed but data_sha256 did not. "
+            "Recompute the tree hash and update catalog.json::data_sha256."
+        )
+    elif version_moved or sha_moved:
+        # Cosmetic bump: neither parquets nor anything else justifying the move.
+        pytest.fail(
+            f"data_version / data_sha256 changed but no parquet files did. "
+            f"version: {base_version!r} -> {current_version!r}, "
+            f"sha: {base_sha!r} -> {current_sha!r}. "
+            "Either revert the catalog edit, or include the data change that motivates it."
+        )
+
+
+# -- Layer 1.e: monotonicity vs main -----------------------------------------
+
+
+def test_data_version_monotonic_vs_main() -> None:
+    """`data_version` must be >= the value on the base branch (lexicographic CalVer).
+
+    Catches: cherry-picking an old data revision back into a PR, or hand-
+    editing the version backwards. CalVer YYYY.MM.MICRO sorts correctly
+    lexicographically because every component is left-padded year/digits
+    of equal width per refresh epoch (years and months are unbounded
+    integers but we treat lexicographic == temporal — that holds within
+    a given year; cross-year is also monotonic by year).
+    """
+    import os
+
+    base_ref = os.environ.get("GITHUB_BASE_REF") or "main"
+    base = f"origin/{base_ref}"
+
+    base_version = _git_value_at(base, "data/catalog.json", "data_version")
+    if base_version is None:
+        pytest.skip(f"No catalog at {base} (first introduction).")
+
+    current_version = nucl_parquet.data_version(_DATA_DIR)
+
+    # Numeric tuple compare — handles `2026.5.10` > `2026.5.9` correctly.
+    def _tup(v: str) -> tuple[int, ...]:
+        return tuple(int(x) for x in v.split("."))
+
+    assert _tup(current_version) >= _tup(base_version), (
+        f"data_version regression: {current_version!r} < {base_version!r} on {base}. CalVer must move forward."
+    )

--- a/tests/test_data_release.py
+++ b/tests/test_data_release.py
@@ -162,17 +162,24 @@ def test_version_and_sha_co_change_in_pr() -> None:
     version_moved = base_version is not None and base_version != current_version
     sha_moved = base_sha is not None and base_sha != current_sha
 
+    # Bootstrap exception: the PR that first introduces `data_sha256` is
+    # allowed to update `data_version` without a parquet change — it's the
+    # one-time format migration / field introduction, not a cosmetic bump.
+    # After this lands, every future PR sees `data_sha256` on base and the
+    # check applies normally.
+    sha_bootstrapped = base_sha is None and current_sha is not None
+
     if parquet_changed:
         # Real data change: both must move.
         assert version_moved, (
             f"Parquet files changed but data_version did not (still {current_version!r}). "
             "Bump it to today's CalVer (e.g. 2026.5.X) in the same PR."
         )
-        assert sha_moved, (
+        assert sha_moved or sha_bootstrapped, (
             "Parquet files changed but data_sha256 did not. "
             "Recompute the tree hash and update catalog.json::data_sha256."
         )
-    elif version_moved or sha_moved:
+    elif (version_moved or sha_moved) and not sha_bootstrapped:
         # Cosmetic bump: neither parquets nor anything else justifying the move.
         pytest.fail(
             f"data_version / data_sha256 changed but no parquet files did. "
@@ -186,14 +193,18 @@ def test_version_and_sha_co_change_in_pr() -> None:
 
 
 def test_data_version_monotonic_vs_main() -> None:
-    """`data_version` must be >= the value on the base branch (lexicographic CalVer).
+    """`data_version` must be >= the value on the base branch.
 
     Catches: cherry-picking an old data revision back into a PR, or hand-
-    editing the version backwards. CalVer YYYY.MM.MICRO sorts correctly
-    lexicographically because every component is left-padded year/digits
-    of equal width per refresh epoch (years and months are unbounded
-    integers but we treat lexicographic == temporal — that holds within
-    a given year; cross-year is also monotonic by year).
+    editing the version backwards. CalVer YYYY.MM.MICRO compared by
+    numeric tuple `(year, month, micro)` so `2026.5.10 > 2026.5.9` works.
+
+    Bootstrap exception: when the SHA anchor (`data_sha256`) was absent
+    on base and is introduced by this PR, we're doing a format migration
+    or first-time field introduction; the version may be re-baselined to
+    start a new MICRO sequence (e.g. `2026.05.11` legacy YYYY.MM.DD → new
+    `2026.5.0`). After this lands, future PRs see the anchor on base and
+    the monotonic check applies normally.
     """
     import os
 
@@ -201,12 +212,18 @@ def test_data_version_monotonic_vs_main() -> None:
     base = f"origin/{base_ref}"
 
     base_version = _git_value_at(base, "data/catalog.json", "data_version")
+    base_sha = _git_value_at(base, "data/catalog.json", "data_sha256")
+    current_sha = nucl_parquet.data_sha256(_DATA_DIR)
     if base_version is None:
         pytest.skip(f"No catalog at {base} (first introduction).")
+    if base_sha is None and current_sha is not None:
+        pytest.skip(
+            "Bootstrap commit introducing data_sha256 — version may re-baseline. "
+            "Future PRs will have the anchor on base and this check will apply normally."
+        )
 
     current_version = nucl_parquet.data_version(_DATA_DIR)
 
-    # Numeric tuple compare — handles `2026.5.10` > `2026.5.9` correctly.
     def _tup(v: str) -> tuple[int, ...]:
         return tuple(int(x) for x in v.split("."))
 

--- a/uv.lock
+++ b/uv.lock
@@ -25,6 +25,15 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -346,6 +355,33 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -368,7 +404,7 @@ wheels = [
 
 [[package]]
 name = "nucl-parquet"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },
@@ -388,6 +424,7 @@ dev = [
 dev = [
     { name = "endf" },
     { name = "huggingface-hub" },
+    { name = "jsonschema" },
     { name = "polars" },
     { name = "pytest" },
     { name = "requests" },
@@ -410,6 +447,7 @@ provides-extras = ["dev"]
 dev = [
     { name = "endf", specifier = ">=0.1.12" },
     { name = "huggingface-hub", specifier = ">=0.30" },
+    { name = "jsonschema", specifier = ">=4.0" },
     { name = "polars", specifier = ">=1.0" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "requests", specifier = ">=2.31" },
@@ -638,6 +676,20 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.32.5"
 source = { registry = "https://pypi.org/simple" }
@@ -663,6 +715,114 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/6e/f964e88b3d2abee2a82c1ac8366da848fce1c6d834dc2132c3fda3970290/rpds_py-0.30.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425", size = 370157, upload-time = "2025-11-30T20:21:53.789Z" },
+    { url = "https://files.pythonhosted.org/packages/94/ba/24e5ebb7c1c82e74c4e4f33b2112a5573ddc703915b13a073737b59b86e0/rpds_py-0.30.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d", size = 359676, upload-time = "2025-11-30T20:21:55.475Z" },
+    { url = "https://files.pythonhosted.org/packages/84/86/04dbba1b087227747d64d80c3b74df946b986c57af0a9f0c98726d4d7a3b/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4", size = 389938, upload-time = "2025-11-30T20:21:57.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/bb/1463f0b1722b7f45431bdd468301991d1328b16cffe0b1c2918eba2c4eee/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07ae8a593e1c3c6b82ca3292efbe73c30b61332fd612e05abee07c79359f292f", size = 402932, upload-time = "2025-11-30T20:21:58.47Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ee/2520700a5c1f2d76631f948b0736cdf9b0acb25abd0ca8e889b5c62ac2e3/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12f90dd7557b6bd57f40abe7747e81e0c0b119bef015ea7726e69fe550e394a4", size = 525830, upload-time = "2025-11-30T20:21:59.699Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ad/bd0331f740f5705cc555a5e17fdf334671262160270962e69a2bdef3bf76/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:99b47d6ad9a6da00bec6aabe5a6279ecd3c06a329d4aa4771034a21e335c3a97", size = 412033, upload-time = "2025-11-30T20:22:00.991Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/1e/372195d326549bb51f0ba0f2ecb9874579906b97e08880e7a65c3bef1a99/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89", size = 390828, upload-time = "2025-11-30T20:22:02.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/2b/d88bb33294e3e0c76bc8f351a3721212713629ffca1700fa94979cb3eae8/rpds_py-0.30.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:946fe926af6e44f3697abbc305ea168c2c31d3e3ef1058cf68f379bf0335a78d", size = 404683, upload-time = "2025-11-30T20:22:04.367Z" },
+    { url = "https://files.pythonhosted.org/packages/50/32/c759a8d42bcb5289c1fac697cd92f6fe01a018dd937e62ae77e0e7f15702/rpds_py-0.30.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:495aeca4b93d465efde585977365187149e75383ad2684f81519f504f5c13038", size = 421583, upload-time = "2025-11-30T20:22:05.814Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/81/e729761dbd55ddf5d84ec4ff1f47857f4374b0f19bdabfcf929164da3e24/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9a0ca5da0386dee0655b4ccdf46119df60e0f10da268d04fe7cc87886872ba7", size = 572496, upload-time = "2025-11-30T20:22:07.713Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f6/69066a924c3557c9c30baa6ec3a0aa07526305684c6f86c696b08860726c/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8d6d1cc13664ec13c1b84241204ff3b12f9bb82464b8ad6e7a5d3486975c2eed", size = 598669, upload-time = "2025-11-30T20:22:09.312Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/48/905896b1eb8a05630d20333d1d8ffd162394127b74ce0b0784ae04498d32/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3896fa1be39912cf0757753826bc8bdc8ca331a28a7c4ae46b7a21280b06bb85", size = 561011, upload-time = "2025-11-30T20:22:11.309Z" },
+    { url = "https://files.pythonhosted.org/packages/22/16/cd3027c7e279d22e5eb431dd3c0fbc677bed58797fe7581e148f3f68818b/rpds_py-0.30.0-cp311-cp311-win32.whl", hash = "sha256:55f66022632205940f1827effeff17c4fa7ae1953d2b74a8581baaefb7d16f8c", size = 221406, upload-time = "2025-11-30T20:22:13.101Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/5b/e7b7aa136f28462b344e652ee010d4de26ee9fd16f1bfd5811f5153ccf89/rpds_py-0.30.0-cp311-cp311-win_amd64.whl", hash = "sha256:a51033ff701fca756439d641c0ad09a41d9242fa69121c7d8769604a0a629825", size = 236024, upload-time = "2025-11-30T20:22:14.853Z" },
+    { url = "https://files.pythonhosted.org/packages/14/a6/364bba985e4c13658edb156640608f2c9e1d3ea3c81b27aa9d889fff0e31/rpds_py-0.30.0-cp311-cp311-win_arm64.whl", hash = "sha256:47b0ef6231c58f506ef0b74d44e330405caa8428e770fec25329ed2cb971a229", size = 229069, upload-time = "2025-11-30T20:22:16.577Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/98a2f4ac921d82f33e03f3835f5bf3a4a40aa1bfdc57975e74a97b2b4bdd/rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad", size = 375086, upload-time = "2025-11-30T20:22:17.93Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05", size = 359053, upload-time = "2025-11-30T20:22:19.297Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1c/ae157e83a6357eceff62ba7e52113e3ec4834a84cfe07fa4b0757a7d105f/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28", size = 390763, upload-time = "2025-11-30T20:22:21.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/36/eb2eb8515e2ad24c0bd43c3ee9cd74c33f7ca6430755ccdb240fd3144c44/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd", size = 408951, upload-time = "2025-11-30T20:22:23.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/65/ad8dc1784a331fabbd740ef6f71ce2198c7ed0890dab595adb9ea2d775a1/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f", size = 514622, upload-time = "2025-11-30T20:22:25.16Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/0cfa7ae158e15e143fe03993b5bcd743a59f541f5952e1546b1ac1b5fd45/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1", size = 414492, upload-time = "2025-11-30T20:22:26.505Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23", size = 394080, upload-time = "2025-11-30T20:22:27.934Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d5/a266341051a7a3ca2f4b750a3aa4abc986378431fc2da508c5034d081b70/rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6", size = 408680, upload-time = "2025-11-30T20:22:29.341Z" },
+    { url = "https://files.pythonhosted.org/packages/10/3b/71b725851df9ab7a7a4e33cf36d241933da66040d195a84781f49c50490c/rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51", size = 423589, upload-time = "2025-11-30T20:22:31.469Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2b/e59e58c544dc9bd8bd8384ecdb8ea91f6727f0e37a7131baeff8d6f51661/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5", size = 573289, upload-time = "2025-11-30T20:22:32.997Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3e/a18e6f5b460893172a7d6a680e86d3b6bc87a54c1f0b03446a3c8c7b588f/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e", size = 599737, upload-time = "2025-11-30T20:22:34.419Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e2/714694e4b87b85a18e2c243614974413c60aa107fd815b8cbc42b873d1d7/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394", size = 563120, upload-time = "2025-11-30T20:22:35.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ab/d5d5e3bcedb0a77f4f613706b750e50a5a3ba1c15ccd3665ecc636c968fd/rpds_py-0.30.0-cp312-cp312-win32.whl", hash = "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf", size = 223782, upload-time = "2025-11-30T20:22:37.271Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b", size = 240463, upload-time = "2025-11-30T20:22:39.021Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d2/b91dc748126c1559042cfe41990deb92c4ee3e2b415f6b5234969ffaf0cc/rpds_py-0.30.0-cp312-cp312-win_arm64.whl", hash = "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e", size = 230868, upload-time = "2025-11-30T20:22:40.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2", size = 374887, upload-time = "2025-11-30T20:22:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8", size = 358904, upload-time = "2025-11-30T20:22:43.479Z" },
+    { url = "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4", size = 389945, upload-time = "2025-11-30T20:22:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136", size = 407783, upload-time = "2025-11-30T20:22:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7", size = 515021, upload-time = "2025-11-30T20:22:47.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2", size = 414589, upload-time = "2025-11-30T20:22:48.872Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6", size = 394025, upload-time = "2025-11-30T20:22:50.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e", size = 408895, upload-time = "2025-11-30T20:22:51.87Z" },
+    { url = "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d", size = 422799, upload-time = "2025-11-30T20:22:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7", size = 572731, upload-time = "2025-11-30T20:22:54.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31", size = 599027, upload-time = "2025-11-30T20:22:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95", size = 563020, upload-time = "2025-11-30T20:22:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d", size = 223139, upload-time = "2025-11-30T20:23:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15", size = 240224, upload-time = "2025-11-30T20:23:02.008Z" },
+    { url = "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1", size = 230645, upload-time = "2025-11-30T20:23:03.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a", size = 364443, upload-time = "2025-11-30T20:23:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e", size = 353375, upload-time = "2025-11-30T20:23:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000", size = 383850, upload-time = "2025-11-30T20:23:07.825Z" },
+    { url = "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db", size = 392812, upload-time = "2025-11-30T20:23:09.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2", size = 517841, upload-time = "2025-11-30T20:23:11.186Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa", size = 408149, upload-time = "2025-11-30T20:23:12.864Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083", size = 383843, upload-time = "2025-11-30T20:23:14.638Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9", size = 396507, upload-time = "2025-11-30T20:23:16.105Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0", size = 414949, upload-time = "2025-11-30T20:23:17.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94", size = 565790, upload-time = "2025-11-30T20:23:19.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08", size = 590217, upload-time = "2025-11-30T20:23:20.885Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
+    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
+    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
+    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
+    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
+    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
+    { url = "https://files.pythonhosted.org/packages/69/71/3f34339ee70521864411f8b6992e7ab13ac30d8e4e3309e07c7361767d91/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c2262bdba0ad4fc6fb5545660673925c2d2a5d9e2e0fb603aad545427be0fc58", size = 372292, upload-time = "2025-11-30T20:24:16.537Z" },
+    { url = "https://files.pythonhosted.org/packages/57/09/f183df9b8f2d66720d2ef71075c59f7e1b336bec7ee4c48f0a2b06857653/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ee6af14263f25eedc3bb918a3c04245106a42dfd4f5c2285ea6f997b1fc3f89a", size = 362128, upload-time = "2025-11-30T20:24:18.086Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/68/5c2594e937253457342e078f0cc1ded3dd7b2ad59afdbf2d354869110a02/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3adbb8179ce342d235c31ab8ec511e66c73faa27a47e076ccc92421add53e2bb", size = 391542, upload-time = "2025-11-30T20:24:20.092Z" },
+    { url = "https://files.pythonhosted.org/packages/49/5c/31ef1afd70b4b4fbdb2800249f34c57c64beb687495b10aec0365f53dfc4/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:250fa00e9543ac9b97ac258bd37367ff5256666122c2d0f2bc97577c60a1818c", size = 404004, upload-time = "2025-11-30T20:24:22.231Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/63/0cfbea38d05756f3440ce6534d51a491d26176ac045e2707adc99bb6e60a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9854cf4f488b3d57b9aaeb105f06d78e5529d3145b1e4a41750167e8c213c6d3", size = 527063, upload-time = "2025-11-30T20:24:24.302Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e6/01e1f72a2456678b0f618fc9a1a13f882061690893c192fcad9f2926553a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:993914b8e560023bc0a8bf742c5f303551992dcb85e247b1e5c7f4a7d145bda5", size = 413099, upload-time = "2025-11-30T20:24:25.916Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/25/8df56677f209003dcbb180765520c544525e3ef21ea72279c98b9aa7c7fb/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58edca431fb9b29950807e301826586e5bbf24163677732429770a697ffe6738", size = 392177, upload-time = "2025-11-30T20:24:27.834Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/b4/0a771378c5f16f8115f796d1f437950158679bcd2a7c68cf251cfb00ed5b/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:dea5b552272a944763b34394d04577cf0f9bd013207bc32323b5a89a53cf9c2f", size = 406015, upload-time = "2025-11-30T20:24:29.457Z" },
+    { url = "https://files.pythonhosted.org/packages/36/d8/456dbba0af75049dc6f63ff295a2f92766b9d521fa00de67a2bd6427d57a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ba3af48635eb83d03f6c9735dfb21785303e73d22ad03d489e88adae6eab8877", size = 423736, upload-time = "2025-11-30T20:24:31.22Z" },
+    { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981, upload-time = "2025-11-30T20:24:32.934Z" },
+    { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The PR that changes data IS the data-release PR. Three CI gates + an auto-tag-on-merge workflow give us a fully auditable data-release path with no manual `git tag`.

Designed via a focused review round (single fresh agent) that surfaced one load-bearing finding — anchor the gate on a SHA-256 tree hash of the parquets, not just version monotonicity. The hash collapses two separate failure modes into one check.

## Gates (`tests/test_data_release.py`)

| Gate | Catches |
|---|---|
| `catalog.json` validates against `catalog.schema.json` | schema-breaking edits |
| `data_version` matches `YYYY.MM.MICRO` | malformed CalVer |
| `data_sha256` matches on-disk parquet tree hash | **silent drift** (parquets change, version doesn't) AND **cosmetic bumps** (version changes, parquets don't) — single anchor for both |
| Co-change in PR diffs | parquet diff requires catalog version+sha bump; bare version bump fails as cosmetic |
| Monotonicity vs base | numeric tuple compare prevents version regression |

## Auto-tag on merge (`.github/workflows/auto-tag-data.yml`)

On push to `main` with `data/catalog.json` in diff: if `data_version` changed vs `HEAD~1`, push the matching `data-${version}` tag → triggers `release-data.yml` → tarball published. Fails loudly if the tag already exists or doesn't match CalVer.

The full release path becomes:
1. Dev fetches fresh data, bumps `data/catalog.json::data_version` + `data_sha256`, opens PR
2. CI gates fire — reviewer sees both changes side-by-side
3. Merge to main
4. Auto-tag pushes `data-2026.5.X` automatically
5. `release-data.yml` builds + uploads tarball

## New helpers

- `nucl_parquet.compute_data_sha256()` — deterministic tree hash, ~4s on current 423MB tree
- `nucl_parquet.data_sha256()` — reads catalog's declared hash

## Format migration

`data_version`: `2026.05.11` → `2026.5.0` (now YYYY.MM.MICRO).

Format change to enable same-month iteration without conflating day-of-month with iteration counter. Schema regex generalized from `\d{2}\.\d{2}` to `\d+\.\d+`. `release-data.yml`'s tag-validation regex updated. Bootstrap exception in the co-change test allows the field-introduction commit (sha None → real value) without requiring a parquet change.

## Schema cleanup (side-effect bugs fixed)

Pre-existing drift between schema and catalog:
- `shared.stopping.required` no longer includes deleted `files.stopping` aggregate key (post-#143)
- `libraries.*.required` reduced to `name` + `data_type` — strata-data-nuclear is an external-dataset ref with a different shape
- `data_type` enum expanded to cover all values in use
- `projectiles` items no longer enum-restricted (heavy-ion identifiers like `c12`, `fe56` were rejected)

## Test plan

- [x] All five new gates pass on this branch
- [x] Full suite: 451 passing
- [x] `compute_data_sha256()` correctly excludes `data/g4_raw/` build cache so a fetcher test run doesn't break the gate
- [x] Bootstrap commit allowed via "sha was None on base" exception
- [ ] CI green on this PR
- [ ] Post-merge: `auto-tag-data.yml` fires + pushes `data-2026.5.0` tag → `release-data.yml` runs end-to-end (verify with the first real data release (data-2026.5.0))

## Follow-up

#157 — embed per-file sha256 in parquet metadata at write time, switch `compute_data_sha256()` to read footers instead of bytes for ~ms PR gates. Performance optimization, not security upgrade — current file-bytes anchor stays as the security baseline.

Refs #144.