### PR TITLE
feat(rs-client): compound stopping power + dose source attribution (#199, #200)

### DIFF
--- a/clients/rs/nucl-parquet/src/lib.rs
+++ b/clients/rs/nucl-parquet/src/lib.rs
@@ -56,7 +56,7 @@ pub use electron::{ElectronDb, ElectronProcess};
 pub use error::Error;
 pub use meta::{
     AbundanceEntry, AbundancesDb, CoincidenceEntry, CoincidenceFilter, CoincidencesDb, DecayDb,
-    DecayEntry, DoseDb, Emission, EmissionEntry, GammaCandidate, RadiationDb,
+    DecayEntry, DoseConstant, DoseDb, Emission, EmissionEntry, GammaCandidate, RadiationDb,
 };
 pub use photon::{PhotonDb, Process};
 pub use relaxation::{RelaxationDb, Transition, TransitionType};

--- a/clients/rs/nucl-parquet/src/meta.rs
+++ b/clients/rs/nucl-parquet/src/meta.rs
@@ -262,13 +262,22 @@ impl DecayDb {
 // DoseDb
 // ---------------------------------------------------------------------------
 
+/// Dose rate constant for a nuclide, with source attribution.
+#[derive(Debug, Clone)]
+pub struct DoseConstant {
+    /// Dose rate constant in µSv·m²/(MBq·h).
+    pub k: f64,
+    /// Source attribution: `"ensdf"`, `"it-approx"`, or `"zero"`.
+    pub source: String,
+}
+
 /// Dose rate constant database (µSv·m²·MBq⁻¹·h⁻¹).
 ///
 /// Thread-safe: `Send + Sync`. Share via `Arc<DoseDb>`.
 #[derive(Clone)]
 pub struct DoseDb {
-    /// (Z, A, state) -> dose constant in µSv·m²/(MBq·h)
-    data: HashMap<(u32, u32, String), f64>,
+    /// (Z, A, state) -> (dose constant, source)
+    data: HashMap<(u32, u32, String), DoseConstant>,
 }
 
 unsafe impl Send for DoseDb {}
@@ -278,7 +287,7 @@ impl DoseDb {
     /// Load dose constant data from `meta/dose_constants.parquet`.
     pub fn open(data_dir: impl AsRef<Path>) -> crate::Result<Self> {
         let path = data_dir.as_ref().join("dose_constants.parquet");
-        let mut data: HashMap<(u32, u32, String), f64> = HashMap::new();
+        let mut data: HashMap<(u32, u32, String), DoseConstant> = HashMap::new();
 
         let file = fs::File::open(&path)?;
         let reader = ParquetRecordBatchReaderBuilder::try_new(file)?.build()?;
@@ -297,17 +306,27 @@ impl DoseDb {
             let k_col = batch
                 .column_by_name("k_uSv_m2_MBq_h")
                 .and_then(|c| c.as_any().downcast_ref::<Float64Array>());
+            let src_col_ref = batch.column_by_name("source");
+            let src_values = src_col_ref.and_then(|c| crate::interp::as_string_array(c));
 
             if let (Some(z), Some(a), Some(state), Some(k)) = (z_col, a_col, state_values, k_col) {
                 #[allow(clippy::needless_range_loop)]
                 for i in 0..batch.num_rows() {
+                    let source = src_values
+                        .as_ref()
+                        .and_then(|s| s[i])
+                        .unwrap_or("")
+                        .to_string();
                     data.insert(
                         (
                             z.value(i) as u32,
                             a.value(i) as u32,
                             state[i].unwrap_or("").to_string(),
                         ),
-                        k.value(i),
+                        DoseConstant {
+                            k: k.value(i),
+                            source,
+                        },
                     );
                 }
             }
@@ -316,12 +335,11 @@ impl DoseDb {
         Ok(Self { data })
     }
 
-    /// Dose rate constant [µSv·m²/(MBq·h)] for nuclide (Z, A, state).
+    /// Dose rate constant with source attribution for nuclide (Z, A, state).
     ///
     /// Returns `None` if the nuclide is not in the database.
-    /// Returns `Some(0.0)` for stable nuclides or those with no gamma emission.
-    pub fn dose_constant(&self, z: u32, a: u32, state: &str) -> Option<f64> {
-        self.data.get(&(z, a, state.to_string())).copied()
+    pub fn dose_constant(&self, z: u32, a: u32, state: &str) -> Option<&DoseConstant> {
+        self.data.get(&(z, a, state.to_string()))
     }
 }
 
@@ -1199,8 +1217,10 @@ mod tests {
     #[ignore = "requires nucl-parquet data files"]
     fn dose_i131_positive() {
         let db = DoseDb::open(meta_dir()).unwrap();
-        let k = db.dose_constant(53, 131, ""); // I-131
-        assert!(k.is_some(), "I-131 should have a dose constant");
-        assert!(k.unwrap() > 0.0, "I-131 dose constant should be positive");
+        let dc = db.dose_constant(53, 131, ""); // I-131
+        assert!(dc.is_some(), "I-131 should have a dose constant");
+        let dc = dc.unwrap();
+        assert!(dc.k > 0.0, "I-131 dose constant should be positive");
+        assert_eq!(dc.source, "ensdf", "I-131 source should be 'ensdf'");
     }
 }

--- a/clients/rs/nucl-parquet/src/stopping.rs
+++ b/clients/rs/nucl-parquet/src/stopping.rs
@@ -37,6 +37,8 @@ use crate::interp::{log_log_interp, sort_paired_vecs, XYTable};
 pub struct StoppingDb {
     /// (source, target_Z) -> (energy_MeV sorted, dedx sorted)
     nist: HashMap<(String, u32), XYTable>,
+    /// (source, compound_name) -> (energy_MeV sorted, dedx sorted)
+    compounds: HashMap<(String, String), XYTable>,
     /// (proj_Z, target_Z) -> (energy_MeV_u sorted, dedx sorted)
     catima: HashMap<(u32, u32), XYTable>,
     /// (proj_Z, target_Z) -> Bohr straggling dΩ²/d(ρx) [MeV² cm²/g] (constant per pair)
@@ -60,10 +62,12 @@ impl StoppingDb {
         }
 
         let nist = Self::load_nist(dir)?;
+        let compounds = Self::load_compounds(dir)?;
         let (catima, catima_strag) = Self::load_catima(dir)?;
 
         Ok(Self {
             nist,
+            compounds,
             catima,
             catima_strag,
         })
@@ -81,6 +85,22 @@ impl StoppingDb {
     #[inline]
     pub fn dedx(&self, source: &str, target_z: u32, energy_mev: f64) -> f64 {
         match self.nist.get(&(source.to_string(), target_z)) {
+            Some((e, s)) => log_log_interp(e, s, energy_mev),
+            None => f64::NAN,
+        }
+    }
+
+    /// Mass stopping power [MeV cm²/g] for a NIST compound material.
+    ///
+    /// `source`: `"PSTAR_compound"` or `"ASTAR_compound"`.
+    /// `compound`: NIST compound name in UPPER_SNAKE_CASE (e.g., `"WATER_LIQUID"`).
+    /// Returns `f64::NAN` if the (source, compound) combination is not loaded.
+    #[inline]
+    pub fn compound_dedx(&self, source: &str, compound: &str, energy_mev: f64) -> f64 {
+        match self
+            .compounds
+            .get(&(source.to_string(), compound.to_string()))
+        {
             Some((e, s)) => log_log_interp(e, s, energy_mev),
             None => f64::NAN,
         }
@@ -147,6 +167,61 @@ impl StoppingDb {
                     #[allow(clippy::needless_range_loop)]
                     for i in 0..batch.num_rows() {
                         let key = (src[i].unwrap_or("").to_string(), z.value(i) as u32);
+                        let entry = map.entry(key).or_default();
+                        entry.0.push(e.value(i));
+                        entry.1.push(s.value(i));
+                    }
+                }
+            }
+        }
+
+        for (e_vec, s_vec) in map.values_mut() {
+            sort_paired_vecs(e_vec, s_vec);
+        }
+
+        Ok(map)
+    }
+
+    fn load_compounds(dir: &Path) -> crate::Result<HashMap<(String, String), XYTable>> {
+        let mut map: HashMap<(String, String), XYTable> = HashMap::new();
+        let compounds_dir = dir.join("compounds");
+        if !compounds_dir.exists() {
+            return Ok(map);
+        }
+
+        for entry in fs::read_dir(&compounds_dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("parquet") {
+                continue;
+            }
+
+            let file = fs::File::open(&path)?;
+            let reader = ParquetRecordBatchReaderBuilder::try_new(file)?.build()?;
+
+            for batch in reader {
+                let batch = batch?;
+
+                let src_col_ref = batch.column_by_name("source");
+                let src_values = src_col_ref.and_then(|c| crate::interp::as_string_array(c));
+                let cmp_col_ref = batch.column_by_name("compound");
+                let cmp_values = cmp_col_ref.and_then(|c| crate::interp::as_string_array(c));
+                let e_col = batch
+                    .column_by_name("energy_MeV")
+                    .and_then(|c| c.as_any().downcast_ref::<Float64Array>());
+                let s_col = batch
+                    .column_by_name("dedx")
+                    .and_then(|c| c.as_any().downcast_ref::<Float64Array>());
+
+                if let (Some(src), Some(cmp), Some(e), Some(s)) =
+                    (src_values, cmp_values, e_col, s_col)
+                {
+                    #[allow(clippy::needless_range_loop)]
+                    for i in 0..batch.num_rows() {
+                        let key = (
+                            src[i].unwrap_or("").to_string(),
+                            cmp[i].unwrap_or("").to_string(),
+                        );
                         let entry = map.entry(key).or_default();
                         entry.0.push(e.value(i));
                         entry.1.push(s.value(i));
@@ -282,6 +357,23 @@ mod tests {
                 "α Cu at {e} MeV: got {got}, NIST {expected}, rel err {rel}",
             );
         }
+    }
+
+    #[test]
+    #[ignore = "requires nucl-parquet data files"]
+    fn compound_water_positive() {
+        let db = StoppingDb::open(data_dir()).unwrap();
+        let s = db.compound_dedx("PSTAR_compound", "WATER_LIQUID", 10.0);
+        assert!(s.is_finite() && s > 0.0, "PSTAR water 10 MeV: {s}");
+    }
+
+    #[test]
+    #[ignore = "requires nucl-parquet data files"]
+    fn compound_miss_returns_nan() {
+        let db = StoppingDb::open(data_dir()).unwrap();
+        assert!(db
+            .compound_dedx("PSTAR_compound", "NONEXISTENT", 10.0)
+            .is_nan());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **#199**: `StoppingDb::compound_dedx(source, compound, energy_mev)` — exposes NIST PSTAR/ASTAR compound stopping power tables that already ship in `stopping/compounds/`. Keyed by `("PSTAR_compound", "WATER_LIQUID")` etc.
- **#200**: `DoseDb::dose_constant()` returns `&DoseConstant { k, source }` instead of bare `f64` — carries source attribution (`"ensdf"`, `"it-approx"`, `"zero"`) from the parquet file

Both unblock hyrr-core's nucl-parquet-rs SSoT migration (exoma-ch/hyrr#195).

## Test plan

- [x] `stopping::compound_water_positive` — PSTAR water at 10 MeV returns positive finite value
- [x] `stopping::compound_miss_returns_nan` — unknown compound returns NaN
- [x] `dose_i131_positive` — I-131 k > 0 and source == "ensdf"
- [x] `cargo check` on nucl-parquet-mcp (no API breakage)

Closes #199, closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)