### PR TITLE
feat(stopping): per-isotope catima table (proj_A column) — closes #169

### DIFF
--- a/data/catalog.json
+++ b/data/catalog.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./catalog.schema.json",
   "version": 1,
-  "data_version": "2026.5.0",
-  "data_sha256": "c18ff3d96e527b2cd68f6ebd4a5271653a0bd8170586948f06f422f97663afae",
+  "data_version": "2026.5.1",
+  "data_sha256": "08a2dd67bfdf537d2252c6700663d30df03ee866f7b393dc6f31a27a2b8615f2",
   "description": "Registry of available nuclear data libraries",
   "libraries": {
     "tendl-2024": {
@@ -285,16 +285,20 @@
       ],
       "sources_note": "PSTAR/ASTAR/ESTAR are NIST ICRU-49/37 tables (reproducible via nucl_parquet.build_stopping). dSTAR/tSTAR are velocity-scaled from PSTAR (exact for electronic stopping). ³He has no NIST table — routes through catima in the loader. catima_* are pycatima tables for common heavy-ion beams; the full 92×92 MeV/u matrix is at catima_full_matrix.",
       "catima": {
+        "schema": ["proj_Z", "proj_A", "target_Z", "energy_MeV_u", "dedx", "straggling"],
         "proj_Z_range": [
           1,
-          92
+          99
         ],
         "target_Z_range": [
           1,
           92
         ],
         "energy_unit": "MeV/u",
-        "note": "Any isotope of proj_Z \u2014 divide total MeV by A to get MeV/u"
+        "n_isotopes": 399,
+        "n_rows": 7341600,
+        "isotope_inventory": "All stable + primordial isotopes (abundance > 0 in meta/abundances.parquet, 287 nuclides) \u222a all ground-state nuclides with T\u00bd > 1 year in meta/decay.parquet (covers Np/Pu/Am/Cm/Bk/Cf/Es transuranics up to Z=99, plus every long-lived radio-isotope of lower-Z elements) \u222a beam/medical allowlist (C-11, N-13, O-15, F-18, P-32). For Z values with no T\u00bd>1yr isotope (At, Rn, Fr), the longest-lived ground state is shipped as fallback.",
+        "isotope_note": "Rows are keyed on (proj_Z, proj_A). At E/A > 0.1 MeV/u dedx is isotope-agnostic to <0.1%; below ~0.01 MeV/u nuclear-stopping reduced-mass effects cause real (up to ~15%) isotope dependence, captured by the per-isotope rows. Querying (Z, A) outside the inventory raises KeyError \u2014 extend nucl_parquet.build_heavy_ions._BEAM_ALLOWLIST or lower _LONGLIVED_THRESHOLD_S and rebuild."
       }
     }
   }

