### PR TITLE
fix(rs-mcp): enable parquet zstd feature so server reads live data

### DIFF
--- a/clients/rs/nucl-parquet-mcp/Cargo.lock
+++ b/clients/rs/nucl-parquet-mcp/Cargo.lock
@@ -265,6 +265,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -702,6 +704,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -974,6 +986,7 @@ dependencies = [
  "seq-macro",
  "thrift",
  "twox-hash",
+ "zstd",
 ]
 
 [[package]]
@@ -999,6 +1012,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "potential_utf"
@@ -2104,3 +2123,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/clients/rs/nucl-parquet-mcp/Cargo.toml
+++ b/clients/rs/nucl-parquet-mcp/Cargo.toml
@@ -15,6 +15,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.12", features = ["rustls-tls", "json"], default-features = false }
-parquet = { version = "54", default-features = false, features = ["arrow"] }
+parquet = { version = "54", default-features = false, features = ["arrow", "zstd"] }
 arrow = { version = "54", default-features = false }
 bytes = "1"


### PR DESCRIPTION
## Problem

End-to-end MCP probe testing of #156's just-published packages against live \`main\` data found that the Rust MCP fails on every tool call:

\`\`\`
Batch read error: Parquet argument error: Parquet error: Disabled feature at compile time: zstd
\`\`\`

Cause: \`parquet\` dependency configured with \`default-features = false, features = [\"arrow\"]\` — excludes the zstd decoder. Every parquet in \`data/\` is zstd-compressed (all \`build_*.py\` scripts use \`compression=\"zstd\"\`).

## Comparison

| Client | parquet features | α-on-Cu@20MeV result |
|---|---|---|
| Python MCP | (pyarrow has all codecs) | ✅ 177.4 |
| TypeScript MCP | (hyparquet bundles compressors) | ✅ 177.4 |
| Rust **core** crate | \`[\"arrow\", \"zstd\"]\` | ✅ 177.4 (anchor test) |
| Rust **MCP** | \`[\"arrow\"]\` (no zstd) | ❌ error |

## Fix

Align Rust MCP's feature set with the core crate.

After this lands, release-please will bump nucl-parquet-mcp-rs from 0.13.1 → 0.13.2.

## Test plan

- [x] \`cargo build --release\` clean
- [x] End-to-end MCP probe: tools/list returns expected tools; tools/call \`get_stopping_power(source=ASTAR, target_z=29)\` returns 121 rows; α-on-Cu @ 20 MeV total = 177.4 MeV·cm²/g (matches NIST ICRU-49)
- [ ] CI green on this PR

Refs #156.