### PR TITLE
fix(release): repair auto-tag-data workflow + workflow_dispatch escape hatch

### DIFF
--- a/.github/workflows/auto-tag-data.yml
+++ b/.github/workflows/auto-tag-data.yml
@@ -16,13 +16,17 @@ on:
   push:
     branches: [main]
     paths: [data/catalog.json]
+  # Manual-trigger escape hatch: if a catalog change merged without
+  # firing this workflow (e.g. the workflow itself was being updated in
+  # the same merge), an admin can dispatch from the Actions UI to retry.
+  workflow_dispatch: {}
 
 permissions:
   contents: write
 
 jobs:
   auto-tag:
-    name: Auto-tag data-${{ steps.detect.outputs.version }} on data_version change
+    name: Auto-tag data release on data_version change
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Problem

The auto-tag workflow shipped in #158 failed at workflow-parse time on every push since merge — three runs all 0s with \"workflow file issue\". The job-level \`name:\` referenced \`steps.detect.outputs.version\`, which doesn't exist until the step actually runs; GitHub rejects the workflow before the first job starts.

## Fix

- Replace the dynamic job name with a static string.
- Add \`workflow_dispatch: {}\` as an escape hatch — an admin can manually trigger the workflow from the Actions UI when the path-filter trigger has been missed (the situation we're in now: #158 merged with the buggy workflow, so the original \`data_version\` bump never produced a tag).

## What this means for the in-flight data release

\`data/catalog.json::data_version\` is at \`2026.5.0\` on main, but no \`data-2026.5.0\` tag exists. After this PR merges:

1. Workflow file is valid again (future PRs auto-tag normally on merge)
2. Admin triggers the workflow once via the Actions UI \"Run workflow\" button on \`auto-tag-data.yml\`
3. The dispatched run will see \`data_version\` unchanged vs \`HEAD~1\` of main (because the auto-tag was supposed to fire on #158's merge, not this PR's), so it'll exit no-op
4. Manual one-time tag push is needed to bootstrap: \`git tag -a data-2026.5.0 -m \"First CalVer data release\" && git push origin data-2026.5.0\`. That fires \`release-data.yml\` and the tarball publishes.

The bootstrap is one-shot; from the next data PR onward, the workflow handles everything.

## Test plan

- [x] Workflow file passes \`prek\` YAML check
- [ ] Workflow validates on GitHub after push (verify Actions tab shows it listed without error)
- [ ] Manual \`workflow_dispatch\` trigger works (post-merge)
- [ ] Next real data PR merges → auto-tag fires → \`release-data.yml\` builds + uploads

Refs #144.