### PR TITLE
feat(rs-client): raw table accessors for StoppingDb + CrossSectionDb

### DIFF
--- a/clients/rs/nucl-parquet/src/stopping.rs
+++ b/clients/rs/nucl-parquet/src/stopping.rs
@@ -110,6 +110,28 @@ impl StoppingDb {
             .unwrap_or(f64::NAN)
     }
 
+    // --- Raw table access (for consumers that do their own interpolation) ---
+
+    /// Raw (energy_MeV, dedx) table for a NIST source + target_Z.
+    ///
+    /// Returns `None` if the (source, target_Z) combination is not loaded.
+    /// Energy array is sorted ascending.
+    pub fn nist_table(&self, source: &str, target_z: u32) -> Option<&XYTable> {
+        self.nist.get(&(source.to_string(), target_z))
+    }
+
+    /// Iterate all loaded (source, target_Z) pairs in the NIST tables.
+    pub fn nist_keys(&self) -> impl Iterator<Item = (&str, u32)> {
+        self.nist.keys().map(|(s, z)| (s.as_str(), *z))
+    }
+
+    /// Raw (energy_MeV_u, dedx) table for a CatIMA (proj_Z, target_Z) pair.
+    ///
+    /// Returns `None` if the pair is not loaded.
+    pub fn catima_table(&self, proj_z: u32, target_z: u32) -> Option<&XYTable> {
+        self.catima.get(&(proj_z, target_z))
+    }
+
     // --- Internal loaders ---
 
     fn load_nist(dir: &Path) -> crate::Result<HashMap<(String, u32), XYTable>> {

--- a/clients/rs/nucl-parquet/src/xs.rs
+++ b/clients/rs/nucl-parquet/src/xs.rs
@@ -167,6 +167,11 @@ impl CrossSectionDb {
     pub fn num_reactions(&self) -> usize {
         self.reactions.len()
     }
+
+    /// Iterate all reaction channel keys: (target_A, residual_Z, residual_A, state).
+    pub fn reaction_keys(&self) -> impl Iterator<Item = &(u32, u32, u32, String)> {
+        self.reactions.keys()
+    }
 }
 
 /// Derive target Z from an XS file path by extracting the element symbol.


### PR DESCRIPTION
## Summary

- `StoppingDb::nist_table(source, target_z)` — raw `&(Vec<f64>, Vec<f64>)` for NIST stopping tables
- `StoppingDb::nist_keys()` — iterate all loaded `(&str, u32)` source+target_Z pairs
- `StoppingDb::catima_table(proj_z, target_z)` — raw CatIMA energy/dedx arrays
- `CrossSectionDb::reaction_keys()` — iterate all `&(u32, u32, u32, String)` reaction channel keys

One-line accessors over existing private fields. Matches the pattern of `CrossSectionDb::entries()` which already exposes raw data.

## Consumer

hyrr-core's `stopping.rs` does Z-interpolation between tabulated elements and energy range checking — both require raw arrays, not the scalar `dedx()` interpolator. `reaction_keys()` is needed to enumerate all channels when converting a `CrossSectionDb` to hyrr's `Vec<CrossSectionData>`.

This unblocks exoma-ch/hyrr#195 (nucl-parquet SSoT migration: replace hyrr's 560-line ParquetDataStore with a 150-line adapter over nucl-parquet).

## Test plan

- [x] `cargo check` passes
- [x] All existing tests unchanged (accessors are additive, non-breaking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)