### PR TITLE
fix(mcp): replace hardcoded version strings with package metadata

### DIFF
--- a/clients/py/nucl-parquet-mcp/nucl_parquet_mcp/server.py
+++ b/clients/py/nucl-parquet-mcp/nucl_parquet_mcp/server.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import io
 import os
-from importlib.metadata import version as _pkg_version
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
 from typing import Any
 
 import httpx
@@ -215,7 +215,12 @@ async def _fetch_manifest(library_id: str) -> dict[str, Any]:
 # MCP Server
 # ---------------------------------------------------------------------------
 
-mcp = FastMCP("nucl-parquet", version=_pkg_version("nucl-parquet-mcp"))
+try:
+    _VERSION = _pkg_version("nucl-parquet-mcp")
+except PackageNotFoundError:
+    _VERSION = "0.0.0-dev"
+
+mcp = FastMCP("nucl-parquet", version=_VERSION)
 
 
 @mcp.tool()

--- a/clients/py/nucl-parquet-mcp/nucl_parquet_mcp/server.py
+++ b/clients/py/nucl-parquet-mcp/nucl_parquet_mcp/server.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import io
 import os
-from importlib.metadata import PackageNotFoundError, version as _pkg_version
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 from typing import Any
 
 import httpx

--- a/clients/py/nucl-parquet-mcp/nucl_parquet_mcp/server.py
+++ b/clients/py/nucl-parquet-mcp/nucl_parquet_mcp/server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import os
+from importlib.metadata import version as _pkg_version
 from typing import Any
 
 import httpx
@@ -214,7 +215,7 @@ async def _fetch_manifest(library_id: str) -> dict[str, Any]:
 # MCP Server
 # ---------------------------------------------------------------------------
 
-mcp = FastMCP("nucl-parquet")
+mcp = FastMCP("nucl-parquet", version=_pkg_version("nucl-parquet-mcp"))
 
 
 @mcp.tool()

--- a/clients/py/nucl-parquet-mcp/tests/test_server.py
+++ b/clients/py/nucl-parquet-mcp/tests/test_server.py
@@ -13,7 +13,22 @@ from nucl_parquet_mcp.server import (
     get_decay_data,
     list_isotopes,
     list_libraries,
+    mcp,
 )
+
+# ---------------------------------------------------------------------------
+# Version tests
+# ---------------------------------------------------------------------------
+
+
+class TestVersion:
+    def test_server_version_from_metadata(self):
+        import importlib.metadata
+
+        expected = importlib.metadata.version("nucl-parquet-mcp")
+        assert mcp.settings.version == expected
+        assert expected  # not empty
+
 
 # ---------------------------------------------------------------------------
 # Catalog tests (no network)

--- a/clients/rs/nucl-parquet-mcp/src/main.rs
+++ b/clients/rs/nucl-parquet-mcp/src/main.rs
@@ -607,7 +607,7 @@ async fn handle_request(
             serde_json::json!({
                 "protocolVersion": "2024-11-05",
                 "capabilities": { "tools": {} },
-                "serverInfo": { "name": "nucl-parquet", "version": "0.3.8" }
+                "serverInfo": { "name": "nucl-parquet", "version": env!("CARGO_PKG_VERSION") }
             }),
         )),
         "tools/list" => Some(JsonRpcResponse::success(id, tool_definitions())),
@@ -770,6 +770,10 @@ mod tests {
         let resp = handle_request(&client, &cache, req).await.unwrap();
         let result = resp.result.unwrap();
         assert_eq!(result["serverInfo"]["name"], "nucl-parquet");
+        assert_eq!(
+            result["serverInfo"]["version"].as_str().unwrap(),
+            env!("CARGO_PKG_VERSION"),
+        );
     }
 
     #[tokio::test]

--- a/clients/ts/nucl-parquet-mcp/package-lock.json
+++ b/clients/ts/nucl-parquet-mcp/package-lock.json
@@ -900,6 +900,7 @@
       "version": "22.19.15",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1357,6 +1358,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1439,6 +1441,7 @@
     "node_modules/express": {
       "version": "5.2.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1662,6 +1665,7 @@
     "node_modules/hono": {
       "version": "4.12.8",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1972,6 +1976,7 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2022,6 +2027,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2544,6 +2550,7 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2580,6 +2587,7 @@
       "version": "5.4.21",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -3190,6 +3198,7 @@
     "node_modules/zod": {
       "version": "3.25.76",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/clients/ts/nucl-parquet-mcp/package-lock.json
+++ b/clients/ts/nucl-parquet-mcp/package-lock.json
@@ -900,7 +900,6 @@
       "version": "22.19.15",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1358,7 +1357,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1441,7 +1439,6 @@
     "node_modules/express": {
       "version": "5.2.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1665,7 +1662,6 @@
     "node_modules/hono": {
       "version": "4.12.8",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1976,7 +1972,6 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2027,7 +2022,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2550,7 +2544,6 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2587,7 +2580,6 @@
       "version": "5.4.21",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -3198,7 +3190,6 @@
     "node_modules/zod": {
       "version": "3.25.76",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/clients/ts/nucl-parquet-mcp/src/index.ts
+++ b/clients/ts/nucl-parquet-mcp/src/index.ts
@@ -1,8 +1,12 @@
+import { createRequire } from "node:module";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { parquetRead } from "hyparquet";
 import { compressors } from "hyparquet-compressors";
 import { z } from "zod";
+
+const require = createRequire(import.meta.url);
+export const { version: PKG_VERSION } = require("../package.json") as { version: string };
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -129,7 +133,7 @@ function truncateRows(rows: Record<string, unknown>[], limit: number): { rows: R
 
 const server = new McpServer({
   name: "nucl-parquet",
-  version: "0.3.7",
+  version: PKG_VERSION,
 });
 
 server.tool(

--- a/clients/ts/nucl-parquet-mcp/test/server.test.ts
+++ b/clients/ts/nucl-parquet-mcp/test/server.test.ts
@@ -1,5 +1,15 @@
+import { createRequire } from "node:module";
 import { describe, it, expect } from "vitest";
-import { getCatalog } from "../src/index.js";
+import { getCatalog, PKG_VERSION } from "../src/index.js";
+
+const require = createRequire(import.meta.url);
+
+describe("version", () => {
+  it("PKG_VERSION matches package.json", () => {
+    const { version } = require("../package.json") as { version: string };
+    expect(PKG_VERSION).toBe(version);
+  });
+});
 
 describe("catalog", () => {
   const catalog = getCatalog();


### PR DESCRIPTION
## Summary
- **Rust MCP**: `"0.3.8"` → `env!("CARGO_PKG_VERSION")` (compile-time from Cargo.toml)
- **TS MCP**: `"0.3.7"` → `createRequire("../package.json").version` (runtime)
- **Python MCP**: no version → `importlib.metadata.version("nucl-parquet-mcp")` (runtime)
- Added version-sanity tests to all three clients

Closes #51

## Test plan
- [x] Rust: `cargo check` + `cargo test handle_initialize` — pass
- [x] TS: `tsup` build + `vitest run` (14/14 tests) — pass
- [x] Python: AST parse OK (full test blocked by pycatima NixOS build issue, unrelated)