### PR TITLE
ci: run client tests on data release (#212)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_call:
 
 jobs:
   hooks:

--- a/.github/workflows/release-data.yml
+++ b/.github/workflows/release-data.yml
@@ -21,6 +21,11 @@ permissions:
   contents: write
 
 jobs:
+  # Run the full CI test suite to verify clients work with the released data.
+  verify:
+    name: Verify clients
+    uses: ./.github/workflows/ci.yml
+
   data-asset:
     name: Build & upload data tarball
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `workflow_call` trigger to `ci.yml` so it can be reused by other workflows
- Add `verify` job to `release-data.yml` that calls the CI workflow — client tests (Python/TS/Rust/Go) run on every data release

## Test plan

- [x] YAML is valid (no syntax errors)
- [x] workflow_call is additive — existing push/PR triggers unchanged

Closes #212.