### PR TITLE
fix(decay): override G4 half-lives with nuclides catalog (#203)

### DIFF
--- a/nucl_parquet/g4/build_all.py
+++ b/nucl_parquet/g4/build_all.py
@@ -258,7 +258,37 @@ def _check_invariants(data_dir: Path) -> None:
     neg = radiation.filter(pl.col("intensity_pct") < 0)
     assert neg.height == 0, f"radiation intensity_pct < 0: {neg.head(5).to_dicts()}"
 
-    logger.info("Sweep invariants pass: parent_level_keV, IT-on-ground, phantom isomer, dedup, non-negative intensity")
+    # 6. decay.parquet half-lives must agree with nuclides catalog (#203).
+    # G4 RadioactiveDecay carries per-transition half-lives that are sometimes
+    # wrong (e.g. Sc-44 ground/metastable swapped). After the catalog override
+    # in build_decay_table, they should match. Flag any >10% disagreement.
+    decay = pl.read_parquet(data_dir / "meta" / "decay.parquet")
+    decay_hl = (
+        decay.select("Z", "A", "state", "half_life_s").unique(["Z", "A", "state"]).rename({"half_life_s": "dec_hl"})
+    )
+    nuc_hl = (
+        nuclides.select("Z", "A", "state", "half_life_s")
+        .rename({"half_life_s": "nuc_hl"})
+        .with_columns(
+            pl.col("Z").cast(pl.Int32),
+            pl.col("A").cast(pl.Int32),
+        )
+    )
+    joined = decay_hl.join(nuc_hl, on=["Z", "A", "state"], how="inner").filter(
+        (pl.col("dec_hl").is_finite())
+        & (pl.col("nuc_hl").is_finite())
+        & (pl.col("dec_hl") > 0)
+        & (pl.col("nuc_hl") > 0)
+    )
+    mismatches = joined.filter(((pl.col("dec_hl") - pl.col("nuc_hl")).abs() / pl.col("nuc_hl")) > 0.10)
+    assert mismatches.height == 0, (
+        f"decay.parquet half-lives disagree with nuclides catalog for {mismatches.height} "
+        f"(Z,A,state) entries (>10%): {mismatches.head(5).to_dicts()}"
+    )
+
+    logger.info(
+        "Sweep invariants pass: parent_level_keV, IT-on-ground, phantom isomer, dedup, non-negative intensity, half-life agreement"
+    )
 
 
 def build_all(data_dir: Path | None = None, *, skip_converters: bool = False, merge_only: bool = False) -> None:

--- a/nucl_parquet/g4/radioactive_decay.py
+++ b/nucl_parquet/g4/radioactive_decay.py
@@ -341,11 +341,30 @@ def build_decay_table(src: pl.DataFrame, nuclides_path: Path) -> pl.DataFrame:
     # Drop parents that didn't map to "" or "m": not representable in v0.10.x.
     kept = with_daughter_state.filter(pl.col("state").is_not_null())
 
+    # Override half_life_s with the authoritative nuclides catalog value.
+    # G4 RadioactiveDecay carries per-transition half-lives that are sometimes
+    # wrong (e.g. Sc-44 ground/metastable swapped). G4ENSDFSTATE (nuclides.parquet)
+    # is canonical. Falls back to the G4 value if no catalog match exists.
+    nuclides = (
+        pl.read_parquet(nuclides_path, columns=["Z", "A", "state", "half_life_s"])
+        .rename({"half_life_s": "_catalog_hl", "Z": "_nuc_z", "A": "_nuc_a", "state": "_nuc_state"})
+        .with_columns(
+            pl.col("_nuc_z").cast(pl.Int32),
+            pl.col("_nuc_a").cast(pl.Int32),
+        )
+    )
+    kept = kept.join(
+        nuclides,
+        left_on=[pl.col("parent_z").cast(pl.Int32), pl.col("parent_a").cast(pl.Int32), pl.col("state")],
+        right_on=["_nuc_z", "_nuc_a", "_nuc_state"],
+        how="left",
+    )
+
     out = kept.select(
         pl.col("parent_z").cast(pl.Int32).alias("Z"),
         pl.col("parent_a").cast(pl.Int32).alias("A"),
         pl.col("state"),
-        _convert_half_life(pl.col("half_life_s")).alias("half_life_s"),
+        _convert_half_life(pl.col("_catalog_hl").fill_null(pl.col("half_life_s"))).alias("half_life_s"),
         _build_mode_mapping_expr(pl.col("decay_mode")).alias("decay_mode"),
         # daughter_z=-1 (SpFission) → null; otherwise int32.
         pl.when(pl.col("daughter_z") < 0).then(None).otherwise(pl.col("daughter_z").cast(pl.Int32)).alias("daughter_Z"),


### PR DESCRIPTION
## Summary

G4 RadioactiveDecay has wrong half-lives for ~30 nuclides where ground/metastable values are swapped (e.g. Sc-44 ground carries 210,996s instead of 14,551s). Our `_label_state()` correctly assigns states by energy, but carries the wrong G4 half-life.

**Fix:** After state assignment, join with `nuclides.parquet` (G4ENSDFSTATE, canonical) and override `half_life_s`. Falls back to G4 value if no catalog match.

**Sweep test:** New CI invariant compares `(Z,A,state,half_life_s)` between `decay.parquet` and `nuclides.parquet` — any >10% disagreement fails the build. Catches this bug class permanently.

Before: 60 half-life mismatches. After: 0.

## Test plan

- [x] Sc-44 ground: 14,551s (was 210,996s)
- [x] Zero mismatches across all ~3200 nuclides
- [x] Sweep invariant passes in `_check_invariants()`

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)