### PR TITLE
fix(coincidences): filter COINCIDENCE_SQL on parent_state (#50)

### DIFF
--- a/nucl_parquet/loader.py
+++ b/nucl_parquet/loader.py
@@ -552,6 +552,7 @@ LEFT JOIN (
 ) r2 ON c.Z = r2.Z AND c.A = r2.A AND r2.state = $state
     AND ABS(c.coinc_energy_keV - r2.energy_keV) < 0.5
 WHERE c.Z = $z AND c.A = $a
+  AND COALESCE(c.parent_state, '') = $state
   AND c.emission1_rad_type = 'gamma' AND c.emission2_rad_type = 'gamma'
   AND c.gamma_energy_keV < c.coinc_energy_keV  -- avoid symmetric duplicates
 ORDER BY coinc_prob_pct DESC NULLS LAST


### PR DESCRIPTION
## Summary

- Add `COALESCE(c.parent_state, '') = $state` to `COINCIDENCE_SQL` WHERE clause
- Without this, `state='m'` queries returned ground-state cascade pairs with NULL intensities (silent wrong results)
- The `coincidences()` Python helper already had this filter (line 633) — only the legacy SQL constant was broken

One-line fix. The `coincidences()` helper + `summing_partners()` helper are the blessed API path; `COINCIDENCE_SQL` is a legacy constant for direct SQL users.

## Test plan

- [x] CI (DuckDB functional tests will validate the SQL parses correctly)
- Existing `coincidences()` helper tests cover the state-filtering logic

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)