### PR TITLE
feat(tcs): materialized summing_partners table (#177)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,46 @@
+# Handoff — 2026-05-15 TCS summing_partners session
+
+## Session summary
+Implemented Sub-C (#177) — materialized `summing_partners` Parquet table with
+ICC-corrected joint emission intensities for HPGe TCS corrections.
+
+### What changed
+
+**Builder** (`nucl_parquet/g4/summing_partners.py`):
+- Reads `coincidences/{Symbol}.parquet`, produces `summing_partners/{Symbol}.parquet`
+- γ-γ pairs: canonicalized (E1 ≤ E2) to dedup symmetric pairs
+- X-ray/Auger ⊗ γ pairs: ICC correction only on gamma side
+- NULL ICC → 0.0 (no internal conversion)
+- Two derived columns: `icc_correction_factor`, `pure_emission_joint_intensity`
+- 104 element files, ~9.3M rows total
+
+**Pipeline integration**:
+- `build_all.py`: added step after `mixed_coincidences`
+- `loader.py`: registered `summing_partners` view via `_register_glob`
+- `loader.py`: added `summing_partners()` Python helper function
+
+**MCP tools** (all three servers):
+- Python: `get_summing_partners(z, a, primary_energy_keV, tolerance_keV, emission1_rad_type)`
+- TypeScript: same tool via DuckDB view
+- Rust: same tool via local Parquet + arrow reader
+
+**Rust MCP fix**: `column_value_to_json` now handles dictionary-encoded strings
+via `arrow::compute::cast` fallback (was silently dropping dictionary-typed
+string columns, causing filter mismatches on summing_partners data).
+
+**Tests**:
+- Python: 7 unit tests (ICC math, NULL coalescing, canonicalization, mixed pairs, schema)
+  + 6 acceptance @data tests (Co-60, Eu-152, Tc-99m)
+- TypeScript: 2 DuckDB integration tests (Co-60 pair, Eu-152 344 keV partners)
+- Rust: 1 integration test (Co-60 via get_summing_partners tool)
+
+### Acceptance criteria verified
+- Eu-152 344 keV (Gd-152 daughter): 71 γ-γ partners (≥10 required)
+- Co-60 1173/1333 keV: icc_correction_factor ≈ 0.9997 (α < 0.001 at high energy)
+- Tc-99m 140 keV: min correction ~0.06 (highly converted M1+E2 transition)
+
+### Design decisions
+1. **Materialized Parquet, not compute-on-read**: consumers stay lean (SSoT pattern)
+2. **One table for γ-γ and X-ray ⊗ γ**: atomic de-excitation is always prompt
+   (femtoseconds), no timing edge case for HPGe
+3. **Canonical ordering**: γ-γ pairs enforce E1 ≤ E2 to eliminate symmetric duplicates

--- a/clients/py/nucl-parquet-mcp/nucl_parquet_mcp/server.py
+++ b/clients/py/nucl-parquet-mcp/nucl_parquet_mcp/server.py
@@ -354,6 +354,59 @@ async def get_coincidences(z: int, a: int | None = None, max_rows: int = 500) ->
 
 
 @mcp.tool()
+async def get_summing_partners(
+    z: int,
+    a: int,
+    primary_energy_keV: float | None = None,
+    tolerance_keV: float = 0.5,
+    emission1_rad_type: str | None = None,
+    max_rows: int = 500,
+) -> str:
+    """Get ICC-corrected summing partners for HPGe true-coincidence-summing (TCS).
+
+    Returns all emission pairs that can sum in a close-geometry HPGe detector.
+    Each row carries ``icc_correction_factor`` and ``pure_emission_joint_intensity``
+    pre-computed. Includes gamma-gamma pairs and X-ray/Auger-gamma pairs.
+
+    Args:
+        z: Atomic number of the daughter nuclide (filing convention).
+        a: Mass number.
+        primary_energy_keV: Filter to pairs matching this energy (either side).
+        tolerance_keV: Energy match tolerance in keV (default 0.5).
+        emission1_rad_type: Filter emission side 1 ('gamma', 'xray', 'auger').
+        max_rows: Maximum rows to return (default 500).
+    """
+    conditions = ["Z = $z", "A = $a"]
+    params: dict[str, Any] = {"z": z, "a": a}
+    if primary_energy_keV is not None:
+        conditions.append(
+            "(ABS(emission1_energy_keV - $energy) < $tol OR ABS(emission2_energy_keV - $energy) < $tol)"
+        )
+        params["energy"] = primary_energy_keV
+        params["tol"] = tolerance_keV
+    if emission1_rad_type is not None:
+        conditions.append("emission1_rad_type = $e1type")
+        params["e1type"] = emission1_rad_type
+    where = " AND ".join(conditions)
+    result = _query(
+        f"SELECT * FROM summing_partners WHERE {where} ORDER BY pure_emission_joint_intensity DESC",
+        params,
+        max_rows,
+    )
+    return json.dumps(
+        {
+            "z": z,
+            "a": a,
+            "primary_energy_keV": primary_energy_keV,
+            "total": result["total"],
+            "truncated": result["truncated"],
+            "rows": result["rows"],
+        },
+        indent=2,
+    )
+
+
+@mcp.tool()
 async def get_beta_spectrum(z: int, a: int, max_rows: int = 500) -> str:
     """Get the continuous beta-decay kinetic-energy spectrum for a nuclide.
 

--- a/clients/py/nucl-parquet-mcp/nucl_parquet_mcp/server.py
+++ b/clients/py/nucl-parquet-mcp/nucl_parquet_mcp/server.py
@@ -379,9 +379,7 @@ async def get_summing_partners(
     conditions = ["Z = $z", "A = $a"]
     params: dict[str, Any] = {"z": z, "a": a}
     if primary_energy_keV is not None:
-        conditions.append(
-            "(ABS(emission1_energy_keV - $energy) < $tol OR ABS(emission2_energy_keV - $energy) < $tol)"
-        )
+        conditions.append("(ABS(emission1_energy_keV - $energy) < $tol OR ABS(emission2_energy_keV - $energy) < $tol)")
         params["energy"] = primary_energy_keV
         params["tol"] = tolerance_keV
     if emission1_rad_type is not None:

--- a/clients/rs/nucl-parquet-mcp/src/main.rs
+++ b/clients/rs/nucl-parquet-mcp/src/main.rs
@@ -203,6 +203,12 @@ fn column_value_to_json(col: &dyn Array, idx: usize) -> serde_json::Value {
     } else if let Some(a) = col.as_any().downcast_ref::<StringArray>() {
         serde_json::Value::String(a.value(idx).to_string())
     } else {
+        // Fallback: try casting to Utf8 (handles dictionary-encoded strings from Parquet)
+        if let Ok(cast) = arrow::compute::cast(col, &arrow::datatypes::DataType::Utf8) {
+            if let Some(s) = cast.as_any().downcast_ref::<StringArray>() {
+                return serde_json::Value::String(s.value(idx).to_string());
+            }
+        }
         serde_json::Value::String(format!("{col:?}"))
     }
 }
@@ -353,6 +359,22 @@ fn tool_definitions() -> serde_json::Value {
                         "max_rows": { "type": "integer", "description": "Max rows (default 500)" }
                     },
                     "required": ["z"]
+                }
+            },
+            {
+                "name": "get_summing_partners",
+                "description": "Get ICC-corrected summing partners for HPGe true-coincidence-summing (TCS) corrections",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "z": { "type": "integer", "description": "Atomic number (daughter, filing convention)" },
+                        "a": { "type": "integer", "description": "Mass number" },
+                        "primary_energy_keV": { "type": "number", "description": "Filter to pairs matching this energy" },
+                        "tolerance_keV": { "type": "number", "description": "Energy tolerance (default 0.5 keV)" },
+                        "emission1_rad_type": { "type": "string", "description": "'gamma', 'xray', or 'auger'" },
+                        "max_rows": { "type": "integer", "description": "Max rows (default 500)" }
+                    },
+                    "required": ["z", "a"]
                 }
             },
             {
@@ -601,6 +623,60 @@ async fn handle_tool_call(
             let truncated = total > max_rows;
             let display: Vec<_> = filtered.into_iter().take(max_rows).collect();
             let result = serde_json::json!({ "z": z, "a": a, "symbol": symbol, "total": total, "truncated": truncated, "rows": display });
+            Ok(
+                serde_json::json!({ "content": [{ "type": "text", "text": serde_json::to_string_pretty(&result).unwrap() }] }),
+            )
+        }
+        "get_summing_partners" => {
+            let z = args
+                .get("z")
+                .and_then(|v| v.as_i64())
+                .ok_or("missing 'z'")?;
+            let a = args
+                .get("a")
+                .and_then(|v| v.as_i64())
+                .ok_or("missing 'a'")?;
+            let primary_energy = args.get("primary_energy_keV").and_then(|v| v.as_f64());
+            let tolerance = args
+                .get("tolerance_keV")
+                .and_then(|v| v.as_f64())
+                .unwrap_or(0.5);
+            let e1_type = args.get("emission1_rad_type").and_then(|v| v.as_str());
+            let max_rows = args.get("max_rows").and_then(|v| v.as_u64()).unwrap_or(500) as usize;
+            let symbol = z_to_symbol(z).ok_or_else(|| format!("Z={z} out of range"))?;
+            let path = data_dir.join(format!("meta/ensdf/summing_partners/{symbol}.parquet"));
+            let rows = load_parquet_rows(cache, &path.to_string_lossy()).await?;
+            let filtered: Vec<_> = rows
+                .into_iter()
+                .filter(|r| {
+                    if r.get("A").and_then(|v| v.as_i64()) != Some(a) {
+                        return false;
+                    }
+                    if let Some(e1t) = e1_type {
+                        if r.get("emission1_rad_type").and_then(|v| v.as_str()) != Some(e1t) {
+                            return false;
+                        }
+                    }
+                    if let Some(pe) = primary_energy {
+                        let e1 = r
+                            .get("emission1_energy_keV")
+                            .and_then(|v| v.as_f64())
+                            .unwrap_or(0.0);
+                        let e2 = r
+                            .get("emission2_energy_keV")
+                            .and_then(|v| v.as_f64())
+                            .unwrap_or(0.0);
+                        if (e1 - pe).abs() >= tolerance && (e2 - pe).abs() >= tolerance {
+                            return false;
+                        }
+                    }
+                    true
+                })
+                .collect();
+            let total = filtered.len();
+            let truncated = total > max_rows;
+            let display: Vec<_> = filtered.into_iter().take(max_rows).collect();
+            let result = serde_json::json!({ "z": z, "a": a, "primary_energy_keV": primary_energy, "total": total, "truncated": truncated, "rows": display });
             Ok(
                 serde_json::json!({ "content": [{ "type": "text", "text": serde_json::to_string_pretty(&result).unwrap() }] }),
             )
@@ -863,7 +939,7 @@ mod tests {
     fn tool_definitions_valid() {
         let defs = tool_definitions();
         let tools = defs.get("tools").unwrap().as_array().unwrap();
-        assert_eq!(tools.len(), 11);
+        assert_eq!(tools.len(), 12);
         for tool in tools {
             assert!(tool.get("name").is_some());
             assert!(tool.get("description").is_some());
@@ -940,7 +1016,7 @@ mod tests {
             .unwrap();
         let result = resp.result.unwrap();
         let tools = result["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 11);
+        assert_eq!(tools.len(), 12);
     }
 
     #[tokio::test]
@@ -1003,6 +1079,37 @@ mod tests {
         let text = content["content"][0]["text"].as_str().unwrap();
         // Co-60 has at least ground state + isomer
         assert!(text.contains("\"count\":"));
+    }
+
+    #[tokio::test]
+    async fn handle_get_summing_partners() {
+        let data_dir = test_data_dir();
+        let catalog = load_catalog(&data_dir).unwrap();
+        let cache: Cache = Arc::new(Mutex::new(HashMap::new()));
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".into(),
+            id: Some(serde_json::json!(1)),
+            method: "tools/call".into(),
+            params: serde_json::json!({
+                "name": "get_summing_partners",
+                "arguments": { "z": 28, "a": 60, "emission1_rad_type": "gamma" }
+            }),
+        };
+        let resp = handle_request(&data_dir, &catalog, &cache, req)
+            .await
+            .unwrap();
+        assert!(resp.error.is_none());
+        let content = resp.result.unwrap();
+        let text = content["content"][0]["text"].as_str().unwrap();
+        // Co-60 → Ni-60: should have the 1173/1333 keV pair
+        assert!(text.contains("\"z\": 28"));
+        assert!(text.contains("\"a\": 60"));
+        let parsed: serde_json::Value = serde_json::from_str(text).unwrap();
+        let total = parsed["total"].as_u64().unwrap();
+        assert!(
+            total >= 1,
+            "Expected ≥1 Co-60 summing partners, got {total}"
+        );
     }
 
     #[tokio::test]

--- a/clients/ts/nucl-parquet-mcp/src/index.ts
+++ b/clients/ts/nucl-parquet-mcp/src/index.ts
@@ -147,6 +147,7 @@ function registerViews(db: duckdb.Database, dataDir: string): void {
   registerGlob(db, join(dataDir, "meta", "ensdf", "levels"), "ensdf_levels");
   registerGlob(db, join(dataDir, "meta", "ensdf", "radiation"), "radiation");
   registerGlob(db, join(dataDir, "meta", "ensdf", "coincidences"), "coincidences");
+  registerGlob(db, join(dataDir, "meta", "ensdf", "summing_partners"), "summing_partners");
   registerGlob(db, join(dataDir, "meta", "ensdf", "beta_spectra"), "beta_spectra");
 
   // --- NUDEX data ---
@@ -551,6 +552,45 @@ server.tool(
       content: [{
         type: "text" as const,
         text: safeStringify({ z: zNum, a: aNum, ...result }, 2),
+      }],
+    };
+  },
+);
+
+server.tool(
+  "get_summing_partners",
+  "Get ICC-corrected summing partners for HPGe true-coincidence-summing (TCS) corrections. Returns emission pairs with pre-computed icc_correction_factor and pure_emission_joint_intensity.",
+  {
+    z: z.number().describe("Atomic number of the daughter nuclide (filing convention)"),
+    a: z.number().describe("Mass number"),
+    primary_energy_keV: z.number().optional().describe("Filter to pairs matching this energy on either side"),
+    tolerance_keV: z.number().optional().describe("Energy match tolerance in keV (default 0.5)"),
+    emission1_rad_type: z.string().optional().describe("Filter side 1: 'gamma', 'xray', 'auger'"),
+    max_rows: z.number().optional().describe("Max rows to return (default 500)"),
+  },
+  async ({ z: zNum, a: aNum, primary_energy_keV, tolerance_keV, emission1_rad_type, max_rows }) => {
+    const conditions = ["Z = ?", "A = ?"];
+    const params: unknown[] = [zNum, aNum];
+    const tol = tolerance_keV ?? 0.5;
+
+    if (primary_energy_keV !== undefined) {
+      conditions.push("(ABS(emission1_energy_keV - ?) < ? OR ABS(emission2_energy_keV - ?) < ?)");
+      params.push(primary_energy_keV, tol, primary_energy_keV, tol);
+    }
+    if (emission1_rad_type !== undefined) {
+      conditions.push("emission1_rad_type = ?");
+      params.push(emission1_rad_type);
+    }
+
+    const result = await query(
+      `SELECT * FROM summing_partners WHERE ${conditions.join(" AND ")} ORDER BY pure_emission_joint_intensity DESC`,
+      params,
+      max_rows ?? 500,
+    );
+    return {
+      content: [{
+        type: "text" as const,
+        text: safeStringify({ z: zNum, a: aNum, primary_energy_keV, ...result }, 2),
       }],
     };
   },

--- a/clients/ts/nucl-parquet-mcp/test/server.test.ts
+++ b/clients/ts/nucl-parquet-mcp/test/server.test.ts
@@ -155,6 +155,42 @@ describe("DuckDB", () => {
     expect((rows[0].n as number)).toBeGreaterThan(0);
   });
 
+  it("queries summing partners for Co-60 (Z=28, A=60)", async () => {
+    const db = getDb();
+    const rows = await new Promise<Record<string, unknown>[]>((resolve, reject) => {
+      db.all(
+        "SELECT * FROM summing_partners WHERE Z = 28 AND A = 60 AND emission1_rad_type = 'gamma'",
+        (err: Error | null, rows: Record<string, unknown>[]) => {
+          if (err) reject(err); else resolve(rows);
+        },
+      );
+    });
+    expect(rows.length).toBeGreaterThan(0);
+    // Check 1173/1333 keV pair exists (canonicalized: E1 ≤ E2)
+    const pair = rows.find(
+      (r) =>
+        Math.abs((r.emission1_energy_keV as number) - 1173.2) < 1.0 &&
+        Math.abs((r.emission2_energy_keV as number) - 1332.5) < 1.0,
+    );
+    expect(pair).toBeDefined();
+    expect(pair!.icc_correction_factor as number).toBeGreaterThan(0.99);
+  });
+
+  it("queries summing partners for Eu-152 (Gd-152 daughter, Z=64)", async () => {
+    const db = getDb();
+    const rows = await new Promise<Record<string, unknown>[]>((resolve, reject) => {
+      db.all(
+        `SELECT * FROM summing_partners WHERE Z = 64 AND A = 152
+         AND emission1_rad_type = 'gamma'
+         AND (ABS(emission1_energy_keV - 344.28) < 1.0 OR ABS(emission2_energy_keV - 344.28) < 1.0)`,
+        (err: Error | null, rows: Record<string, unknown>[]) => {
+          if (err) reject(err); else resolve(rows);
+        },
+      );
+    });
+    expect(rows.length).toBeGreaterThanOrEqual(10);
+  });
+
   it("has 20+ registered tables/views", async () => {
     const db = getDb();
     const tables = await new Promise<Record<string, unknown>[]>((resolve, reject) => {

--- a/data/catalog.json
+++ b/data/catalog.json
@@ -239,7 +239,7 @@
       "name": "Geant4-derived nuclear structure + EM (via strata-data)",
       "description": "G4ENSDFSTATE3.0 + PhotonEvaporation6.1.2 + RadioactiveDecay6.1.2 republished as Parquet by the strata project — source for nuclides.parquet / ground_states.parquet / levels/ / radiation/ / decay.parquet from v0.11.0 onward (replaces the v0.10.x IAEA-LiveChart pipeline). v0.13+ also pulls the em/ subdir for ESTAR + Sternheimer density-effect data (issue #121). See ADR-0002.",
       "source_url": "https://huggingface.co/datasets/gerchowl/strata-data",
-      "revision": "ae6bc9751058e1e5d95982c78f2ee5b08093433d",
+      "revision": "e4ac11f7d4d60f235cf26286d6d0e87f86e3e3ad",
       "fetcher": "scripts/fetch_strata_nuclear.py",
       "data_type": "nuclear_structure_and_em",
       "files": [

--- a/nucl_parquet/g4/build_all.py
+++ b/nucl_parquet/g4/build_all.py
@@ -56,6 +56,7 @@ from nucl_parquet.g4 import (
     photon_evap_gammas,
     photon_evap_levels,
     radioactive_decay,
+    summing_partners,
     xray_auger,
 )
 
@@ -331,6 +332,16 @@ def build_all(data_dir: Path | None = None, *, skip_converters: bool = False, me
         data_dir / "meta" / "ensdf" / "radiation",
         data_dir / "meta" / "ensdf" / "coincidences",
     )
+
+    # Materialize summing_partners/ from augmented coincidences/ — ICC-corrected
+    # pairs for HPGe TCS corrections. Runs after mixed_coincidences so both γ-γ
+    # and X-ray/Auger ⊗ γ pairs are present. Per issue #177.
+    logger.info("[summing] materialize summing_partners/ from coincidences/ (#177)")
+    sp_paths = summing_partners.build(
+        data_dir / "meta" / "ensdf" / "coincidences",
+        data_dir / "meta" / "ensdf" / "summing_partners",
+    )
+    logger.info("wrote %d summing-partner files", len(sp_paths))
 
     logger.info("[invariants] sweeping the rebuilt dataset")
     _check_invariants(data_dir)

--- a/nucl_parquet/g4/photon_evap_gammas.py
+++ b/nucl_parquet/g4/photon_evap_gammas.py
@@ -11,7 +11,9 @@ Input schema (strata)
 
     z UInt8, a UInt16, parent_level UInt16, daughter_level UInt16,
     gamma_energy_kev Float64, intensity Float32, multipolarity UInt16,
-    mixing_ratio Float32, icc_total Float32
+    mixing_ratio Float32, icc_total Float32,
+    icc_frac_K Float32, icc_frac_L1..L3 Float32, icc_frac_M1..M5 Float32,
+    icc_frac_outer Float32  (nullable; present when icc_total > 0)
 
 Output schema (per element ``meta/ensdf/radiation/{Symbol}.parquet``)
 ---------------------------------------------------------------------
@@ -289,6 +291,14 @@ def transform(
         pl.col("multipolarity").cast(pl.Int32),
         pl.col("mixing_ratio").cast(pl.Float32),
         pl.col("icc_total").cast(pl.Float32),
+        # Per-shell ICC fractions (BrIcc-precomputed in PhotonEvaporation6.1.2).
+        # Nullable Float32; present when icc_total > 0. Consumed by xray_auger.py
+        # to partition IC vacancies across atomic shells (#193).
+        *[pl.col(c).cast(pl.Float32) for c in [
+            "icc_frac_K", "icc_frac_L1", "icc_frac_L2", "icc_frac_L3",
+            "icc_frac_M1", "icc_frac_M2", "icc_frac_M3", "icc_frac_M4",
+            "icc_frac_M5", "icc_frac_outer",
+        ] if c in with_state.columns],
     ).sort(["Z", "A", "parent_level_keV", "energy_keV"])
 
 

--- a/nucl_parquet/g4/photon_evap_gammas.py
+++ b/nucl_parquet/g4/photon_evap_gammas.py
@@ -294,11 +294,22 @@ def transform(
         # Per-shell ICC fractions (BrIcc-precomputed in PhotonEvaporation6.1.2).
         # Nullable Float32; present when icc_total > 0. Consumed by xray_auger.py
         # to partition IC vacancies across atomic shells (#193).
-        *[pl.col(c).cast(pl.Float32) for c in [
-            "icc_frac_K", "icc_frac_L1", "icc_frac_L2", "icc_frac_L3",
-            "icc_frac_M1", "icc_frac_M2", "icc_frac_M3", "icc_frac_M4",
-            "icc_frac_M5", "icc_frac_outer",
-        ] if c in with_state.columns],
+        *[
+            pl.col(c).cast(pl.Float32)
+            for c in [
+                "icc_frac_K",
+                "icc_frac_L1",
+                "icc_frac_L2",
+                "icc_frac_L3",
+                "icc_frac_M1",
+                "icc_frac_M2",
+                "icc_frac_M3",
+                "icc_frac_M4",
+                "icc_frac_M5",
+                "icc_frac_outer",
+            ]
+            if c in with_state.columns
+        ],
     ).sort(["Z", "A", "parent_level_keV", "energy_keV"])
 
 

--- a/nucl_parquet/g4/summing_partners.py
+++ b/nucl_parquet/g4/summing_partners.py
@@ -93,10 +93,7 @@ _OUTPUT_COLUMNS = [
 
 def _build_gamma_gamma(coinc: pl.DataFrame) -> pl.DataFrame:
     """Extract γ-γ pairs, canonicalize (E1 ≤ E2), compute ICC correction."""
-    gg = coinc.filter(
-        (pl.col("emission1_rad_type") == "gamma")
-        & (pl.col("emission2_rad_type") == "gamma")
-    )
+    gg = coinc.filter((pl.col("emission1_rad_type") == "gamma") & (pl.col("emission2_rad_type") == "gamma"))
     if gg.is_empty():
         return _empty_output()
 
@@ -172,8 +169,7 @@ def _build_gamma_gamma(coinc: pl.DataFrame) -> pl.DataFrame:
 def _build_mixed(coinc: pl.DataFrame) -> pl.DataFrame:
     """Extract X-ray/Auger ⊗ γ pairs, compute ICC correction (gamma side only)."""
     mixed = coinc.filter(
-        pl.col("emission1_rad_type").is_in(["xray", "auger"])
-        & (pl.col("emission2_rad_type") == "gamma")
+        pl.col("emission1_rad_type").is_in(["xray", "auger"]) & (pl.col("emission2_rad_type") == "gamma")
     )
     if mixed.is_empty():
         return _empty_output()

--- a/nucl_parquet/g4/summing_partners.py
+++ b/nucl_parquet/g4/summing_partners.py
@@ -132,10 +132,11 @@ def _build_gamma_gamma(coinc: pl.DataFrame) -> pl.DataFrame:
         .alias("emission2_icc_total"),
     )
 
-    # Deduplicate after canonicalization — same (Z, A, E1, E2, parent_level)
-    # should appear once.
+    # Deduplicate after canonicalization — same (Z, A, state, E1, E2, parent_level)
+    # should appear once. Include parent_state so ground-state and metastable
+    # decay channels feeding the same cascade aren't collapsed.
     gg = gg.unique(
-        subset=["Z", "A", "emission1_energy_keV", "emission2_energy_keV", "parent_level_keV"],
+        subset=["Z", "A", "parent_state", "emission1_energy_keV", "emission2_energy_keV", "parent_level_keV"],
         keep="first",
     )
 

--- a/nucl_parquet/g4/summing_partners.py
+++ b/nucl_parquet/g4/summing_partners.py
@@ -1,0 +1,343 @@
+"""Derive ``meta/ensdf/summing_partners/{Symbol}.parquet`` — ICC-corrected
+coincidence pairs for HPGe true-coincidence-summing (TCS) corrections.
+
+Per issue #177 / epic #173 Sub-C.
+
+Each output row is one **summing partner pair** — two emissions from the same
+parent decay event that can arrive simultaneously at an HPGe detector:
+
+- **γ-γ pairs**: two nuclear gammas from a cascade, with ``icc_correction_factor``
+  folding both sides' internal conversion coefficients.
+- **X-ray/Auger ⊗ γ pairs**: atomic emission (from EC/IC vacancy) coincident with
+  a nuclear gamma.  ICC correction applies only to the gamma side; atomic
+  transitions have no ICC.
+
+The table is materialized from ``coincidences/{Symbol}.parquet`` (already built
+by :mod:`nucl_parquet.g4.coincidences` + :mod:`nucl_parquet.g4.mixed_coincidences`)
+with two derived columns:
+
+- ``icc_correction_factor``: product of ``1 / (1 + α)`` per gamma-typed emission
+  side (NULL α treated as 0 = no internal conversion).
+- ``pure_emission_joint_intensity``: ``pair_intensity × icc_correction_factor``.
+
+γ-γ pairs are **canonicalized**: ``emission1_energy_keV ≤ emission2_energy_keV``
+to eliminate symmetric duplicates (Co-60 1173/1333 appears once, not twice).
+Mixed pairs are inherently asymmetric (X-ray/Auger on side 1, gamma on side 2)
+so no dedup is needed.
+
+Schema (output, per element ``meta/ensdf/summing_partners/{Symbol}.parquet``)
+-----------------------------------------------------------------------------
+
+    Z                            Int64    — daughter nucleus (filing convention)
+    A                            Int64
+    parent_state                 Utf8     — '' | 'm' | 'm2'
+    parent_decay_mode            Utf8     — 'beta-' | 'beta+' | 'KshellEC' | ...
+    emission1_rad_type           Utf8     — 'gamma' | 'xray' | 'auger'
+    emission1_energy_keV         Float64
+    emission1_intensity          Float32
+    emission1_icc_total          Float32  — NULL for X-ray/Auger (no ICC)
+    emission1_shell              Utf8     — 'K'|'L'|'M'|'N' for X-ray/Auger; NULL for gamma
+    emission2_rad_type           Utf8     — always 'gamma' in current build
+    emission2_energy_keV         Float64
+    emission2_intensity          Float32
+    emission2_icc_total          Float32
+    emission2_shell              Utf8     — NULL (always for gamma)
+    parent_level_keV             Float64
+    intermediate_level_keV       Float64
+    final_level_keV              Float64
+    pair_intensity               Float32  — raw from coincidences
+    icc_correction_factor        Float32  — 1/((1+α₁)(1+α₂)) for γ-γ; 1/(1+α₂) for xray⊗γ
+    pure_emission_joint_intensity Float32 — pair_intensity × icc_correction_factor
+
+Usage::
+
+    uv run python -m nucl_parquet.g4.summing_partners
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+
+import polars as pl
+
+from nucl_parquet.g4.photon_evap_levels import Z_TO_SYMBOL
+
+logger = logging.getLogger(__name__)
+
+# Output column order — stable across all elements.
+_OUTPUT_COLUMNS = [
+    "Z",
+    "A",
+    "parent_state",
+    "parent_decay_mode",
+    "emission1_rad_type",
+    "emission1_energy_keV",
+    "emission1_intensity",
+    "emission1_icc_total",
+    "emission1_shell",
+    "emission2_rad_type",
+    "emission2_energy_keV",
+    "emission2_intensity",
+    "emission2_icc_total",
+    "emission2_shell",
+    "parent_level_keV",
+    "intermediate_level_keV",
+    "final_level_keV",
+    "pair_intensity",
+    "icc_correction_factor",
+    "pure_emission_joint_intensity",
+]
+
+
+def _build_gamma_gamma(coinc: pl.DataFrame) -> pl.DataFrame:
+    """Extract γ-γ pairs, canonicalize (E1 ≤ E2), compute ICC correction."""
+    gg = coinc.filter(
+        (pl.col("emission1_rad_type") == "gamma")
+        & (pl.col("emission2_rad_type") == "gamma")
+    )
+    if gg.is_empty():
+        return _empty_output()
+
+    # Canonicalize: enforce emission1_energy ≤ emission2_energy.
+    # Swap sides where γ1 > γ2 so each pair appears exactly once.
+    needs_swap = pl.col("gamma1_energy_keV") > pl.col("gamma2_energy_keV")
+
+    gg = gg.with_columns(
+        # After swap: e1 is the lower-energy gamma, e2 the higher.
+        pl.when(needs_swap)
+        .then(pl.col("gamma2_energy_keV"))
+        .otherwise(pl.col("gamma1_energy_keV"))
+        .alias("emission1_energy_keV"),
+        pl.when(needs_swap)
+        .then(pl.col("gamma2_intensity"))
+        .otherwise(pl.col("gamma1_intensity"))
+        .alias("emission1_intensity"),
+        pl.when(needs_swap)
+        .then(pl.col("gamma2_icc_total"))
+        .otherwise(pl.col("gamma1_icc_total"))
+        .alias("emission1_icc_total"),
+        pl.when(needs_swap)
+        .then(pl.col("gamma1_energy_keV"))
+        .otherwise(pl.col("gamma2_energy_keV"))
+        .alias("emission2_energy_keV"),
+        pl.when(needs_swap)
+        .then(pl.col("gamma1_intensity"))
+        .otherwise(pl.col("gamma2_intensity"))
+        .alias("emission2_intensity"),
+        pl.when(needs_swap)
+        .then(pl.col("gamma1_icc_total"))
+        .otherwise(pl.col("gamma2_icc_total"))
+        .alias("emission2_icc_total"),
+    )
+
+    # Deduplicate after canonicalization — same (Z, A, E1, E2, parent_level)
+    # should appear once.
+    gg = gg.unique(
+        subset=["Z", "A", "emission1_energy_keV", "emission2_energy_keV", "parent_level_keV"],
+        keep="first",
+    )
+
+    # ICC correction: 1 / ((1 + α₁) × (1 + α₂)), NULL → 0.
+    alpha1 = pl.col("emission1_icc_total").fill_null(0.0).cast(pl.Float64)
+    alpha2 = pl.col("emission2_icc_total").fill_null(0.0).cast(pl.Float64)
+    icc_corr = (1.0 / ((1.0 + alpha1) * (1.0 + alpha2))).cast(pl.Float32)
+
+    return gg.select(
+        pl.col("Z"),
+        pl.col("A"),
+        pl.col("parent_state").fill_null(""),
+        pl.col("parent_decay_mode"),
+        pl.lit("gamma").alias("emission1_rad_type"),
+        pl.col("emission1_energy_keV"),
+        pl.col("emission1_intensity"),
+        pl.col("emission1_icc_total"),
+        pl.lit(None, dtype=pl.Utf8).alias("emission1_shell"),
+        pl.lit("gamma").alias("emission2_rad_type"),
+        pl.col("emission2_energy_keV"),
+        pl.col("emission2_intensity"),
+        pl.col("emission2_icc_total"),
+        pl.lit(None, dtype=pl.Utf8).alias("emission2_shell"),
+        pl.col("parent_level_keV"),
+        pl.col("intermediate_level_keV"),
+        pl.col("final_level_keV"),
+        pl.col("pair_intensity"),
+        icc_corr.alias("icc_correction_factor"),
+        (pl.col("pair_intensity").cast(pl.Float64) * icc_corr).cast(pl.Float32).alias("pure_emission_joint_intensity"),
+    )
+
+
+def _build_mixed(coinc: pl.DataFrame) -> pl.DataFrame:
+    """Extract X-ray/Auger ⊗ γ pairs, compute ICC correction (gamma side only)."""
+    mixed = coinc.filter(
+        pl.col("emission1_rad_type").is_in(["xray", "auger"])
+        & (pl.col("emission2_rad_type") == "gamma")
+    )
+    if mixed.is_empty():
+        return _empty_output()
+
+    # ICC correction: only on the gamma side (emission2). X-ray/Auger has no ICC.
+    alpha2 = pl.col("gamma2_icc_total").fill_null(0.0).cast(pl.Float64)
+    icc_corr = (1.0 / (1.0 + alpha2)).cast(pl.Float32)
+
+    return mixed.select(
+        pl.col("Z"),
+        pl.col("A"),
+        pl.col("parent_state").fill_null(""),
+        pl.col("parent_decay_mode"),
+        pl.col("emission1_rad_type"),
+        pl.col("emission1_energy_keV"),
+        pl.col("emission1_intensity"),
+        pl.lit(None, dtype=pl.Float32).alias("emission1_icc_total"),
+        pl.col("emission1_shell"),
+        pl.col("emission2_rad_type"),
+        pl.col("emission2_energy_keV"),
+        pl.col("emission2_intensity"),
+        pl.col("gamma2_icc_total").alias("emission2_icc_total"),
+        pl.col("emission2_shell"),
+        pl.col("parent_level_keV"),
+        pl.col("intermediate_level_keV"),
+        pl.col("final_level_keV"),
+        pl.col("pair_intensity"),
+        icc_corr.alias("icc_correction_factor"),
+        (pl.col("pair_intensity").cast(pl.Float64) * icc_corr).cast(pl.Float32).alias("pure_emission_joint_intensity"),
+    )
+
+
+def _empty_output() -> pl.DataFrame:
+    """Empty DataFrame with the full output schema."""
+    return pl.DataFrame(
+        schema={
+            "Z": pl.Int64,
+            "A": pl.Int64,
+            "parent_state": pl.Utf8,
+            "parent_decay_mode": pl.Utf8,
+            "emission1_rad_type": pl.Utf8,
+            "emission1_energy_keV": pl.Float64,
+            "emission1_intensity": pl.Float32,
+            "emission1_icc_total": pl.Float32,
+            "emission1_shell": pl.Utf8,
+            "emission2_rad_type": pl.Utf8,
+            "emission2_energy_keV": pl.Float64,
+            "emission2_intensity": pl.Float32,
+            "emission2_icc_total": pl.Float32,
+            "emission2_shell": pl.Utf8,
+            "parent_level_keV": pl.Float64,
+            "intermediate_level_keV": pl.Float64,
+            "final_level_keV": pl.Float64,
+            "pair_intensity": pl.Float32,
+            "icc_correction_factor": pl.Float32,
+            "pure_emission_joint_intensity": pl.Float32,
+        }
+    )
+
+
+def build_for_element(coinc: pl.DataFrame) -> pl.DataFrame:
+    """Build summing partner rows for a single element's coincidences.
+
+    Parameters
+    ----------
+    coinc
+        All rows from ``coincidences/{Symbol}.parquet`` for one element.
+
+    Returns
+    -------
+    DataFrame in the output schema, sorted for stable output.
+    """
+    gg = _build_gamma_gamma(coinc)
+    mixed = _build_mixed(coinc)
+
+    if gg.is_empty() and mixed.is_empty():
+        return _empty_output()
+
+    frames = [f for f in [gg, mixed] if not f.is_empty()]
+    result = pl.concat(frames, how="vertical_relaxed") if len(frames) > 1 else frames[0]
+
+    return result.select(_OUTPUT_COLUMNS).sort(
+        ["Z", "A", "parent_state", "emission1_rad_type", "emission1_energy_keV", "emission2_energy_keV"],
+        nulls_last=True,
+    )
+
+
+def build(coincidences_dir: Path, out_dir: Path) -> list[Path]:
+    """End-to-end: read coincidences, build summing partners, write per-element.
+
+    Parameters
+    ----------
+    coincidences_dir
+        Directory containing ``{Symbol}.parquet`` coincidence files (output of
+        :mod:`nucl_parquet.g4.coincidences` + :mod:`nucl_parquet.g4.mixed_coincidences`).
+    out_dir
+        Directory to write ``{Symbol}.parquet`` summing partner files into.
+    """
+    if not coincidences_dir.exists():
+        raise FileNotFoundError(f"coincidences directory not found at {coincidences_dir}")
+
+    coinc_paths = sorted(coincidences_dir.glob("*.parquet"))
+    if not coinc_paths:
+        raise FileNotFoundError(f"No coincidence parquet files in {coincidences_dir}")
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    symbol_to_z = {sym: z for z, sym in Z_TO_SYMBOL.items()}
+
+    written: list[Path] = []
+    total_rows = 0
+    for p in coinc_paths:
+        symbol = p.stem
+        z = symbol_to_z.get(symbol)
+        if z is None:
+            logger.warning("skipping %s: no Z mapping for symbol %s", p.name, symbol)
+            continue
+
+        coinc = pl.read_parquet(p)
+        result = build_for_element(coinc)
+
+        if result.is_empty():
+            logger.debug("[%s] Z=%d: no summing partners", symbol, z)
+            continue
+
+        out_path = out_dir / f"{symbol}.parquet"
+        out_path.unlink(missing_ok=True)
+        result.write_parquet(out_path, compression="zstd")
+        written.append(out_path)
+        total_rows += result.height
+        logger.info("[%s] Z=%d: %d summing partners", symbol, z, result.height)
+
+    logger.info(
+        "Wrote %d per-element summing-partner files (%d rows total) to %s",
+        len(written),
+        total_rows,
+        out_dir,
+    )
+    return written
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", maxsplit=1)[0])
+    repo_root = Path(__file__).resolve().parents[2]
+    meta = repo_root / "data" / "meta" / "ensdf"
+    parser.add_argument(
+        "--coincidences-dir",
+        type=Path,
+        default=meta / "coincidences",
+        help="Directory with coincidence parquet files (input).",
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=meta / "summing_partners",
+        help="Directory to write summing partner parquet files into.",
+    )
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s: %(message)s",
+    )
+    build(args.coincidences_dir, args.out_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/nucl_parquet/g4/xray_auger.py
+++ b/nucl_parquet/g4/xray_auger.py
@@ -419,10 +419,7 @@ def compute_ic_vacancy_rates(
         pl.col("icc_total").cast(pl.Float64),
     ]
     if has_per_shell_icc:
-        gamma_cols.extend(
-            pl.col(c).cast(pl.Float64) for c in _ICC_FRAC_COLS
-            if c in photon_evap_gammas.columns
-        )
+        gamma_cols.extend(pl.col(c).cast(pl.Float64) for c in _ICC_FRAC_COLS if c in photon_evap_gammas.columns)
     gammas = photon_evap_gammas.select(gamma_cols)
 
     # For each isomer parent, propagate cascade populations from the isomer

--- a/nucl_parquet/g4/xray_auger.py
+++ b/nucl_parquet/g4/xray_auger.py
@@ -13,9 +13,11 @@ This module convolves three independent inputs into a per-(Z, A, state)
    ``{KshellEC, LshellEC, MshellEC, NshellEC}`` carrying per-shell ``branching``
    summed across daughter levels.
 
-3. **Internal-conversion totals** (``data/g4_raw/strata-nuclear/photon_evap_gammas.parquet``):
-   ``icc_total`` per gamma transition; we approximate per-shell IC vacancies
-   as **K-shell only** (per-shell partial ICCs absent from strata).
+3. **Internal-conversion coefficients** (``data/g4_raw/strata-nuclear/photon_evap_gammas.parquet``):
+   ``icc_total`` per gamma transition plus per-shell fractions
+   ``icc_frac_K, icc_frac_L1..L3, icc_frac_M1..M5, icc_frac_outer``
+   (BrIcc-precomputed, embedded in G4 PhotonEvaporation6.1.2).
+   IC vacancies are partitioned across shells using these fractions.
 
 Output schema (matches ``radiation/`` v0.10.x columns + new optional ones):
     Z, A, state, rad_type, energy_keV, intensity_pct,
@@ -135,13 +137,31 @@ _XRAY_LABEL: Final[dict[tuple[str, str], str]] = {
     ("M5", "N7"): "Mα1",
 }
 
-# v0.11 approximation: EC L/M/N totals attributed to L1/M1/N1 vacancies for
-# atomic-relaxation lookup. (Sub-shell branchings absent from strata input.)
+# EC shell-letter to EADL sub-shell mapping. EC branchings from
+# decay_detailed use shell-letter labels (K, L, M, N); EADL indexes by
+# sub-shell. EC L/M/N totals are attributed to L1/M1/N1 (the dominant
+# sub-shell for EC capture at most Z).
 _SHELL_TOTAL_TO_VACANCY: Final[dict[str, str]] = {
     "K": "K",
     "L": "L1",
     "M": "M1",
     "N": "N1",
+}
+
+# Per-shell ICC fraction columns exported by strata's PhotonEvaporation
+# parser (BrIcc-precomputed, G4 columns 7-16). Maps column name → EADL
+# vacancy sub-shell label.
+_ICC_FRAC_COLS: Final[dict[str, str]] = {
+    "icc_frac_K": "K",
+    "icc_frac_L1": "L1",
+    "icc_frac_L2": "L2",
+    "icc_frac_L3": "L3",
+    "icc_frac_M1": "M1",
+    "icc_frac_M2": "M2",
+    "icc_frac_M3": "M3",
+    "icc_frac_M4": "M4",
+    "icc_frac_M5": "M5",
+    "icc_frac_outer": "O1",  # "outer" lumps O+P+Q; attribute to O1 (largest)
 }
 
 
@@ -326,37 +346,27 @@ def compute_ic_vacancy_rates(
     parent_states: pl.DataFrame,
     k_edges: dict[int, float] | None = None,
 ) -> pl.DataFrame:
-    """Approximate per-(Z, A, state) IC vacancy rates (K-shell only).
+    """Compute per-(Z, A, state) IC vacancy rates, partitioned by shell.
 
-    Restricted to **the depopulating gammas of the isomer level itself** —
-    we don't propagate cascade populations through subsequent levels. This
-    is a v0.11.x simplification (see design memo §"Known gaps"):
-
-    - Avoids over-counting K vacancies when the same lower level appears in
-      many cascade paths under the isomer.
-    - Captures the dominant IC for canonical isomers when the level the
-      strata catalog matches as ``parent_ex_kev`` is the depopulating one.
-    - For ground-state EC parents, IC of post-EC daughter gammas is not
-      yet folded in (see design memo §"Known gaps", item 4).
-
-    The yield is computed as
-    ``Σ_g (intensity_g / 100) × icc_g / (1 + icc_g)``
-    over all gammas whose ``parent_level`` equals the isomer's level_idx
-    (resolved by ±1 keV match against ``photon_evap_levels``). Cascade
-    propagation (a daughter level emitting its own IC-converted gamma) is
-    intentionally skipped — that path is a v0.12 follow-up.
+    When the strata gamma table carries per-shell ICC fractions
+    (``icc_frac_K``, ``icc_frac_L1``, …), IC vacancies are distributed
+    across all contributing sub-shells. Falls back to K-shell only when
+    the per-shell columns are absent (pre-v0.12 strata data).
 
     Args:
         photon_evap_gammas: Strata's gamma table (z, a, parent_level,
-            daughter_level, gamma_energy_kev, intensity, icc_total, …).
+            daughter_level, gamma_energy_kev, intensity, icc_total,
+            icc_frac_K, icc_frac_L1..L3, icc_frac_M1..M5, icc_frac_outer).
         photon_evap_levels: Strata's level table (z, a, level_idx,
             excitation_kev, half_life_s, …).
         parent_states: DataFrame of (Z, A, state, parent_ex_kev) for the
             parents we want IC vacancies for.
 
     Returns:
