### PR TITLE
fix(ci): auto-tag dispatches release-data workflow directly

### DIFF
--- a/.github/workflows/auto-tag-data.yml
+++ b/.github/workflows/auto-tag-data.yml
@@ -77,3 +77,13 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -a "${TAG}" -m "Auto-tagged from data/catalog.json::data_version on merge"
           git push origin "${TAG}"
+
+      # GITHUB_TOKEN-created tags don't trigger push events for other
+      # workflows (GitHub's infinite-loop prevention). Explicitly dispatch
+      # the release workflow so the tarball gets built without manual intervention.
+      - name: Trigger release-data workflow
+        if: steps.detect.outputs.tag != ''
+        env:
+          TAG: ${{ steps.detect.outputs.tag }}
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run release-data.yml -f tag="${TAG}"

--- a/.github/workflows/release-data.yml
+++ b/.github/workflows/release-data.yml
@@ -2,12 +2,20 @@ name: Release Data
 
 # Data releases follow CalVer (YYYY.MM.MICRO) on their own tag namespace,
 # decoupled from the code semver release pipeline (.github/workflows/release.yml).
-# Trigger by pushing a tag like `data-2026.5.0` (or via auto-tag-data.yml on
-# merge to main when data/catalog.json::data_version changes).
+# Triggers:
+#   1. Tag push (manual `git push origin data-X.Y.Z`)
+#   2. workflow_dispatch from auto-tag-data.yml (GITHUB_TOKEN tags don't
+#      fire push events — this is the normal path after PR merge)
 
 on:
   push:
     tags: ["data-*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Data tag to release (e.g. data-2026.5.1)"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -20,13 +28,24 @@ jobs:
       - uses: actions/checkout@v5
       - name: Install zstd
         run: sudo apt-get update && sudo apt-get install -y zstd
+      - name: Checkout tag (workflow_dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tag }}
       - name: Build tarball
         run: |
           # Tag form: data-YYYY.MM.MICRO → strip the `data-` prefix to get CalVer.
-          CALVER=${GITHUB_REF#refs/tags/data-}
+          # workflow_dispatch passes the tag via inputs.tag; push events via GITHUB_REF.
+          if [ -n "${{ inputs.tag }}" ]; then
+            CALVER="${{ inputs.tag }}"
+            CALVER=${CALVER#data-}
+          else
+            CALVER=${GITHUB_REF#refs/tags/data-}
+          fi
           # Sanity-check the tag actually matches CalVer.
           if ! [[ "${CALVER}" =~ ^[0-9]{4}\.[0-9]+\.[0-9]+$ ]]; then
-            echo "ERROR: tag ${GITHUB_REF} does not match data-YYYY.MM.MICRO" >&2
+            echo "ERROR: tag does not match data-YYYY.MM.MICRO (got CalVer='${CALVER}')" >&2
             exit 1
           fi
           # Sanity-check catalog.json::data_version matches the tag.
@@ -41,6 +60,7 @@ jobs:
       - name: Upload to release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ inputs.tag || github.ref_name }}
           files: ${{ env.ASSET_PATH }}
           fail_on_unmatched_files: true
           generate_release_notes: true


### PR DESCRIPTION
## Summary
- `auto-tag-data.yml` now calls `gh workflow run release-data.yml -f tag=<tag>` after pushing the tag
- `release-data.yml` gains `workflow_dispatch` trigger with `tag` input
- Both tag-push (manual) and workflow_dispatch (auto) paths remain functional
- CalVer + catalog validation runs in both cases

**Root cause:** `GITHUB_TOKEN`-created tags don't trigger `push` events for other workflows (GitHub's infinite-loop prevention). The `data-2026.5.1` tag was created but no tarball was published until manual re-push.

## Test plan
- [x] Manual verification: `data-2026.5.1` release was created after manual tag re-push
- [ ] Next data release will exercise the full auto path