### PR TITLE
feat(rs-client): raw table accessors for StoppingDb + CrossSectionDb (#202)

### DIFF
--- a/clients/rs/nucl-parquet/src/lib.rs
+++ b/clients/rs/nucl-parquet/src/lib.rs
@@ -54,6 +54,7 @@ mod xs;
 pub use data_dir::DataDir;
 pub use electron::{ElectronDb, ElectronProcess};
 pub use error::Error;
+pub use interp::XYTable;
 pub use meta::{
     AbundanceEntry, AbundancesDb, CoincidenceEntry, CoincidenceFilter, CoincidencesDb, DecayDb,
     DecayEntry, DoseConstant, DoseDb, Emission, EmissionEntry, GammaCandidate, RadiationDb,

--- a/clients/rs/nucl-parquet/src/stopping.rs
+++ b/clients/rs/nucl-parquet/src/stopping.rs
@@ -130,6 +130,27 @@ impl StoppingDb {
             .unwrap_or(f64::NAN)
     }
 
+    /// Raw NIST stopping power table for a (source, target_Z) pair.
+    ///
+    /// Returns `(energy_MeV[], dedx[])` sorted by energy, or `None` if not loaded.
+    #[inline]
+    pub fn nist_table(&self, source: &str, target_z: u32) -> Option<&XYTable> {
+        self.nist.get(&(source.to_string(), target_z))
+    }
+
+    /// Iterate all loaded NIST (source, target_Z) keys.
+    pub fn nist_keys(&self) -> impl Iterator<Item = (&str, u32)> + '_ {
+        self.nist.keys().map(|(s, z)| (s.as_str(), *z))
+    }
+
+    /// Raw CatIMA stopping power table for a (proj_Z, target_Z) pair.
+    ///
+    /// Returns `(energy_MeV_u[], dedx[])` sorted by energy, or `None` if not loaded.
+    #[inline]
+    pub fn catima_table(&self, proj_z: u32, target_z: u32) -> Option<&XYTable> {
+        self.catima.get(&(proj_z, target_z))
+    }
+
     // --- Internal loaders ---
 
     fn load_nist(dir: &Path) -> crate::Result<HashMap<(String, u32), XYTable>> {

--- a/clients/rs/nucl-parquet/src/xs.rs
+++ b/clients/rs/nucl-parquet/src/xs.rs
@@ -163,6 +163,13 @@ impl CrossSectionDb {
         self.target_z
     }
 
+    /// Iterate all loaded reaction channel keys: `(target_A, residual_Z, residual_A, state)`.
+    pub fn reaction_keys(&self) -> impl Iterator<Item = (u32, u32, u32, &str)> + '_ {
+        self.reactions
+            .keys()
+            .map(|(ta, rz, ra, s)| (*ta, *rz, *ra, s.as_str()))
+    }
+
     /// Number of distinct reaction channels loaded.
     pub fn num_reactions(&self) -> usize {
         self.reactions.len()


### PR DESCRIPTION
## Summary

One-line accessors over existing private fields:

- `StoppingDb::nist_table(source, target_z)` → `Option<&XYTable>`
- `StoppingDb::nist_keys()` → iterate `(&str, u32)` pairs
- `StoppingDb::catima_table(proj_z, target_z)` → `Option<&XYTable>`
- `CrossSectionDb::reaction_keys()` → iterate `(u32, u32, u32, &str)` channel keys
- Export `XYTable` type alias from crate root

Unblocks hyrr-core's Z-interpolation and channel enumeration (exoma-ch/hyrr#195).

## Test plan

- [x] `cargo check` passes
- Additive, non-breaking — all existing tests unchanged

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)