-        DataFrame: (Z, A, parent_ex_kev, daughter_Z, shell='K', vacancy_rate).
+        DataFrame: (Z, A, parent_ex_kev, daughter_Z, shell, vacancy_rate).
         Daughter Z = parent Z (IC happens in same atom).
+        ``shell`` is a sub-shell label (K, L1, L2, …) when per-shell data
+        is available, or ``'K'`` as fallback.
     """
     empty_schema = {
         "Z": pl.Int32,
@@ -397,7 +407,9 @@ def compute_ic_vacancy_rates(
         .agg(pl.col("level_idx").first())
     )
 
-    gammas = photon_evap_gammas.select(
+    # Detect per-shell ICC fraction columns (present in strata >= v0.12).
+    has_per_shell_icc = "icc_frac_K" in photon_evap_gammas.columns
+    gamma_cols = [
         pl.col("z").cast(pl.Int32).alias("Z"),
         pl.col("a").cast(pl.Int32).alias("A"),
         pl.col("parent_level").alias("level_idx"),
@@ -405,10 +417,16 @@ def compute_ic_vacancy_rates(
         pl.col("gamma_energy_kev").cast(pl.Float64),
         pl.col("intensity").cast(pl.Float64),
         pl.col("icc_total").cast(pl.Float64),
-    )
+    ]
+    if has_per_shell_icc:
+        gamma_cols.extend(
+            pl.col(c).cast(pl.Float64) for c in _ICC_FRAC_COLS
+            if c in photon_evap_gammas.columns
+        )
+    gammas = photon_evap_gammas.select(gamma_cols)
 
     # For each isomer parent, propagate cascade populations from the isomer
-    # level down through the gamma scheme, summing K-shell IC vacancies
+    # level down through the gamma scheme, summing per-shell IC vacancies
     # over each transition. This captures the canonical Tc-99m physics:
     # the *level-1 → ground* 140.5 keV transition (populated via the
     # 2.17 keV depopulating gamma of the isomer) is the dominant
@@ -436,33 +454,46 @@ def compute_ic_vacancy_rates(
             (pl.col("__trans_rate") / pl.col("__trans_rate").sum().over(["level_idx"])).alias("transition_frac"),
         )
 
-        v_k = 0.0
+        # Accumulate per-shell vacancies.
+        vacancies: dict[str, float] = {}  # shell_label → vacancy_rate
         for g in gammas_za.iter_rows(named=True):
             src = int(g["level_idx"])
             src_pop = populations.get(src, 0.0)
             if src_pop <= 0.0:
                 continue
-            energy = float(g["gamma_energy_kev"])
-            if k_edge is not None and energy < k_edge:
-                continue
             icc = float(g["icc_total"])
+            if icc <= 0.0:
+                continue
             t_frac = float(g["transition_frac"])
-            ic_frac = icc / (1.0 + icc) if (1.0 + icc) > 0 else 0.0
-            v_k += src_pop * t_frac * ic_frac
+            ic_frac = icc / (1.0 + icc)
+            ic_contrib = src_pop * t_frac * ic_frac
 
-        if v_k <= 0.0:
-            continue
-        # Cap at 1.0: physical bound is one K vacancy per parent decay.
-        out_rows.append(
-            {
-                "Z": z,
-                "A": a,
-                "parent_ex_kev": parent_ex_kev,
-                "daughter_Z": z,
-                "shell": "K",
-                "vacancy_rate": min(v_k, 1.0),
-            }
-        )
+            if has_per_shell_icc and g.get("icc_frac_K") is not None:
+                # Distribute IC across shells using BrIcc fractions.
+                for col, shell_label in _ICC_FRAC_COLS.items():
+                    frac = g.get(col)
+                    if frac is not None and frac > 0.0:
+                        vacancies[shell_label] = vacancies.get(shell_label, 0.0) + ic_contrib * frac
+            else:
+                # Fallback: K-only (pre-v0.12 data or missing fractions).
+                energy = float(g["gamma_energy_kev"])
+                if k_edge is not None and energy < k_edge:
+                    continue
+                vacancies["K"] = vacancies.get("K", 0.0) + ic_contrib
+
+        for shell_label, v in vacancies.items():
+            if v <= 0.0:
+                continue
+            out_rows.append(
+                {
+                    "Z": z,
+                    "A": a,
+                    "parent_ex_kev": parent_ex_kev,
+                    "daughter_Z": z,
+                    "shell": shell_label,
+                    "vacancy_rate": min(v, 1.0),
+                }
+            )
 
     if not out_rows:
         return pl.DataFrame(schema=empty_schema)
@@ -531,7 +562,11 @@ def synthesize_emissions(
         if eadl.is_empty():
             continue
 
-        vacancy_shell = _SHELL_TOTAL_TO_VACANCY.get(rec["shell"])
+        shell_input = rec["shell"]
+        # Sub-shell labels (K, L1, L2, L3, M1, …) from per-shell IC pass
+        # through directly as EADL vacancy_shell keys. Shell-letter labels
+        # (L, M, N) from EC are mapped via _SHELL_TOTAL_TO_VACANCY.
+        vacancy_shell = _SHELL_TOTAL_TO_VACANCY.get(shell_input, shell_input)
         if vacancy_shell is None:
             continue
 
@@ -866,8 +901,16 @@ def check_energy_conservation(
         .agg(pl.col("intensity_pct").sum().alias("actual_pct"))
         .rename({"parent_level_keV": "parent_ex_kev"})
     )
-    expected = vacancy_rates.with_columns((pl.col("vacancy_rate") * 100.0).alias("expected_pct")).select(
-        ["Z", "A", "parent_ex_kev", "shell", "expected_pct"]
+    # Roll up sub-shell vacancy rates (L1, L2, L3 → L) to match the
+    # shell-letter grouping used for emissions (rad_subtype first char).
+    expected = (
+        vacancy_rates.with_columns(
+            pl.col("shell").str.slice(0, 1).alias("shell_letter"),
+            (pl.col("vacancy_rate") * 100.0).alias("expected_pct"),
+        )
+        .group_by(["Z", "A", "parent_ex_kev", "shell_letter"])
+        .agg(pl.col("expected_pct").sum())
+        .rename({"shell_letter": "shell"})
     )
 
     joined = (

--- a/nucl_parquet/loader.py
+++ b/nucl_parquet/loader.py
@@ -730,11 +730,10 @@ def summing_partners(
     params: list[object] = [int(z), int(a), parent_state]
 
     if primary_energy_keV is not None:
-        where.append(
-            "(ABS(s.emission1_energy_keV - ?) < ? OR ABS(s.emission2_energy_keV - ?) < ?)"
+        where.append("(ABS(s.emission1_energy_keV - ?) < ? OR ABS(s.emission2_energy_keV - ?) < ?)")
+        params.extend(
+            [float(primary_energy_keV), float(tolerance_keV), float(primary_energy_keV), float(tolerance_keV)]
         )
-        params.extend([float(primary_energy_keV), float(tolerance_keV),
-                        float(primary_energy_keV), float(tolerance_keV)])
 
     if emission1_rad_type is not None:
         where.append("s.emission1_rad_type = ?")

--- a/nucl_parquet/loader.py
+++ b/nucl_parquet/loader.py
@@ -244,6 +244,8 @@ def connect(data_dir: Path | str | None = None) -> duckdb.DuckDBPyConnection:
     _register_glob(db, data_dir / "meta" / "ensdf" / "levels", "ensdf_levels")
     _register_glob(db, data_dir / "meta" / "ensdf" / "radiation", "radiation")
     _register_glob(db, data_dir / "meta" / "ensdf" / "coincidences", "coincidences")
+    # ICC-corrected summing partners for HPGe TCS corrections (#177).
+    _register_glob(db, data_dir / "meta" / "ensdf" / "summing_partners", "summing_partners")
     # Pre-tabulated β-decay continuous spectra per transition (#78). Companion
     # to `radiation` (which has discrete γ/X-ray/Auger lines): `beta_spectra`
     # has the continuous β kinetic-energy distribution sampled on 200 bins
@@ -685,6 +687,66 @@ def identify_gamma(
             float(min_intensity),
         ],
     )
+
+
+def summing_partners(
+    db: duckdb.DuckDBPyConnection,
+    z: int,
+    a: int,
+    primary_energy_keV: float | None = None,
+    tolerance_keV: float = 0.5,
+    parent_state: str = "",
+    emission1_rad_type: str | None = None,
+) -> duckdb.DuckDBPyRelation:
+    """ICC-corrected summing partners for HPGe TCS corrections (#177).
+
+    Returns all emission pairs that can sum in a close-geometry HPGe detector
+    for the specified nuclide. Each row carries ``icc_correction_factor`` and
+    ``pure_emission_joint_intensity`` pre-computed.
+
+    Parameters
+    ----------
+    db
+        DuckDB connection from :func:`connect`.
+    z, a
+        Daughter nucleus (filing convention — Co-60 cascades are under Ni-60).
+    primary_energy_keV
+        If given, filter to pairs where *either* emission matches this energy
+        within ``tolerance_keV``. Typical use: find all summing partners of a
+        specific gamma line.
+    tolerance_keV
+        Energy-match tolerance (default 0.5 keV, typical HPGe FWHM at ~1 MeV).
+    parent_state
+        ``""`` (ground) | ``"m"`` | ``"m2"``.
+    emission1_rad_type
+        Filter emission side 1: ``"gamma"`` | ``"xray"`` | ``"auger"``.
+        Pass ``"gamma"`` for γ-γ only; omit for all pair types.
+
+    Returns
+    -------
+    DuckDB relation; call ``.pl()`` / ``.df()`` / ``.arrow()`` as usual.
+    """
+    where = ["s.Z = ?", "s.A = ?", "COALESCE(s.parent_state, '') = ?"]
+    params: list[object] = [int(z), int(a), parent_state]
+
+    if primary_energy_keV is not None:
+        where.append(
+            "(ABS(s.emission1_energy_keV - ?) < ? OR ABS(s.emission2_energy_keV - ?) < ?)"
+        )
+        params.extend([float(primary_energy_keV), float(tolerance_keV),
+                        float(primary_energy_keV), float(tolerance_keV)])
+
+    if emission1_rad_type is not None:
+        where.append("s.emission1_rad_type = ?")
+        params.append(emission1_rad_type)
+
+    sql = f"""
+        SELECT s.*
+        FROM summing_partners s
+        WHERE {" AND ".join(where)}
+        ORDER BY s.pure_emission_joint_intensity DESC NULLS LAST
+    """
+    return db.sql(sql, params=params)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/g4/test_xray_auger.py
+++ b/tests/g4/test_xray_auger.py
@@ -555,9 +555,7 @@ class TestSpotChecks:
         fractions (icc_frac_K=0, icc_frac_L1..L3 large) must produce L
         X-ray lines. Before #193, all IC was attributed to K-shell and
         L X-rays were completely absent."""
-        au = emissions.filter(
-            (pl.col("Z") == 79) & (pl.col("A") == 197) & (pl.col("rad_type") == "xray")
-        )
+        au = emissions.filter((pl.col("Z") == 79) & (pl.col("A") == 197) & (pl.col("rad_type") == "xray"))
         l_xrays = au.filter(pl.col("rad_subtype").str.starts_with("L"))
         l_total = l_xrays["intensity_pct"].sum()
         # L X-rays must be present and substantial (α_L >> α_K for 130 keV M4).
@@ -565,8 +563,7 @@ class TestSpotChecks:
         # be comparable to K (~20-75% depending on state-assignment filtering).
         assert l_total > 0.0, "Au-197m L X-rays absent — per-shell ICC not wired"
         assert l_total > 10.0, (
-            f"Au-197m L X-ray total ({l_total:.1f}%) too low — "
-            f"per-shell ICC fractions may not be propagating"
+            f"Au-197m L X-ray total ({l_total:.1f}%) too low — per-shell ICC fractions may not be propagating"
         )
         # Lα1 at ~9.7 keV should be one of the top lines.
         la1 = au.filter(pl.col("rad_subtype") == "Lα1")

--- a/tests/g4/test_xray_auger.py
+++ b/tests/g4/test_xray_auger.py
@@ -550,6 +550,31 @@ class TestSpotChecks:
         # X-ray line (≈ 4–6 % per decay).
         assert 3.0 <= ba["intensity_pct"][0] <= 8.0
 
+    def test_au197m_l_xrays_present(self, emissions: pl.DataFrame) -> None:
+        """Au-197m 130 keV M4: L-shell IC dominates K-shell. Per-shell ICC
+        fractions (icc_frac_K=0, icc_frac_L1..L3 large) must produce L
+        X-ray lines. Before #193, all IC was attributed to K-shell and
+        L X-rays were completely absent."""
+        au = emissions.filter(
+            (pl.col("Z") == 79) & (pl.col("A") == 197) & (pl.col("rad_type") == "xray")
+        )
+        l_xrays = au.filter(pl.col("rad_subtype").str.starts_with("L"))
+        k_xrays = au.filter(pl.col("rad_subtype").str.starts_with("K"))
+        l_total = l_xrays["intensity_pct"].sum()
+        k_total = k_xrays["intensity_pct"].sum()
+        # L X-rays must be present and substantial (α_L >> α_K for 130 keV M4).
+        # Before #193, L was 0% and K was ~96%. With per-shell ICC, L should
+        # be comparable to K (~20-75% depending on state-assignment filtering).
+        assert l_total > 0.0, "Au-197m L X-rays absent — per-shell ICC not wired"
+        assert l_total > 10.0, (
+            f"Au-197m L X-ray total ({l_total:.1f}%) too low — "
+            f"per-shell ICC fractions may not be propagating"
+        )
+        # Lα1 at ~9.7 keV should be one of the top lines.
+        la1 = au.filter(pl.col("rad_subtype") == "Lα1")
+        assert la1.height >= 1, "Au-197m Lα1 line missing"
+        assert 9.0 <= la1["energy_keV"][0] <= 10.5
+
     def test_co57_energy_conservation_K_shell(self, emissions: pl.DataFrame) -> None:
         """Σ(K X-rays + K Augers) ≈ K-vacancy rate × 100 within 5%."""
         co = emissions.filter((pl.col("Z") == 27) & (pl.col("A") == 57) & (pl.col("state") == ""))

--- a/tests/g4/test_xray_auger.py
+++ b/tests/g4/test_xray_auger.py
@@ -559,9 +559,7 @@ class TestSpotChecks:
             (pl.col("Z") == 79) & (pl.col("A") == 197) & (pl.col("rad_type") == "xray")
         )
         l_xrays = au.filter(pl.col("rad_subtype").str.starts_with("L"))