--- a/nucl_parquet/build_heavy_ions.py
+++ b/nucl_parquet/build_heavy_ions.py
@@ -1,19 +1,34 @@
 """Generate heavy-ion stopping power tables via pycatima and save as Parquet.
 
-Pre-computes mass stopping power [MeV cm2/g] for all elements Z=1-92 as
-projectiles against all elements Z=1-92 as targets.
+Pre-computes mass stopping power [MeV cm2/g] for an enumerated set of
+projectile isotopes (Z, A) against all elements Z=1-92 as targets.
 
-Stopping power at a given MeV/u depends only on projectile Z and velocity,
-not on the specific isotope — so energy is stored in MeV/u. Any isotope of
-element Z can be looked up by converting total MeV → MeV/u (divide by A).
+The energy axis is stored in MeV/u. At fixed MeV/u above ~15 keV/u, dedx is
+isotope-agnostic to <1% for medium-to-heavy projectiles and within catima's
+quoted uncertainty. Below that threshold, nuclear stopping dominates and the
+reduced-mass A_p·A_t/(A_p+A_t) introduces real isotope dependence (up to
+~15% for light projectiles). Per-isotope tabulation lets consumers query the
+correct row at any energy, eliminating the silent-error path that existed
+when only one row per Z was shipped.
 
-Also computes Bohr energy straggling variance dΩ²/d(ρx) [MeV² cm²/g] per
-(proj_Z, target_Z) pair.  Bohr straggling is energy-independent (the high-
-energy limit); it overestimates at very low β but is acceptable for therapy-
-range ions.
+Bohr energy straggling variance dΩ²/d(ρx) [MeV² cm²/g] is the high-energy
+limit (Bohr 1948); it overestimates at very low β but is acceptable for
+therapy-range ions.
 
-Output: stopping/catima.parquet
-        (schema: proj_Z, target_Z, energy_MeV_u, dedx, straggling)
+Projectile inventory (≈391 isotopes):
+  - All stable + primordial isotopes (abundance > 0 in
+    data/meta/abundances.parquet) — 287 nuclides
+  - All ground-state nuclides with T½ > 1 year in data/meta/decay.parquet —
+    includes transuranics (Np, Pu, Am, Cm, Bk, Cf, Es) up to Z=99 and the
+    long-lived isotopes of every Z below 92
+  - Beam/medical allowlist for short-lived but commonly-used isotopes:
+    T (³H), C-11, N-13, O-15, F-18, P-32 (others already covered above)
+
+Targets are restricted to Z=1..92 where pycatima's get_material() returns
+a valid molar mass; transuranic projectiles still hit Z≤92 targets fine.
+
+Output: stopping/catima/catima.parquet
+        (schema: proj_Z, proj_A, target_Z, energy_MeV_u, dedx, straggling)
 
 Usage:
     uv run python -m nucl_parquet.build_heavy_ions
@@ -35,9 +50,73 @@ _ENERGIES_MEV_U: np.ndarray = np.geomspace(0.001, 300.0, 200)
 # dΩ²/d(ρx) = BOHR_CONST × Z_p² × Z_t / A_t
 _BOHR_CONST: float = 0.15737
 
+# Threshold for "long-lived" — any ground state with T½ > 1 year ships.
+# Covers transuranics (Pu-239 24kyr, Am-241 432yr, Cf-252 2.6yr, etc.),
+# every long-lived radio-anchor (Tc-97, Pm-145, Pa-231, ...) and standard
+# nucleosynthesis chain members. Catches Es-254 (276d) by not requiring stability.
+_LONGLIVED_THRESHOLD_S: float = 365.0 * 86400.0  # 1 year
+
+# Beam/medical isotopes worth shipping even if their T½ is < 1 year.
+_BEAM_ALLOWLIST: list[tuple[int, int]] = [
+    (1, 3),  # T (tritium beams, fusion plasma)  T½ 12.3 yr — already long-lived
+    (6, 11),  # C-11 (PET)                        T½ 20 min
+    (7, 13),  # N-13 (PET)                        T½ 9.97 min
+    (8, 15),  # O-15 (PET)                        T½ 2.04 min
+    (9, 18),  # F-18 (PET / FDG)                  T½ 110 min
+    (15, 32),  # P-32 (therapy)                    T½ 14.3 d
+]
+
+
+def _resolve_projectile_isotopes(data_dir: Path) -> list[tuple[int, int]]:
+    """Return sorted list of (proj_Z, proj_A) pairs to bake.
+
+    Union of:
+      - stable + primordial isotopes (abundance > 0 in abundances.parquet)
+      - all ground-state nuclides with T½ > _LONGLIVED_THRESHOLD_S in decay.parquet
+      - short-lived beam/medical allowlist
+
+    Capped to Z=1..99 (catima Bethe-Bloch accepts arbitrary projectile Z, but
+    we stop at Es since beyond that no isotope has T½ > 1 yr).
+    """
+    import polars as pl
+
+    abund = pl.read_parquet(data_dir / "meta" / "abundances.parquet")
+    stable = abund.filter(pl.col("abundance") > 0).select("Z", "A").unique()
+
+    decay = pl.read_parquet(data_dir / "meta" / "decay.parquet")
+    longlived = (
+        decay.filter((pl.col("state") == "") & (pl.col("half_life_s") > _LONGLIVED_THRESHOLD_S))
+        .select("Z", "A")
+        .unique()
+    )
+
+    rows: set[tuple[int, int]] = set()
+    rows.update((int(z), int(a)) for z, a in zip(stable["Z"].to_list(), stable["A"].to_list()))
+    rows.update((int(z), int(a)) for z, a in zip(longlived["Z"].to_list(), longlived["A"].to_list()))
+    rows.update(_BEAM_ALLOWLIST)
+
+    # Fallback: for any Z=1..92 still missing (At, Rn, Fr — every isotope has
+    # T½ < 1 yr), pick the longest-lived ground state so the table covers every
+    # element. Better a short-lived canonical than a NaN.
+    covered_zs = {z for z, _ in rows}
+    for z in range(1, 93):
+        if z in covered_zs:
+            continue
+        best = (
+            decay.filter((pl.col("Z") == z) & (pl.col("state") == ""))
+            .sort("half_life_s", descending=True, nulls_last=True)
+            .select("A")
+            .head(1)
+        )
+        if best.height == 0:
+            raise RuntimeError(f"No ground-state decay row for Z={z}; cannot pick canonical isotope")
+        rows.add((z, int(best["A"][0])))
+
+    return sorted(p for p in rows if 1 <= p[0] <= 99)
+
 
 def build(data_dir: Path | None = None) -> None:
-    """Generate catima stopping tables for all 92 projectile elements."""
+    """Generate catima stopping tables for the enumerated isotope set."""
     if data_dir is None:
         data_dir = _resolve_data_dir()
     data_dir = Path(data_dir)
@@ -45,17 +124,27 @@ def build(data_dir: Path | None = None) -> None:
     import polars as pl
     import pycatima as catima
 
-    n_proj = 92
+    isotopes = _resolve_projectile_isotopes(data_dir)
     n_target = 92
     n_energy = len(_ENERGIES_MEV_U)
-    total = n_proj * n_target * n_energy
-    print(f"Building catima tables: {n_proj} × {n_target} × {n_energy} = {total:,} rows\n")
+    total = len(isotopes) * n_target * n_energy
+    print(
+        f"Building catima tables: {len(isotopes)} isotopes × {n_target} targets "
+        f"× {n_energy} energies = {total:,} rows\n"
+    )
 
-    out_path = data_dir / "stopping" / "catima.parquet"
+    # Verify every Z=1..92 has at least one isotope (sanity check).
+    z_covered = {z for z, _ in isotopes}
+    missing_z = sorted(set(range(1, 93)) - z_covered)
+    if missing_z:
+        raise RuntimeError(f"No isotope for Z in {missing_z}")
+
+    out_path = data_dir / "stopping" / "catima" / "catima.parquet"
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
-    all_proj_zs: list[int] = []
-    all_target_zs: list[int] = []
+    all_proj_z: list[int] = []
+    all_proj_a: list[int] = []
+    all_target_z: list[int] = []
     all_energies: list[float] = []
     all_dedxs: list[float] = []
     all_strag: list[float] = []
@@ -65,36 +154,37 @@ def build(data_dir: Path | None = None) -> None:
     for z in range(1, 93):
         target_A[z] = catima.get_material(z).molar_mass()
 
-    # A only affects velocity at a given total energy — at fixed MeV/u, dedx is
-    # isotope-independent. We use a representative A (≈2Z) purely to initialise
-    # the catima Projectile object; it does not affect the stored dedx values.
-    for proj_Z in range(1, 93):
-        proj_A = max(1, round(proj_Z * 2.0))
+    last_z = None
+    for proj_Z, proj_A in isotopes:
         proj = catima.Projectile(proj_A, proj_Z)
-
         for target_Z in range(1, 93):
             mat = catima.get_material(target_Z)
             # Bohr straggling: dΩ²/d(ρx) = const × Z_p² × Z_t / A_t
             strag = _BOHR_CONST * proj_Z**2 * target_Z / target_A[target_Z]
             for e in _ENERGIES_MEV_U:
                 proj.T(float(e))
-                all_proj_zs.append(proj_Z)
-                all_target_zs.append(target_Z)
+                all_proj_z.append(proj_Z)
+                all_proj_a.append(proj_A)
+                all_target_z.append(target_Z)
                 all_energies.append(float(e))
                 all_dedxs.append(catima.dedx(proj, mat))
                 all_strag.append(strag)
-
-        print(f"  Z={proj_Z:2d}: done")
+        if proj_Z != last_z:
+            print(f"  Z={proj_Z:2d}: A={proj_A} done", flush=True)
+            last_z = proj_Z
+        else:
+            print(f"          A={proj_A} done", flush=True)
 
     df = pl.DataFrame(
         {
-            "proj_Z": pl.Series(all_proj_zs, dtype=pl.Int32),
-            "target_Z": pl.Series(all_target_zs, dtype=pl.Int32),
+            "proj_Z": pl.Series(all_proj_z, dtype=pl.Int32),
+            "proj_A": pl.Series(all_proj_a, dtype=pl.Int32),
+            "target_Z": pl.Series(all_target_z, dtype=pl.Int32),
             "energy_MeV_u": pl.Series(all_energies, dtype=pl.Float64),
             "dedx": pl.Series(all_dedxs, dtype=pl.Float64),
             "straggling": pl.Series(all_strag, dtype=pl.Float64),
         }
-    ).sort("proj_Z", "target_Z", "energy_MeV_u")
+    ).sort("proj_Z", "proj_A", "target_Z", "energy_MeV_u")
 
     df.write_parquet(out_path, compression="zstd")
     print(f"\nWrote {len(df):,} rows to {out_path}")

--- a/nucl_parquet/loader.py
+++ b/nucl_parquet/loader.py
@@ -646,8 +646,11 @@ def _resolve_projectile(name: str) -> tuple[int, int, str]:
 # Cache: (source, target_Z) -> (log_E, log_S) arrays
 _stopping_cache: dict[tuple[str, int], tuple[np.ndarray, np.ndarray]] = {}
 
-# Cache: (proj_Z, target_Z) -> (log_E_MeV_u, log_S) arrays
-_catima_cache: dict[tuple[int, int], tuple[np.ndarray, np.ndarray]] = {}
+# Cache: (proj_Z, proj_A, target_Z) -> (log_E_MeV_u, log_S) arrays
+_catima_cache: dict[tuple[int, int, int], tuple[np.ndarray, np.ndarray]] = {}
+
+# Cache: proj_Z -> sorted list of available proj_A values (for error messages)
+_catima_isotopes_cache: dict[int, list[int]] = {}
 
 
 def _get_stopping_table(
@@ -671,17 +674,34 @@ def _get_stopping_table(
     return _stopping_cache[key]
 
 
+def _get_catima_isotopes(
+    db: duckdb.DuckDBPyConnection,
+    proj_Z: int,
+) -> list[int]:
+    """Return sorted list of proj_A values available in catima_stopping for proj_Z."""
+    if proj_Z not in _catima_isotopes_cache:
+        result = db.sql(
+            "SELECT DISTINCT proj_A FROM catima_stopping WHERE proj_Z = $pz ORDER BY proj_A",
+            params={"pz": proj_Z},
+        ).fetchall()
+        _catima_isotopes_cache[proj_Z] = [int(row[0]) for row in result]
+    return _catima_isotopes_cache[proj_Z]
+
+
 def _get_catima_table(
     db: duckdb.DuckDBPyConnection,
     proj_Z: int,
+    proj_A: int,
     target_Z: int,
 ) -> tuple[np.ndarray, np.ndarray]:
-    """Get log-log catima stopping arrays (energy in MeV/u), cached."""
-    key = (proj_Z, target_Z)
+    """Get log-log catima stopping arrays (energy in MeV/u) for a specific isotope, cached."""
+    key = (proj_Z, proj_A, target_Z)
     if key not in _catima_cache:
         result = db.sql(
-            "SELECT energy_MeV_u, dedx FROM catima_stopping WHERE proj_Z = $pz AND target_Z = $tz ORDER BY energy_MeV_u",
-            params={"pz": proj_Z, "tz": target_Z},
+            "SELECT energy_MeV_u, dedx FROM catima_stopping "
+            "WHERE proj_Z = $pz AND proj_A = $pa AND target_Z = $tz "
+            "ORDER BY energy_MeV_u",
+            params={"pz": proj_Z, "pa": proj_A, "tz": target_Z},
         ).fetchnumpy()
         E = result["energy_MeV_u"]
         S = result["dedx"]
@@ -719,22 +739,41 @@ def elemental_dedx(
     NIST PSTAR/ASTAR only publishes 25 elemental materials; for target_Z not
     in NIST's table (e.g. Tc, Pm, Po, Rn), the loader falls back to catima.
 
+    Catima tables are tabulated per-isotope (proj_Z, proj_A): the energy axis
+    is MeV/u, but the rows differ between isotopes of the same Z at low energy
+    where nuclear stopping (reduced-mass-dependent) dominates. Above ~0.1 MeV/u
+    isotope differences are <0.1%; below ~0.01 MeV/u they reach up to ~15% for
+    light projectiles. Querying an A not present in the table raises KeyError.
+
     Args:
         db: DuckDB connection from connect().
         projectile: Projectile name. Light ions: 'p','d','t','h','a','e'.
                     Heavy ions: element symbol + mass number, e.g. 'c12',
-                    'pb208', 'xe132' (any isotope of Z=1-92).
+                    'pb208', 'xe132'. Must be a tabulated isotope; see
+                    nucl_parquet.build_heavy_ions for the inventory.
         target_Z: Target element atomic number (1-92).
         energy_MeV: Total projectile kinetic energy [MeV].
 
     Returns:
         Mass stopping power [MeV cm2/g].
+
+    Raises:
+        KeyError: if `projectile` is unknown or its (Z, A) is not in the
+            catima table.
     """
     energy_MeV = np.atleast_1d(np.asarray(energy_MeV, dtype=float))
     proj_A, proj_Z, ref_source = _resolve_projectile(projectile)
 
     if ref_source == "catima":
