### PR TITLE
chore: add .envrc for anvil-dev fabric integration

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,6 @@
+# direnv config — auto-loaded on cd. Run `direnv allow` once per checkout.
+#
+# Make this repos data dir discoverable as NUCL_PARQUET_DATA for
+# downstream consumers (hyrr, exopet) that import this venv. Sibling
+# resolution at $PWD/data is repo-local — works the same on any host.
+export NUCL_PARQUET_DATA="$PWD/data"


### PR DESCRIPTION
## Why

Lars runs Claude Code agents on `anvil-dev` (NixOS microVM, see [gerchowl/anvil](https://github.com/gerchowl/anvil) ADR-020). The fabric exports a set of env vars via PAM (`STRATA_DATA_DIR`, `SCCACHE_DIR`, `HF_HOME`, …) that every shell on vm-dev inherits — including agent subshells.

This PR adds a `.envrc` so direnv auto-loads project-specific bindings when you `cd` into the repo on vm-dev.

## What changes

Make this repos data dir discoverable as NUCL_PARQUET_DATA for downstream consumers (hyrr, exopet) that import this venv. Sibling resolution at $PWD/data is repo-local — works the same on any host.

## Activation

Run `direnv allow` once per checkout to enable. On non-anvil hosts (Mac, CI), guarded exports stay unset and code falls back to its existing defaults — zero behaviour change for non-anvil users.