-        k_xrays = au.filter(pl.col("rad_subtype").str.starts_with("K"))
         l_total = l_xrays["intensity_pct"].sum()
-        k_total = k_xrays["intensity_pct"].sum()
         # L X-rays must be present and substantial (α_L >> α_K for 130 keV M4).
         # Before #193, L was 0% and K was ~96%. With per-shell ICC, L should
         # be comparable to K (~20-75% depending on state-assignment filtering).

--- a/tests/test_g4_summing_partners.py
+++ b/tests/test_g4_summing_partners.py
@@ -1,0 +1,270 @@
+"""Tests for the summing_partners materializer (issue #177).
+
+Two layers:
+  * Synthetic unit tests verifying ICC correction math, canonicalization,
+    mixed-pair handling, and NULL coalescing.
+  * ``@pytest.mark.data`` spot checks confirming the acceptance criteria:
+    - Eu-152 344 keV: ≥10 γ-γ partners
+    - Co-60 1173/1333 keV: canonical symmetric pair, icc_correction ≈ 1
+    - Tc-99m 140 keV: significant ICC correction
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from nucl_parquet.g4.summing_partners import build_for_element, _OUTPUT_COLUMNS
+
+_REPO_ROOT = Path(__file__).parent.parent
+_SP_DIR = _REPO_ROOT / "data" / "meta" / "ensdf" / "summing_partners"
+
+
+# --------------------------------------------------------------------------- helpers
+
+
+def _make_coinc_gg(
+    rows: list[dict],
+) -> pl.DataFrame:
+    """Minimal coincidences frame with γ-γ rows + emission-agnostic columns."""
+    schema = {
+        "Z": pl.Int64,
+        "A": pl.Int64,
+        "dataset": pl.Int64,
+        "gamma_energy_keV": pl.Float64,
+        "coinc_energy_keV": pl.Float64,
+        "gamma1_energy_keV": pl.Float64,
+        "gamma1_intensity": pl.Float32,
+        "gamma2_energy_keV": pl.Float64,
+        "gamma2_intensity": pl.Float32,
+        "parent_level_keV": pl.Float64,
+        "intermediate_level_keV": pl.Float64,
+        "final_level_keV": pl.Float64,
+        "pair_intensity": pl.Float32,
+        "gamma1_icc_total": pl.Float32,
+        "gamma2_icc_total": pl.Float32,
+        "parent_state": pl.Utf8,
+        "parent_decay_mode": pl.Utf8,
+        "daughter_ex_keV": pl.Float64,
+        "emission1_rad_type": pl.Utf8,
+        "emission1_energy_keV": pl.Float64,
+        "emission1_intensity": pl.Float32,
+        "emission1_shell": pl.Utf8,
+        "emission2_rad_type": pl.Utf8,
+        "emission2_energy_keV": pl.Float64,
+        "emission2_intensity": pl.Float32,
+        "emission2_shell": pl.Utf8,
+    }
+    return pl.DataFrame([{**{k: None for k in schema}, **r} for r in rows], schema=schema)
+
+
+# --------------------------------------------------------------------------- unit tests
+
+
+class TestIccCorrection:
+    """Verify ICC math: 1/((1+α₁)×(1+α₂))."""
+
+    def test_both_zero(self):
+        """No ICC → correction factor = 1.0."""
+        coinc = _make_coinc_gg([{
+            "Z": 28, "A": 60, "gamma1_energy_keV": 100.0, "gamma2_energy_keV": 200.0,
+            "gamma1_intensity": 100.0, "gamma2_intensity": 100.0,
+            "parent_level_keV": 300.0, "intermediate_level_keV": 200.0, "final_level_keV": 0.0,
+            "pair_intensity": 100.0, "gamma1_icc_total": 0.0, "gamma2_icc_total": 0.0,
+            "parent_state": "", "emission1_rad_type": "gamma", "emission2_rad_type": "gamma",
+            "emission1_energy_keV": 100.0, "emission2_energy_keV": 200.0,
+        }])
+        result = build_for_element(coinc)
+        assert result.height == 1
+        row = result.row(0, named=True)
+        assert abs(row["icc_correction_factor"] - 1.0) < 1e-5
+
+    def test_significant_icc(self):
+        """α₁=0.1, α₂=0.2 → correction = 1/((1.1)×(1.2)) ≈ 0.7576."""
+        coinc = _make_coinc_gg([{
+            "Z": 28, "A": 60, "gamma1_energy_keV": 100.0, "gamma2_energy_keV": 200.0,
+            "gamma1_intensity": 100.0, "gamma2_intensity": 100.0,
+            "parent_level_keV": 300.0, "intermediate_level_keV": 200.0, "final_level_keV": 0.0,
+            "pair_intensity": 100.0, "gamma1_icc_total": 0.1, "gamma2_icc_total": 0.2,
+            "parent_state": "", "emission1_rad_type": "gamma", "emission2_rad_type": "gamma",
+            "emission1_energy_keV": 100.0, "emission2_energy_keV": 200.0,
+        }])
+        result = build_for_element(coinc)
+        row = result.row(0, named=True)
+        expected = 1.0 / (1.1 * 1.2)
+        assert abs(row["icc_correction_factor"] - expected) < 1e-4
+        assert abs(row["pure_emission_joint_intensity"] - 100.0 * expected) < 0.1
+
+    def test_null_icc_treated_as_zero(self):
+        """NULL ICC → coalesced to 0 → correction = 1.0."""
+        coinc = _make_coinc_gg([{
+            "Z": 28, "A": 60, "gamma1_energy_keV": 100.0, "gamma2_energy_keV": 200.0,
+            "gamma1_intensity": 100.0, "gamma2_intensity": 100.0,
+            "parent_level_keV": 300.0, "intermediate_level_keV": 200.0, "final_level_keV": 0.0,
+            "pair_intensity": 100.0, "gamma1_icc_total": None, "gamma2_icc_total": None,
+            "parent_state": "", "emission1_rad_type": "gamma", "emission2_rad_type": "gamma",
+            "emission1_energy_keV": 100.0, "emission2_energy_keV": 200.0,
+        }])
+        result = build_for_element(coinc)
+        row = result.row(0, named=True)
+        assert abs(row["icc_correction_factor"] - 1.0) < 1e-5
+
+
+class TestCanonicalization:
+    """γ-γ pairs should be canonicalized with E1 ≤ E2."""
+
+    def test_symmetric_pair_deduped(self):
+        """Two rows (E1=100,E2=200) and (E1=200,E2=100) → one output row."""
+        coinc = _make_coinc_gg([
+            {
+                "Z": 28, "A": 60, "gamma1_energy_keV": 100.0, "gamma2_energy_keV": 200.0,
+                "gamma1_intensity": 100.0, "gamma2_intensity": 50.0,
+                "parent_level_keV": 300.0, "intermediate_level_keV": 200.0, "final_level_keV": 0.0,
+                "pair_intensity": 50.0, "gamma1_icc_total": 0.0, "gamma2_icc_total": 0.0,
+                "parent_state": "", "emission1_rad_type": "gamma", "emission2_rad_type": "gamma",
+                "emission1_energy_keV": 100.0, "emission2_energy_keV": 200.0,
+            },
+            {
+                "Z": 28, "A": 60, "gamma1_energy_keV": 200.0, "gamma2_energy_keV": 100.0,
+                "gamma1_intensity": 50.0, "gamma2_intensity": 100.0,
+                "parent_level_keV": 300.0, "intermediate_level_keV": 200.0, "final_level_keV": 0.0,
+                "pair_intensity": 50.0, "gamma1_icc_total": 0.0, "gamma2_icc_total": 0.0,
+                "parent_state": "", "emission1_rad_type": "gamma", "emission2_rad_type": "gamma",
+                "emission1_energy_keV": 200.0, "emission2_energy_keV": 100.0,
+            },
+        ])
+        result = build_for_element(coinc)
+        assert result.height == 1
+        row = result.row(0, named=True)
+        assert row["emission1_energy_keV"] <= row["emission2_energy_keV"]
+
+
+class TestMixedPairs:
+    """X-ray/Auger ⊗ γ pairs: ICC only on gamma side."""
+
+    def test_xray_gamma_icc(self):
+        """X-ray side has no ICC; gamma side α=0.1 → correction = 1/1.1."""
+        coinc = _make_coinc_gg([{
+            "Z": 62, "A": 152, "gamma1_energy_keV": None, "gamma2_energy_keV": None,
+            "gamma1_intensity": None, "gamma2_intensity": None,
+            "parent_level_keV": 344.0, "intermediate_level_keV": None, "final_level_keV": None,
+            "pair_intensity": 10.0, "gamma1_icc_total": None, "gamma2_icc_total": 0.1,
+            "parent_state": "", "parent_decay_mode": "KshellEC",
+            "emission1_rad_type": "xray", "emission2_rad_type": "gamma",
+            "emission1_energy_keV": 40.0, "emission1_intensity": 5.0, "emission1_shell": "K",
+            "emission2_energy_keV": 344.0, "emission2_intensity": 100.0,
+        }])
+        result = build_for_element(coinc)
+        assert result.height == 1
+        row = result.row(0, named=True)
+        expected = 1.0 / 1.1
+        assert abs(row["icc_correction_factor"] - expected) < 1e-4
+        assert row["emission1_icc_total"] is None  # X-ray: no ICC
+        assert abs(row["emission2_icc_total"] - 0.1) < 1e-5
+
+
+class TestOutputSchema:
+    """Output has all required columns in the right order."""
+
+    def test_column_names(self):
+        coinc = _make_coinc_gg([{
+            "Z": 28, "A": 60, "gamma1_energy_keV": 100.0, "gamma2_energy_keV": 200.0,
+            "gamma1_intensity": 100.0, "gamma2_intensity": 100.0,
+            "parent_level_keV": 300.0, "intermediate_level_keV": 200.0, "final_level_keV": 0.0,
+            "pair_intensity": 100.0, "gamma1_icc_total": 0.0, "gamma2_icc_total": 0.0,
+            "parent_state": "", "emission1_rad_type": "gamma", "emission2_rad_type": "gamma",
+            "emission1_energy_keV": 100.0, "emission2_energy_keV": 200.0,
+        }])
+        result = build_for_element(coinc)
+        assert result.columns == _OUTPUT_COLUMNS
+
+
+# --------------------------------------------------------------------------- data tests
+
+
+@pytest.mark.data
+class TestCo60:
+    """Co-60 → Ni-60: 1173/1333 keV canonical pair."""
+
+    def test_pair_exists(self):
+        ni = pl.read_parquet(_SP_DIR / "Ni.parquet")
+        co60 = ni.filter(
+            (pl.col("A") == 60)
+            & (pl.col("emission1_rad_type") == "gamma")
+        )
+        pair = co60.filter(
+            ((pl.col("emission1_energy_keV") - 1173.2).abs() < 1.0)
+            & ((pl.col("emission2_energy_keV") - 1332.5).abs() < 1.0)
+        )
+        assert pair.height >= 1, "Co-60 1173/1333 keV pair missing"
+
+    def test_icc_correction_near_unity(self):
+        """α for 1173 and 1333 keV are < 0.001 → correction ≈ 1."""
+        ni = pl.read_parquet(_SP_DIR / "Ni.parquet")
+        pair = ni.filter(
+            (pl.col("A") == 60)
+            & (pl.col("emission1_rad_type") == "gamma")
+            & ((pl.col("emission1_energy_keV") - 1173.2).abs() < 1.0)
+            & ((pl.col("emission2_energy_keV") - 1332.5).abs() < 1.0)
+        )
+        row = pair.row(0, named=True)
+        assert row["icc_correction_factor"] > 0.99, f"Expected ~1.0, got {row['icc_correction_factor']}"
+
+    def test_canonicalized(self):
+        """1173 < 1333, so emission1 should be the lower energy."""
+        ni = pl.read_parquet(_SP_DIR / "Ni.parquet")
+        pair = ni.filter(
+            (pl.col("A") == 60)
+            & (pl.col("emission1_rad_type") == "gamma")
+            & ((pl.col("emission1_energy_keV") - 1173.2).abs() < 1.0)
+            & ((pl.col("emission2_energy_keV") - 1332.5).abs() < 1.0)
+        )
+        row = pair.row(0, named=True)
+        assert row["emission1_energy_keV"] < row["emission2_energy_keV"]
+
+
+@pytest.mark.data
+class TestEu152:
+    """Eu-152 → Gd-152 (β-): 344 keV γ should have ≥10 summing partners."""
+
+    def test_partner_count(self):
+        gd = pl.read_parquet(_SP_DIR / "Gd.parquet")
+        partners = gd.filter(
+            (pl.col("A") == 152)
+            & (pl.col("emission1_rad_type") == "gamma")
+            & (
+                ((pl.col("emission1_energy_keV") - 344.28).abs() < 1.0)
+                | ((pl.col("emission2_energy_keV") - 344.28).abs() < 1.0)
+            )
+        )
+        assert partners.height >= 10, f"Expected ≥10 partners, got {partners.height}"
+
+    def test_mixed_pairs_exist(self):
+        """Eu-152 EC decay → Sm-152: X-ray ⊗ γ pairs should exist."""
+        sm = pl.read_parquet(_SP_DIR / "Sm.parquet")
+        mixed = sm.filter(
+            (pl.col("A") == 152)
+            & (pl.col("emission1_rad_type") != "gamma")
+        )
+        assert mixed.height > 0, "Eu-152 → Sm-152 should have X-ray/Auger ⊗ γ pairs"
+
+
+@pytest.mark.data
+class TestTc99m:
+    """Tc-99m → Tc-99: 140 keV M1+E2 (α_K ≈ 0.107) → significant ICC correction."""
+
+    def test_icc_significant(self):
+        tc = pl.read_parquet(_SP_DIR / "Tc.parquet")
+        tc99 = tc.filter(
+            (pl.col("A") == 99)
+            & (
+                ((pl.col("emission1_energy_keV") - 140.5).abs() < 1.0)
+                | ((pl.col("emission2_energy_keV") - 140.5).abs() < 1.0)
+            )
+        )
+        assert tc99.height > 0, "Tc-99m 140 keV summing partners missing"
+        # At least one pair should show significant ICC correction (< 0.95)
+        min_corr = tc99["icc_correction_factor"].min()
+        assert min_corr < 0.95, f"Expected significant ICC correction, min factor = {min_corr}"

--- a/tests/test_g4_summing_partners.py
+++ b/tests/test_g4_summing_partners.py
@@ -16,7 +16,7 @@ from pathlib import Path
 import polars as pl
 import pytest
 
-from nucl_parquet.g4.summing_partners import build_for_element, _OUTPUT_COLUMNS
+from nucl_parquet.g4.summing_partners import _OUTPUT_COLUMNS, build_for_element
 
 _REPO_ROOT = Path(__file__).parent.parent
 _SP_DIR = _REPO_ROOT / "data" / "meta" / "ensdf" / "summing_partners"
@@ -68,14 +68,29 @@ class TestIccCorrection:
 
     def test_both_zero(self):
         """No ICC → correction factor = 1.0."""
-        coinc = _make_coinc_gg([{
-            "Z": 28, "A": 60, "gamma1_energy_keV": 100.0, "gamma2_energy_keV": 200.0,
-            "gamma1_intensity": 100.0, "gamma2_intensity": 100.0,
-            "parent_level_keV": 300.0, "intermediate_level_keV": 200.0, "final_level_keV": 0.0,
-            "pair_intensity": 100.0, "gamma1_icc_total": 0.0, "gamma2_icc_total": 0.0,
-            "parent_state": "", "emission1_rad_type": "gamma", "emission2_rad_type": "gamma",
-            "emission1_energy_keV": 100.0, "emission2_energy_keV": 200.0,
-        }])
+        coinc = _make_coinc_gg(
+            [
+                {
+                    "Z": 28,
+                    "A": 60,
+                    "gamma1_energy_keV": 100.0,
+                    "gamma2_energy_keV": 200.0,
+                    "gamma1_intensity": 100.0,
+                    "gamma2_intensity": 100.0,
+                    "parent_level_keV": 300.0,
+                    "intermediate_level_keV": 200.0,
+                    "final_level_keV": 0.0,
+                    "pair_intensity": 100.0,
+                    "gamma1_icc_total": 0.0,
+                    "gamma2_icc_total": 0.0,
+                    "parent_state": "",
+                    "emission1_rad_type": "gamma",
+                    "emission2_rad_type": "gamma",
+                    "emission1_energy_keV": 100.0,
+                    "emission2_energy_keV": 200.0,
+                }
+            ]
+        )
         result = build_for_element(coinc)
         assert result.height == 1
         row = result.row(0, named=True)
@@ -83,14 +98,29 @@ class TestIccCorrection:
 
     def test_significant_icc(self):
         """α₁=0.1, α₂=0.2 → correction = 1/((1.1)×(1.2)) ≈ 0.7576."""
-        coinc = _make_coinc_gg([{
-            "Z": 28, "A": 60, "gamma1_energy_keV": 100.0, "gamma2_energy_keV": 200.0,
-            "gamma1_intensity": 100.0, "gamma2_intensity": 100.0,
-            "parent_level_keV": 300.0, "intermediate_level_keV": 200.0, "final_level_keV": 0.0,
-            "pair_intensity": 100.0, "gamma1_icc_total": 0.1, "gamma2_icc_total": 0.2,
-            "parent_state": "", "emission1_rad_type": "gamma", "emission2_rad_type": "gamma",
-            "emission1_energy_keV": 100.0, "emission2_energy_keV": 200.0,
-        }])
+        coinc = _make_coinc_gg(
+            [
+                {
+                    "Z": 28,
+                    "A": 60,
+                    "gamma1_energy_keV": 100.0,
+                    "gamma2_energy_keV": 200.0,
+                    "gamma1_intensity": 100.0,
+                    "gamma2_intensity": 100.0,
+                    "parent_level_keV": 300.0,
+                    "intermediate_level_keV": 200.0,
+                    "final_level_keV": 0.0,
+                    "pair_intensity": 100.0,
+                    "gamma1_icc_total": 0.1,
+                    "gamma2_icc_total": 0.2,
+                    "parent_state": "",
+                    "emission1_rad_type": "gamma",
+                    "emission2_rad_type": "gamma",
+                    "emission1_energy_keV": 100.0,
+                    "emission2_energy_keV": 200.0,
+                }
+            ]
+        )
         result = build_for_element(coinc)
         row = result.row(0, named=True)
         expected = 1.0 / (1.1 * 1.2)
@@ -99,14 +129,29 @@ class TestIccCorrection:
 
     def test_null_icc_treated_as_zero(self):
         """NULL ICC → coalesced to 0 → correction = 1.0."""
-        coinc = _make_coinc_gg([{
-            "Z": 28, "A": 60, "gamma1_energy_keV": 100.0, "gamma2_energy_keV": 200.0,
-            "gamma1_intensity": 100.0, "gamma2_intensity": 100.0,
-            "parent_level_keV": 300.0, "intermediate_level_keV": 200.0, "final_level_keV": 0.0,
-            "pair_intensity": 100.0, "gamma1_icc_total": None, "gamma2_icc_total": None,
-            "parent_state": "", "emission1_rad_type": "gamma", "emission2_rad_type": "gamma",
-            "emission1_energy_keV": 100.0, "emission2_energy_keV": 200.0,
-        }])
+        coinc = _make_coinc_gg(
+            [
+                {
+                    "Z": 28,
+                    "A": 60,
+                    "gamma1_energy_keV": 100.0,
+                    "gamma2_energy_keV": 200.0,
+                    "gamma1_intensity": 100.0,
+                    "gamma2_intensity": 100.0,
+                    "parent_level_keV": 300.0,
+                    "intermediate_level_keV": 200.0,
+                    "final_level_keV": 0.0,
+                    "pair_intensity": 100.0,
+                    "gamma1_icc_total": None,
+                    "gamma2_icc_total": None,
+                    "parent_state": "",
+                    "emission1_rad_type": "gamma",
+                    "emission2_rad_type": "gamma",
+                    "emission1_energy_keV": 100.0,
+                    "emission2_energy_keV": 200.0,
+                }
+            ]
+        )
         result = build_for_element(coinc)
         row = result.row(0, named=True)
         assert abs(row["icc_correction_factor"] - 1.0) < 1e-5
@@ -117,24 +162,48 @@ class TestCanonicalization:
 
     def test_symmetric_pair_deduped(self):
         """Two rows (E1=100,E2=200) and (E1=200,E2=100) → one output row."""
-        coinc = _make_coinc_gg([
-            {
-                "Z": 28, "A": 60, "gamma1_energy_keV": 100.0, "gamma2_energy_keV": 200.0,
-                "gamma1_intensity": 100.0, "gamma2_intensity": 50.0,
-                "parent_level_keV": 300.0, "intermediate_level_keV": 200.0, "final_level_keV": 0.0,
-                "pair_intensity": 50.0, "gamma1_icc_total": 0.0, "gamma2_icc_total": 0.0,
-                "parent_state": "", "emission1_rad_type": "gamma", "emission2_rad_type": "gamma",
-                "emission1_energy_keV": 100.0, "emission2_energy_keV": 200.0,
-            },
-            {
-                "Z": 28, "A": 60, "gamma1_energy_keV": 200.0, "gamma2_energy_keV": 100.0,
-                "gamma1_intensity": 50.0, "gamma2_intensity": 100.0,
-                "parent_level_keV": 300.0, "intermediate_level_keV": 200.0, "final_level_keV": 0.0,
-                "pair_intensity": 50.0, "gamma1_icc_total": 0.0, "gamma2_icc_total": 0.0,
-                "parent_state": "", "emission1_rad_type": "gamma", "emission2_rad_type": "gamma",
-                "emission1_energy_keV": 200.0, "emission2_energy_keV": 100.0,
-            },
-        ])
+        coinc = _make_coinc_gg(
+            [
+                {
+                    "Z": 28,
+                    "A": 60,
+                    "gamma1_energy_keV": 100.0,
+                    "gamma2_energy_keV": 200.0,
+                    "gamma1_intensity": 100.0,
+                    "gamma2_intensity": 50.0,
+                    "parent_level_keV": 300.0,
+                    "intermediate_level_keV": 200.0,
+                    "final_level_keV": 0.0,
+                    "pair_intensity": 50.0,
+                    "gamma1_icc_total": 0.0,
+                    "gamma2_icc_total": 0.0,
+                    "parent_state": "",
+                    "emission1_rad_type": "gamma",
+                    "emission2_rad_type": "gamma",
+                    "emission1_energy_keV": 100.0,
+                    "emission2_energy_keV": 200.0,
+                },
+                {
+                    "Z": 28,
+                    "A": 60,
+                    "gamma1_energy_keV": 200.0,
+                    "gamma2_energy_keV": 100.0,
+                    "gamma1_intensity": 50.0,
+                    "gamma2_intensity": 100.0,
+                    "parent_level_keV": 300.0,
+                    "intermediate_level_keV": 200.0,
+                    "final_level_keV": 0.0,
+                    "pair_intensity": 50.0,
+                    "gamma1_icc_total": 0.0,
+                    "gamma2_icc_total": 0.0,
+                    "parent_state": "",
+                    "emission1_rad_type": "gamma",
+                    "emission2_rad_type": "gamma",
+                    "emission1_energy_keV": 200.0,
+                    "emission2_energy_keV": 100.0,
+                },
+            ]
+        )
         result = build_for_element(coinc)
         assert result.height == 1
         row = result.row(0, named=True)
@@ -146,16 +215,33 @@ class TestMixedPairs:
 
     def test_xray_gamma_icc(self):
         """X-ray side has no ICC; gamma side α=0.1 → correction = 1/1.1."""
-        coinc = _make_coinc_gg([{
-            "Z": 62, "A": 152, "gamma1_energy_keV": None, "gamma2_energy_keV": None,
-            "gamma1_intensity": None, "gamma2_intensity": None,
-            "parent_level_keV": 344.0, "intermediate_level_keV": None, "final_level_keV": None,
-            "pair_intensity": 10.0, "gamma1_icc_total": None, "gamma2_icc_total": 0.1,
-            "parent_state": "", "parent_decay_mode": "KshellEC",
-            "emission1_rad_type": "xray", "emission2_rad_type": "gamma",
-            "emission1_energy_keV": 40.0, "emission1_intensity": 5.0, "emission1_shell": "K",
-            "emission2_energy_keV": 344.0, "emission2_intensity": 100.0,
-        }])
+        coinc = _make_coinc_gg(
+            [
+                {
+                    "Z": 62,
+                    "A": 152,
+                    "gamma1_energy_keV": None,
+                    "gamma2_energy_keV": None,
+                    "gamma1_intensity": None,
+                    "gamma2_intensity": None,
+                    "parent_level_keV": 344.0,
+                    "intermediate_level_keV": None,
+                    "final_level_keV": None,
+                    "pair_intensity": 10.0,
+                    "gamma1_icc_total": None,
+                    "gamma2_icc_total": 0.1,
+                    "parent_state": "",
+                    "parent_decay_mode": "KshellEC",
+                    "emission1_rad_type": "xray",
+                    "emission2_rad_type": "gamma",
+                    "emission1_energy_keV": 40.0,
+                    "emission1_intensity": 5.0,
+                    "emission1_shell": "K",
+                    "emission2_energy_keV": 344.0,
+                    "emission2_intensity": 100.0,
+                }
+            ]
+        )
         result = build_for_element(coinc)
         assert result.height == 1
         row = result.row(0, named=True)
@@ -169,14 +255,29 @@ class TestOutputSchema:
     """Output has all required columns in the right order."""
 
     def test_column_names(self):
-        coinc = _make_coinc_gg([{
-            "Z": 28, "A": 60, "gamma1_energy_keV": 100.0, "gamma2_energy_keV": 200.0,
-            "gamma1_intensity": 100.0, "gamma2_intensity": 100.0,
-            "parent_level_keV": 300.0, "intermediate_level_keV": 200.0, "final_level_keV": 0.0,
-            "pair_intensity": 100.0, "gamma1_icc_total": 0.0, "gamma2_icc_total": 0.0,
-            "parent_state": "", "emission1_rad_type": "gamma", "emission2_rad_type": "gamma",
-            "emission1_energy_keV": 100.0, "emission2_energy_keV": 200.0,
-        }])
+        coinc = _make_coinc_gg(
+            [
+                {
+                    "Z": 28,
+                    "A": 60,
+                    "gamma1_energy_keV": 100.0,
+                    "gamma2_energy_keV": 200.0,
+                    "gamma1_intensity": 100.0,
+                    "gamma2_intensity": 100.0,
+                    "parent_level_keV": 300.0,
+                    "intermediate_level_keV": 200.0,
+                    "final_level_keV": 0.0,
+                    "pair_intensity": 100.0,
+                    "gamma1_icc_total": 0.0,
+                    "gamma2_icc_total": 0.0,
+                    "parent_state": "",
+                    "emission1_rad_type": "gamma",
+                    "emission2_rad_type": "gamma",
+                    "emission1_energy_keV": 100.0,
+                    "emission2_energy_keV": 200.0,
+                }
+            ]
+        )
         result = build_for_element(coinc)
         assert result.columns == _OUTPUT_COLUMNS
 
@@ -190,10 +291,7 @@ class TestCo60:
 
     def test_pair_exists(self):
         ni = pl.read_parquet(_SP_DIR / "Ni.parquet")
-        co60 = ni.filter(
-            (pl.col("A") == 60)
-            & (pl.col("emission1_rad_type") == "gamma")
-        )
+        co60 = ni.filter((pl.col("A") == 60) & (pl.col("emission1_rad_type") == "gamma"))
         pair = co60.filter(
             ((pl.col("emission1_energy_keV") - 1173.2).abs() < 1.0)
             & ((pl.col("emission2_energy_keV") - 1332.5).abs() < 1.0)
@@ -244,10 +342,7 @@ class TestEu152:
     def test_mixed_pairs_exist(self):
         """Eu-152 EC decay → Sm-152: X-ray ⊗ γ pairs should exist."""
         sm = pl.read_parquet(_SP_DIR / "Sm.parquet")
-        mixed = sm.filter(
-            (pl.col("A") == 152)
-            & (pl.col("emission1_rad_type") != "gamma")
-        )
+        mixed = sm.filter((pl.col("A") == 152) & (pl.col("emission1_rad_type") != "gamma"))
         assert mixed.height > 0, "Eu-152 → Sm-152 should have X-ray/Auger ⊗ γ pairs"
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -404,7 +404,7 @@ wheels = [
 
 [[package]]
 name = "nucl-parquet"
-version = "0.14.0"
+version = "0.14.1"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
## Summary

- Add `summing_partners/{Symbol}.parquet` — pre-computed ICC-corrected coincidence pairs for HPGe true-coincidence-summing (TCS) corrections
- Builder (`nucl_parquet/g4/summing_partners.py`) reads `coincidences/` and materializes γ-γ + X-ray/Auger ⊗ γ pairs with `icc_correction_factor` and `pure_emission_joint_intensity`
- γ-γ pairs canonicalized (E1 ≤ E2) to eliminate symmetric duplicates; NULL ICC → 0.0
- `get_summing_partners` tool added to Python, TypeScript, and Rust MCP servers
- Rust MCP: fix dictionary-encoded string handling in `column_value_to_json` (was silently dropping dict-typed columns)

## Design decisions

1. **Materialized Parquet, not compute-on-read** — consumers stay lean (SSoT pattern); no per-language ICC math
2. **One table for γ-γ and X-ray ⊗ γ** — atomic de-excitation is always prompt (femtoseconds); no timing edge case for HPGe
3. **Canonical ordering** — γ-γ pairs enforce E1 ≤ E2 to deduplicate symmetric pairs (Co-60 1173/1333 appears once)

## Acceptance criteria

- [x] Eu-152 344 keV (Gd-152 daughter): 71 γ-γ partners (≥10 required)
- [x] Co-60 1173/1333 keV: `icc_correction_factor ≈ 0.9997` (α < 0.001 at high energy)
- [x] Tc-99m 140 keV: significant ICC correction (min factor ~0.06)
- [x] Python + Rust + TS surfaces parity

## Test plan

- [ ] Python unit tests: ICC math, NULL coalescing, canonicalization, mixed pairs, schema validation
- [ ] Python @data tests: Co-60 pair, Eu-152 ≥10 partners, Tc-99m ICC significance
- [ ] TypeScript DuckDB tests: Co-60 pair lookup, Eu-152 partner count
- [ ] Rust integration test: Co-60 via get_summing_partners tool
- [ ] CI: cargo fmt + clippy, vitest, pytest

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)