-        log_E, log_S = _get_catima_table(db, proj_Z, target_Z)
+        available_As = _get_catima_isotopes(db, proj_Z)
+        if proj_A not in available_As:
+            raise KeyError(
+                f"catima table has no row for Z={proj_Z} A={proj_A}. "
+                f"Available isotopes for Z={proj_Z}: {available_As}. "
+                "Use a tabulated isotope or rebuild via build_heavy_ions.py "
+                "with an extended allowlist."
+            )
+        log_E, log_S = _get_catima_table(db, proj_Z, proj_A, target_Z)
         if len(log_E) == 0:
             return np.full_like(energy_MeV, np.nan)
         # catima table is in MeV/u — convert total MeV by dividing by A
@@ -745,9 +784,11 @@ def elemental_dedx(
         # NIST tables only cover 25 elemental materials; fall back to catima
         # (Bethe-Bloch) for elements NIST doesn't publish (Tc, Pm, Po, Rn, …).
         if ref_source in ("PSTAR", "ASTAR"):
-            log_E_c, log_S_c = _get_catima_table(db, proj_Z, target_Z)
-            if len(log_E_c) > 0:
-                return _interp_loglog(log_E_c, log_S_c, energy_MeV / proj_A)
+            available_As = _get_catima_isotopes(db, proj_Z)
+            if proj_A in available_As:
+                log_E_c, log_S_c = _get_catima_table(db, proj_Z, proj_A, target_Z)
+                if len(log_E_c) > 0:
+                    return _interp_loglog(log_E_c, log_S_c, energy_MeV / proj_A)
         return np.full_like(energy_MeV, np.nan)
 
     if ref_source == "ESTAR":

--- a/tests/test_stopping_anchors.py
+++ b/tests/test_stopping_anchors.py
@@ -182,11 +182,10 @@ def test_alpha_dedx_matches_nist_astar_exactly(
 def test_he3_dispatches_through_catima(data_dir_path: Path, energy_MeV_per_u: float) -> None:
     """³He via the loader must equal a direct catima lookup at the same MeV/u.
 
-    Goes through `_get_catima_table(2, target_Z)` and `_interp_loglog(.../A)`
+    Goes through `_get_catima_table(2, 3, target_Z)` and `_interp_loglog(.../A)`
     independently to assert the dispatch is reading the right row and dividing
     by proj_A=3. Note this only validates the *dispatch arithmetic* — pycatima's
-    actual ³He physics isn't anchored against a published reference here. The
-    physics anchor is via α (same proj_Z=2, same row).
+    actual ³He physics isn't anchored against a published reference here.
     """
     import numpy as np
 
@@ -194,7 +193,7 @@ def test_he3_dispatches_through_catima(data_dir_path: Path, energy_MeV_per_u: fl
 
     db = np_lib.connect(data_dir_path)
     he3 = float(np_lib.elemental_dedx(db, "he3", 29, energy_MeV_per_u * 3.0)[0])
-    log_E, log_S = _get_catima_table(db, proj_Z=2, target_Z=29)
+    log_E, log_S = _get_catima_table(db, proj_Z=2, proj_A=3, target_Z=29)
     expected = float(_interp_loglog(log_E, log_S, np.atleast_1d(energy_MeV_per_u))[0])
     assert he3 == pytest.approx(expected, rel=1e-9), (
         f"³He dispatch at {energy_MeV_per_u} MeV/u: got {he3}, direct catima lookup {expected}"
@@ -285,7 +284,7 @@ def test_alpha_falls_back_to_catima_for_non_nist_element(data_dir_path: Path) ->
 
     db = np_lib.connect(data_dir_path)
     got = float(np_lib.elemental_dedx(db, "a", 43, 5.0)[0])
-    log_E_c, log_S_c = _get_catima_table(db, proj_Z=2, target_Z=43)
+    log_E_c, log_S_c = _get_catima_table(db, proj_Z=2, proj_A=4, target_Z=43)
     expected = float(_interp_loglog(log_E_c, log_S_c, np.atleast_1d(5.0 / 4.0))[0])
     assert got == pytest.approx(expected, rel=1e-9), (
         f"Tc α fallback returned {got}, but direct catima lookup is {expected}"

--- a/tests/test_stopping_catima_isotopes.py
+++ b/tests/test_stopping_catima_isotopes.py
@@ -1,0 +1,121 @@
+"""Isotope-aware tests for the per-isotope catima stopping table (#169).
+
+Verifies:
+- Schema includes `proj_A` column
+- Inventory covers every Z in 1..92 and includes the documented allowlist isotopes
+- Different isotopes of the same Z give *different* dedx at low energy (real
+  reduced-mass effect from nuclear stopping)
+- Different isotopes of the same Z converge to <0.1% spread at high energy
+- Querying an (Z, A) that isn't tabulated raises a clear KeyError
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nucl_parquet import loader as np_lib
+
+
+@pytest.fixture(scope="module")
+def data_dir_path() -> Path:
+    return Path("data").resolve()
+
+
+@pytest.mark.data
+def test_catima_schema_has_proj_a(data_dir_path: Path) -> None:
+    """catima_stopping must expose a proj_A:int32 column."""
+    import polars as pl
+
+    df = pl.read_parquet(data_dir_path / "stopping" / "catima" / "catima.parquet")
+    assert "proj_A" in df.columns
+    assert df["proj_A"].dtype == pl.Int32
+
+
+@pytest.mark.data
+def test_catima_covers_every_z(data_dir_path: Path) -> None:
+    """Every Z in 1..92 must have at least one tabulated isotope."""
+    import polars as pl
+
+    df = pl.read_parquet(data_dir_path / "stopping" / "catima" / "catima.parquet")
+    z_present = set(df["proj_Z"].unique().to_list())
+    missing = sorted(set(range(1, 93)) - z_present)
+    assert not missing, f"Z values without any tabulated isotope: {missing}"
+
+
+@pytest.mark.data
+def test_catima_includes_beam_allowlist(data_dir_path: Path) -> None:
+    """The build's beam/medical allowlist must appear in the on-disk table."""
+    import polars as pl
+
+    df = pl.read_parquet(data_dir_path / "stopping" / "catima" / "catima.parquet")
+    pairs = set((int(z), int(a)) for z, a in zip(df["proj_Z"].to_list(), df["proj_A"].to_list()))
+    must_have = [
+        (1, 3),  # T
+        (6, 11),  # C-11
+        (6, 14),  # C-14
+        (9, 18),  # F-18
+        (27, 60),  # Co-60
+        (88, 226),  # Ra-226 (canonical for radioactive-only Ra)
+        (92, 238),  # U-238
+    ]
+    missing = [p for p in must_have if p not in pairs]
+    assert not missing, f"Allowlist isotopes missing from table: {missing}"
+
+
+@pytest.mark.data
+def test_isotopes_differ_at_low_energy(data_dir_path: Path) -> None:
+    """H-1 vs T at 1 keV/u on Cu must differ by > 5% (real nuclear-stopping effect)."""
+    db = np_lib.connect(data_dir_path)
+    # p (PSTAR) and t (PSTAR), both route to PSTAR — not a catima isotope test.
+    # Use the catima path explicitly via _get_catima_table.
+    import numpy as np
+
+    from nucl_parquet.loader import _get_catima_table, _interp_loglog
+
+    log_E_p, log_S_p = _get_catima_table(db, proj_Z=1, proj_A=1, target_Z=29)
+    log_E_t, log_S_t = _get_catima_table(db, proj_Z=1, proj_A=3, target_Z=29)
+    e_per_u = np.array([0.001])
+    p_dedx = float(_interp_loglog(log_E_p, log_S_p, e_per_u)[0])
+    t_dedx = float(_interp_loglog(log_E_t, log_S_t, e_per_u)[0])
+    rel = abs(p_dedx - t_dedx) / max(p_dedx, t_dedx) * 100.0
+    assert rel > 5.0, (
+        f"H-1 vs H-3 at 0.001 MeV/u on Cu: dedx(p)={p_dedx:.3g}, dedx(t)={t_dedx:.3g}, "
+        f"diff={rel:.2f}% — expected >5% from reduced-mass nuclear stopping"
+    )
+
+
+@pytest.mark.data
+def test_isotopes_converge_at_high_energy(data_dir_path: Path) -> None:
+    """C-12 vs C-14 at 10 MeV/u on Cu must agree to <0.1% (Bethe regime)."""
+    db = np_lib.connect(data_dir_path)
+    import numpy as np
+
+    from nucl_parquet.loader import _get_catima_table, _interp_loglog
+
+    log_E_12, log_S_12 = _get_catima_table(db, proj_Z=6, proj_A=12, target_Z=29)
+    log_E_14, log_S_14 = _get_catima_table(db, proj_Z=6, proj_A=14, target_Z=29)
+    e_per_u = np.array([10.0])
+    c12 = float(_interp_loglog(log_E_12, log_S_12, e_per_u)[0])
+    c14 = float(_interp_loglog(log_E_14, log_S_14, e_per_u)[0])
+    rel = abs(c12 - c14) / c12 * 100.0
+    assert rel < 0.1, (
+        f"C-12 vs C-14 at 10 MeV/u on Cu: dedx(C-12)={c12:.5g}, dedx(C-14)={c14:.5g}, "
+        f"diff={rel:.4f}% — expected <0.1% in Bethe regime"
+    )
+
+
+@pytest.mark.data
+def test_unknown_isotope_raises_with_clear_message(data_dir_path: Path) -> None:
+    """Querying an (Z, A) outside the inventory must raise KeyError listing what *is* available."""
+    db = np_lib.connect(data_dir_path)
+    # He-5 is unbound — doesn't exist as a nucleus, so it can't be in any table.
+    with pytest.raises(KeyError) as exc:
+        np_lib.elemental_dedx(db, "he5", 29, 100.0)
+    msg = str(exc.value)
+    assert "Z=2" in msg
+    assert "A=5" in msg
+    assert "Available isotopes" in msg
+    # He-4 (stable) must be advertised as available
+    assert "4" in msg


### PR DESCRIPTION
## Summary

The catima 92×92 stopping table now ships **per-isotope rows** keyed on `(proj_Z, proj_A, target_Z, energy_MeV_u)`, replacing the old single-row-per-Z table that silently used `proj_A = round(2*Z)` (which gave unphysical A values for high Z — U-184 doesn't exist).

## Why this matters

- At E/A > ~0.1 MeV/u, dedx is isotope-agnostic to <0.1% — the old schema was fine here.
- Below ~0.01 MeV/u, reduced-mass-driven nuclear stopping makes isotope choice matter by **up to ~15% for light projectiles**.
- The old table returned a silently-wrong value in that regime; the new one returns the correct row, or `KeyError` if the requested isotope isn't tabulated.

Falsification done before implementing (see #169 discussion): swept the full energy range with pycatima for H/D/T, He-3/4, C/O/Ar/Fe/Xe/Pb/U isotope pairs. Isotope spread reaches 14.6% at 0.001 MeV/u for H/D/T on Cu, 5% for C-12/14 on Pb, etc. — confirmed real physics, not metadata fluff.

## Inventory — 399 isotopes covering Z=1..99

- All **stable + primordial** isotopes (abundance > 0 in `meta/abundances.parquet`) — 287
- All **ground-state nuclides with T½ > 1 year** per `meta/decay.parquet` — 131 long-lived, including:
  - transuranics: Np-235/237, Pu-236/238/239/240/241/242/244, Am-241/243, Cm-243..250, Bk-247, Cf-249..252, Es-252
  - long-lived radio-anchors at lower Z (Tc-97, Pm-145, Rb-87, K-40, U-235/238, etc.)
- Beam/medical allowlist for short-lived but commonly-used species: C-11, N-13, O-15, F-18, P-32
- Per-element fallback for At, Rn, Fr (no T½>1yr ground state): longest-lived ground state ships so every Z=1..92 is covered

Targets stay capped at Z=1..92 (pycatima `get_material()` returns 0 g/mol for Z>95).

## Client changes

- `_get_catima_table(db, proj_Z, proj_A, target_Z)` — new `proj_A` arg threaded through SQL `WHERE`.
- `_get_catima_isotopes(db, proj_Z)` — cached per-Z isotope list (used for error messages).
- `elemental_dedx(...)` raises `KeyError` listing available A when `(Z, A)` isn't tabulated, instead of silently returning the canonical row. Public API signature is unchanged.

## Data release

- `data_version`: `2026.5.0` → `2026.5.1`
- `data_sha256`: `08a2dd67…`
- `catima.parquet`: ~13 MB → ~55 MB (7.3M rows, 399 isotopes × 92 targets × 200 energies)
- Auto-tag-data workflow will cut `data-2026.5.1` on merge to main.

## Test plan

- [x] All 134 existing stopping tests pass
- [x] 6 new tests in `tests/test_stopping_catima_isotopes.py`:
  - schema has `proj_A:int32`
  - inventory covers Z=1..92
  - beam allowlist round-trips to parquet
  - H-1 vs H-3 differ by >5% at 0.001 MeV/u on Cu (real low-E physics)
  - C-12 vs C-14 converge to <0.1% at 10 MeV/u on Cu (Bethe regime)
  - `KeyError` for unknown (Z, A) with available-A listed in message
- [ ] CI green on main
- [ ] After merge: verify data-2026.5.1 tag created + tarball published

Closes #169