### PR TITLE
feat(rs-client): add from_bytes constructors to all typed DBs

### DIFF
--- a/clients/rs/nucl-parquet/src/electron.rs
+++ b/clients/rs/nucl-parquet/src/electron.rs
@@ -59,72 +59,89 @@ impl ElectronDb {
             }
 
             let file = fs::File::open(&path)?;
-            let reader = ParquetRecordBatchReaderBuilder::try_new(file)?.build()?;
+            Self::parse_one_into(file, &mut xs_tables)?;
+        }
 
-            let mut process_data: HashMap<ElectronProcess, (Vec<f64>, Vec<f64>)> = HashMap::new();
-            let mut z_val: Option<u8> = None;
+        Ok(Self { xs_tables })
+    }
 
-            for batch in reader {
-                let batch = batch?;
+    /// Construct from a single element's EEDL Parquet bytes.
+    ///
+    /// The element Z is determined from the `Z` column in the data.
+    pub fn from_bytes(data: &[u8]) -> crate::Result<Self> {
+        let bytes = bytes::Bytes::from(data.to_vec());
+        let mut xs_tables = HashMap::new();
+        Self::parse_one_into(bytes, &mut xs_tables)?;
+        Ok(Self { xs_tables })
+    }
 
-                let z_col = batch
-                    .column_by_name("Z")
-                    .and_then(|c| c.as_any().downcast_ref::<Int32Array>());
-                let e_col = batch
-                    .column_by_name("energy_MeV")
-                    .and_then(|c| c.as_any().downcast_ref::<Float64Array>());
-                let proc_col_ref = batch.column_by_name("process");
-                let proc_values = proc_col_ref.and_then(|c| crate::interp::as_string_array(c));
-                let xs_col = batch
-                    .column_by_name("xs_barns")
-                    .and_then(|c| c.as_any().downcast_ref::<Float64Array>());
+    #[allow(clippy::type_complexity)]
+    fn parse_one_into(
+        reader_source: impl parquet::file::reader::ChunkReader + 'static,
+        xs_tables: &mut HashMap<(u8, ElectronProcess), (Vec<f64>, Vec<f64>)>,
+    ) -> crate::Result<()> {
+        let reader = ParquetRecordBatchReaderBuilder::try_new(reader_source)?.build()?;
 
-                if let (Some(z), Some(e), Some(proc), Some(xs)) =
-                    (z_col, e_col, proc_values, xs_col)
-                {
-                    #[allow(clippy::needless_range_loop)]
-                    for i in 0..batch.num_rows() {
-                        if z_val.is_none() {
-                            z_val = Some(z.value(i) as u8);
-                        }
-                        let proc_str = match proc[i] {
-                            Some(s) => s,
-                            None => continue,
-                        };
-                        let process = match proc_str {
-                            "elastic" => Some(ElectronProcess::Elastic),
-                            "bremsstrahlung" => Some(ElectronProcess::Bremsstrahlung),
-                            "excitation" => Some(ElectronProcess::Excitation),
-                            _ if proc_str.starts_with("ionization") => {
-                                Some(ElectronProcess::Ionization)
-                            }
-                            _ => None,
-                        };
-                        if let Some(p) = process {
-                            let entry = process_data.entry(p).or_default();
-                            entry.0.push(e.value(i));
-                            entry.1.push(xs.value(i));
-                        }
+        let mut process_data: HashMap<ElectronProcess, (Vec<f64>, Vec<f64>)> = HashMap::new();
+        let mut z_val: Option<u8> = None;
+
+        for batch in reader {
+            let batch = batch?;
+
+            let z_col = batch
+                .column_by_name("Z")
+                .and_then(|c| c.as_any().downcast_ref::<Int32Array>());
+            let e_col = batch
+                .column_by_name("energy_MeV")
+                .and_then(|c| c.as_any().downcast_ref::<Float64Array>());
+            let proc_col_ref = batch.column_by_name("process");
+            let proc_values = proc_col_ref.and_then(|c| crate::interp::as_string_array(c));
+            let xs_col = batch
+                .column_by_name("xs_barns")
+                .and_then(|c| c.as_any().downcast_ref::<Float64Array>());
+
+            if let (Some(z), Some(e), Some(proc), Some(xs)) = (z_col, e_col, proc_values, xs_col) {
+                #[allow(clippy::needless_range_loop)]
+                for i in 0..batch.num_rows() {
+                    if z_val.is_none() {
+                        z_val = Some(z.value(i) as u8);
                     }
-                }
-            }
-
-            if let Some(z) = z_val {
-                // Subshell ionization rows share the same energy grid; sum them.
-                if let Some((energies, xs_vals)) = process_data.remove(&ElectronProcess::Ionization)
-                {
-                    let summed = sum_by_energy(&energies, &xs_vals);
-                    process_data.insert(ElectronProcess::Ionization, summed);
-                }
-
-                for (process, (mut energies, mut xs)) in process_data {
-                    sort_paired_vecs(&mut energies, &mut xs);
-                    xs_tables.insert((z, process), (energies, xs));
+                    let proc_str = match proc[i] {
+                        Some(s) => s,
+                        None => continue,
+                    };
+                    let process = match proc_str {
+                        "elastic" => Some(ElectronProcess::Elastic),
+                        "bremsstrahlung" => Some(ElectronProcess::Bremsstrahlung),
+                        "excitation" => Some(ElectronProcess::Excitation),
+                        _ if proc_str.starts_with("ionization") => {
+                            Some(ElectronProcess::Ionization)
+                        }
+                        _ => None,
+                    };
+                    if let Some(p) = process {
+                        let entry = process_data.entry(p).or_default();
+                        entry.0.push(e.value(i));
+                        entry.1.push(xs.value(i));
+                    }
                 }
             }
         }
 
-        Ok(Self { xs_tables })
+        if let Some(z) = z_val {
+            // Subshell ionization rows share the same energy grid; sum them.
+            if let Some((energies, xs_vals)) = process_data.remove(&ElectronProcess::Ionization) {
+                let summed = sum_by_energy(&energies, &xs_vals);
+                process_data.insert(ElectronProcess::Ionization, summed);
+            }
+
+            for (process, (mut energies, mut xs)) in process_data {
+                sort_paired_vecs(&mut energies, &mut xs);
+                xs_tables.insert((z, process), (energies, xs));
+            }
+        }
+
+        Ok(())
     }
 
     /// Cross-section [barns/atom] for element Z at energy E [MeV] for a given process.
@@ -254,5 +271,40 @@ mod tests {
             xs.is_finite() && xs > 0.0,
             "Cu bremsstrahlung XS at 1 MeV: {xs}"
         );
+    }
+
+    fn data_meta_dir() -> std::path::PathBuf {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("..")
+            .join("data")
+            .join("meta")
+    }
+
+    #[test]
+    #[ignore = "requires nucl-parquet data files"]
+    fn from_bytes_matches_open() {
+        let db_file = ElectronDb::open(data_meta_dir()).unwrap();
+        let eedl_dir = data_meta_dir().join("eedl");
+        let first_file = std::fs::read_dir(&eedl_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .find(|e| e.path().extension().and_then(|x| x.to_str()) == Some("parquet"))
+            .expect("at least one EEDL file");
+        let data = std::fs::read(first_file.path()).unwrap();
+        let db_bytes = ElectronDb::from_bytes(&data).unwrap();
+        // Find the Z loaded and compare
+        for z in 1..=100u8 {
+            if db_bytes.has_element(z) {
+                let xs_file = db_file.cross_section(z, 1.0, ElectronProcess::Elastic);
+                let xs_bytes = db_bytes.cross_section(z, 1.0, ElectronProcess::Elastic);
+                assert!(
+                    (xs_file - xs_bytes).abs() < 1e-12,
+                    "Z={z} elastic XS mismatch: {xs_file} vs {xs_bytes}"
+                );
+                break;
+            }
+        }
     }
 }

--- a/clients/rs/nucl-parquet/src/meta.rs
+++ b/clients/rs/nucl-parquet/src/meta.rs
@@ -61,10 +61,21 @@ impl AbundancesDb {
     /// Load isotopic abundance data from `meta/abundances.parquet`.
     pub fn open(data_dir: impl AsRef<Path>) -> crate::Result<Self> {
         let path = data_dir.as_ref().join("abundances.parquet");
+        let file = fs::File::open(&path)?;
+        Self::parse(file)
+    }
+
+    /// Construct from in-memory Parquet bytes.
+    pub fn from_bytes(data: &[u8]) -> crate::Result<Self> {
+        Self::parse(bytes::Bytes::from(data.to_vec()))
+    }
+
+    fn parse(
+        reader_source: impl parquet::file::reader::ChunkReader + 'static,
+    ) -> crate::Result<Self> {
         let mut data: HashMap<u32, Vec<AbundanceEntry>> = HashMap::new();
 
-        let file = fs::File::open(&path)?;
-        let reader = ParquetRecordBatchReaderBuilder::try_new(file)?.build()?;
+        let reader = ParquetRecordBatchReaderBuilder::try_new(reader_source)?.build()?;
 
         for batch in reader {
             let batch = batch?;
@@ -160,10 +171,21 @@ impl DecayDb {
     /// Load decay data from `meta/decay.parquet`.
     pub fn open(data_dir: impl AsRef<Path>) -> crate::Result<Self> {
         let path = data_dir.as_ref().join("decay.parquet");
+        let file = fs::File::open(&path)?;
+        Self::parse(file)
+    }
+
+    /// Construct from in-memory Parquet bytes.
+    pub fn from_bytes(data: &[u8]) -> crate::Result<Self> {
+        Self::parse(bytes::Bytes::from(data.to_vec()))
+    }
+
+    fn parse(
+        reader_source: impl parquet::file::reader::ChunkReader + 'static,
+    ) -> crate::Result<Self> {
         let mut data: HashMap<(u32, u32), Vec<DecayEntry>> = HashMap::new();
 
-        let file = fs::File::open(&path)?;
-        let reader = ParquetRecordBatchReaderBuilder::try_new(file)?.build()?;
+        let reader = ParquetRecordBatchReaderBuilder::try_new(reader_source)?.build()?;
 
         for batch in reader {
             let batch = batch?;
@@ -287,10 +309,21 @@ impl DoseDb {
     /// Load dose constant data from `meta/dose_constants.parquet`.
     pub fn open(data_dir: impl AsRef<Path>) -> crate::Result<Self> {
         let path = data_dir.as_ref().join("dose_constants.parquet");
+        let file = fs::File::open(&path)?;
+        Self::parse(file)
+    }
+
+    /// Construct from in-memory Parquet bytes.
+    pub fn from_bytes(data: &[u8]) -> crate::Result<Self> {
+        Self::parse(bytes::Bytes::from(data.to_vec()))
+    }
+
+    fn parse(
+        reader_source: impl parquet::file::reader::ChunkReader + 'static,
+    ) -> crate::Result<Self> {
         let mut data: HashMap<(u32, u32, String), DoseConstant> = HashMap::new();
 
-        let file = fs::File::open(&path)?;
-        let reader = ParquetRecordBatchReaderBuilder::try_new(file)?.build()?;
+        let reader = ParquetRecordBatchReaderBuilder::try_new(reader_source)?.build()?;
 
         for batch in reader {
             let batch = batch?;
@@ -474,10 +507,33 @@ impl CoincidencesDb {
         Ok(arc)
     }
 
+    /// Load a single element's coincidence data from in-memory Parquet bytes,
+    /// bypassing the lazy directory-based loader.
+    ///
+    /// The returned entries are cached under `z` for subsequent lookups via
+    /// [`pairs`](Self::pairs) and [`pairs_filtered`](Self::pairs_filtered).
+    pub fn from_element_bytes(
+        &self,
+        z: u32,
+        data: &[u8],
+    ) -> crate::Result<Arc<Vec<CoincidenceEntry>>> {
+        let bytes = bytes::Bytes::from(data.to_vec());
+        let entries = Self::parse_reader(bytes)?;
+        let arc = Arc::new(entries);
+        self.cache.write().unwrap().insert(z, Arc::clone(&arc));
+        Ok(arc)
+    }
+
     fn load_file(path: &Path) -> crate::Result<Vec<CoincidenceEntry>> {
-        let mut out: Vec<CoincidenceEntry> = Vec::new();
         let file = fs::File::open(path)?;
-        let reader = ParquetRecordBatchReaderBuilder::try_new(file)?.build()?;
+        Self::parse_reader(file)
+    }
+
+    fn parse_reader(
+        reader_source: impl parquet::file::reader::ChunkReader + 'static,
+    ) -> crate::Result<Vec<CoincidenceEntry>> {
+        let mut out: Vec<CoincidenceEntry> = Vec::new();
+        let reader = ParquetRecordBatchReaderBuilder::try_new(reader_source)?.build()?;
 
         for batch in reader {
             let batch = batch?;
@@ -817,10 +873,37 @@ impl RadiationDb {
         Ok(arc)
     }
 
+    /// Load a single element's radiation data from in-memory Parquet bytes,
+    /// bypassing the lazy directory-based loader.
+    ///
+    /// The returned entries are cached under `z` for subsequent lookups via
+    /// [`emissions`](Self::emissions) and related methods.
+    ///
+    /// **Note:** the cross-isotope γ index used by [`identify_gamma`](Self::identify_gamma)
+    /// is built from on-disk files only. If you need `identify_gamma` with
+    /// bytes-only data, load via the standard `open()` path.
+    pub fn from_element_bytes(
+        &self,
+        z: u32,
+        data: &[u8],
+    ) -> crate::Result<Arc<Vec<EmissionEntry>>> {
+        let bytes = bytes::Bytes::from(data.to_vec());
+        let entries = Self::parse_reader(bytes)?;
+        let arc = Arc::new(entries);
+        self.cache.write().unwrap().insert(z, Arc::clone(&arc));
+        Ok(arc)
+    }
+
     fn load_file(path: &Path) -> crate::Result<Vec<EmissionEntry>> {
-        let mut out: Vec<EmissionEntry> = Vec::new();
         let file = fs::File::open(path)?;
-        let reader = ParquetRecordBatchReaderBuilder::try_new(file)?.build()?;
+        Self::parse_reader(file)
+    }
+
+    fn parse_reader(
+        reader_source: impl parquet::file::reader::ChunkReader + 'static,
+    ) -> crate::Result<Vec<EmissionEntry>> {
+        let mut out: Vec<EmissionEntry> = Vec::new();
+        let reader = ParquetRecordBatchReaderBuilder::try_new(reader_source)?.build()?;
 
         for batch in reader {
             let batch = batch?;
@@ -1222,5 +1305,96 @@ mod tests {
         let dc = dc.unwrap();
         assert!(dc.k > 0.0, "I-131 dose constant should be positive");
         assert_eq!(dc.source, "ensdf", "I-131 source should be 'ensdf'");
+    }
+
+    #[test]
+    #[ignore = "requires nucl-parquet data files"]
+    fn abundances_from_bytes_matches_open() {
+        let path = meta_dir().join("abundances.parquet");
+        let db_file = AbundancesDb::open(meta_dir()).unwrap();
+        let data = std::fs::read(&path).unwrap();
+        let db_bytes = AbundancesDb::from_bytes(&data).unwrap();
+        // Cu-63 abundance should match
+        let ab_file = db_file.abundance(29, 63);
+        let ab_bytes = db_bytes.abundance(29, 63);
+        assert!(
+            (ab_file - ab_bytes).abs() < 1e-12,
+            "Cu-63 abundance mismatch: {ab_file} vs {ab_bytes}"
+        );
+    }
+
+    #[test]
+    #[ignore = "requires nucl-parquet data files"]
+    fn decay_from_bytes_matches_open() {
+        let path = meta_dir().join("decay.parquet");
+        let db_file = DecayDb::open(meta_dir()).unwrap();
+        let data = std::fs::read(&path).unwrap();
+        let db_bytes = DecayDb::from_bytes(&data).unwrap();
+        let modes_file = db_file.modes(29, 64, "");
+        let modes_bytes = db_bytes.modes(29, 64, "");
+        assert_eq!(
+            modes_file.len(),
+            modes_bytes.len(),
+            "Cu-64 decay mode count mismatch"
+        );
+    }
+
+    #[test]
+    #[ignore = "requires nucl-parquet data files"]
+    fn dose_from_bytes_matches_open() {
+        let path = meta_dir().join("dose_constants.parquet");
+        let db_file = DoseDb::open(meta_dir()).unwrap();
+        let data = std::fs::read(&path).unwrap();
+        let db_bytes = DoseDb::from_bytes(&data).unwrap();
+        let dc_file = db_file.dose_constant(53, 131, "").unwrap();
+        let dc_bytes = db_bytes.dose_constant(53, 131, "").unwrap();
+        assert!(
+            (dc_file.k - dc_bytes.k).abs() < 1e-12,
+            "I-131 dose constant mismatch: {} vs {}",
+            dc_file.k,
+            dc_bytes.k
+        );
+    }
+
+    #[test]
+    #[ignore = "requires nucl-parquet data files"]
+    fn coincidences_from_element_bytes() {
+        let db = CoincidencesDb::open(meta_dir()).unwrap();
+        // Load Ni (Z=28) from file normally
+        let pairs_file = db.pairs(28, 60).unwrap();
+        // Now load from bytes
+        let path = meta_dir()
+            .join("ensdf")
+            .join("coincidences")
+            .join("Ni.parquet");
+        let data = std::fs::read(&path).unwrap();
+        let db2 = CoincidencesDb::open(meta_dir()).unwrap();
+        db2.from_element_bytes(28, &data).unwrap();
+        let pairs_bytes = db2.pairs(28, 60).unwrap();
+        assert_eq!(
+            pairs_file.len(),
+            pairs_bytes.len(),
+            "Ni-60 coincidence pair count mismatch"
+        );
+    }
+
+    #[test]
+    #[ignore = "requires nucl-parquet data files"]
+    fn radiation_from_element_bytes() {
+        let db = RadiationDb::open(meta_dir()).unwrap();
+        let lines_file = db.emissions(28, 60, "").unwrap();
+        let path = meta_dir()
+            .join("ensdf")
+            .join("radiation")
+            .join("Ni.parquet");
+        let data = std::fs::read(&path).unwrap();
+        let db2 = RadiationDb::open(meta_dir()).unwrap();
+        db2.from_element_bytes(28, &data).unwrap();
+        let lines_bytes = db2.emissions(28, 60, "").unwrap();
+        assert_eq!(
+            lines_file.len(),
+            lines_bytes.len(),
+            "Ni-60 emission line count mismatch"
+        );
     }
 }

--- a/clients/rs/nucl-parquet/src/photon.rs
+++ b/clients/rs/nucl-parquet/src/photon.rs
@@ -117,6 +117,22 @@ impl PhotonDb {
         })
     }
 
+    /// Construct from a single element's photon XS Parquet bytes.
+    ///
+    /// Loads only per-process cross-sections; form factors and scattering
+    /// functions will be empty. Use [`open`](Self::open) for the full dataset
+    /// including form factors and scattering functions.
+    pub fn from_bytes(data: &[u8]) -> crate::Result<Self> {
+        let bytes = bytes::Bytes::from(data.to_vec());
+        let mut xs_tables = HashMap::new();
+        Self::parse_xs_into(bytes, &mut xs_tables)?;
+        Ok(Self {
+            xs_tables,
+            form_factors: HashMap::new(),
+            scattering_fns: HashMap::new(),
+        })
+    }
+
     /// Interpolate cross-section [barns/atom] for element Z at energy E [MeV].
     ///
     /// Returns 0.0 if the element or process is not in the database.
@@ -209,102 +225,112 @@ impl PhotonDb {
             }
 
             let file = fs::File::open(&path)?;
-            let reader = ParquetRecordBatchReaderBuilder::try_new(file)?.build()?;
+            Self::parse_xs_into(file, &mut tables)?;
+        }
 
-            // Accumulate rows per process
-            let mut process_data: HashMap<Process, (Vec<f64>, Vec<f64>)> = HashMap::new();
-            let mut z_val: Option<u8> = None;
+        Ok(tables)
+    }
 
-            for batch in reader {
-                let batch = batch?;
+    fn parse_xs_into(
+        reader_source: impl parquet::file::reader::ChunkReader + 'static,
+        tables: &mut HashMap<(u8, Process), XsTable>,
+    ) -> crate::Result<()> {
+        let reader = ParquetRecordBatchReaderBuilder::try_new(reader_source)?.build()?;
 
-                let z_col = batch
-                    .column_by_name("Z")
-                    .ok_or_else(|| Error::MissingColumn {
-                        file: path.clone(),
-                        column: "Z".into(),
-                    })?
-                    .as_any()
-                    .downcast_ref::<Int32Array>()
-                    .ok_or_else(|| Error::MissingColumn {
-                        file: path.clone(),
-                        column: "Z (wrong type)".into(),
-                    })?;
+        // Accumulate rows per process
+        let mut process_data: HashMap<Process, (Vec<f64>, Vec<f64>)> = HashMap::new();
+        let mut z_val: Option<u8> = None;
 
-                let e_col = batch
-                    .column_by_name("energy_MeV")
-                    .ok_or_else(|| Error::MissingColumn {
-                        file: path.clone(),
-                        column: "energy_MeV".into(),
-                    })?
-                    .as_any()
-                    .downcast_ref::<Float64Array>()
-                    .ok_or_else(|| Error::MissingColumn {
-                        file: path.clone(),
-                        column: "energy_MeV (wrong type)".into(),
-                    })?;
+        // Sentinel path for error messages when loading from bytes.
+        let sentinel = std::path::PathBuf::from("<bytes>");
 
-                let proc_col =
-                    batch
-                        .column_by_name("process")
-                        .ok_or_else(|| Error::MissingColumn {
-                            file: path.clone(),
-                            column: "process".into(),
-                        })?;
-                let proc_values = crate::interp::as_string_array(proc_col).ok_or_else(|| {
-                    Error::MissingColumn {
-                        file: path.clone(),
-                        column: "process (wrong type)".into(),
-                    }
+        for batch in reader {
+            let batch = batch?;
+
+            let z_col = batch
+                .column_by_name("Z")
+                .ok_or_else(|| Error::MissingColumn {
+                    file: sentinel.clone(),
+                    column: "Z".into(),
+                })?
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .ok_or_else(|| Error::MissingColumn {
+                    file: sentinel.clone(),
+                    column: "Z (wrong type)".into(),
                 })?;
 
-                let xs_col = batch
-                    .column_by_name("xs_barns")
-                    .ok_or_else(|| Error::MissingColumn {
-                        file: path.clone(),
-                        column: "xs_barns".into(),
-                    })?
-                    .as_any()
-                    .downcast_ref::<Float64Array>()
-                    .ok_or_else(|| Error::MissingColumn {
-                        file: path.clone(),
-                        column: "xs_barns (wrong type)".into(),
-                    })?;
+            let e_col = batch
+                .column_by_name("energy_MeV")
+                .ok_or_else(|| Error::MissingColumn {
+                    file: sentinel.clone(),
+                    column: "energy_MeV".into(),
+                })?
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .ok_or_else(|| Error::MissingColumn {
+                    file: sentinel.clone(),
+                    column: "energy_MeV (wrong type)".into(),
+                })?;
 
-                #[allow(clippy::needless_range_loop)]
-                for i in 0..batch.num_rows() {
-                    if z_val.is_none() {
-                        z_val = Some(z_col.value(i) as u8);
-                    }
+            let proc_col = batch
+                .column_by_name("process")
+                .ok_or_else(|| Error::MissingColumn {
+                    file: sentinel.clone(),
+                    column: "process".into(),
+                })?;
+            let proc_values =
+                crate::interp::as_string_array(proc_col).ok_or_else(|| Error::MissingColumn {
+                    file: sentinel.clone(),
+                    column: "process (wrong type)".into(),
+                })?;
 
-                    let proc_str = match proc_values[i] {
-                        Some(s) => s,
-                        None => continue,
-                    };
-                    if let Some(process) = Process::from_str(proc_str) {
-                        let entry = process_data.entry(process).or_default();
-                        entry.0.push(e_col.value(i));
-                        entry.1.push(xs_col.value(i));
-                    }
+            let xs_col = batch
+                .column_by_name("xs_barns")
+                .ok_or_else(|| Error::MissingColumn {
+                    file: sentinel.clone(),
+                    column: "xs_barns".into(),
+                })?
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .ok_or_else(|| Error::MissingColumn {
+                    file: sentinel.clone(),
+                    column: "xs_barns (wrong type)".into(),
+                })?;
+
+            #[allow(clippy::needless_range_loop)]
+            for i in 0..batch.num_rows() {
+                if z_val.is_none() {
+                    z_val = Some(z_col.value(i) as u8);
                 }
-            }
 
-            if let Some(z) = z_val {
-                for (process, (mut energy, mut xs)) in process_data {
-                    // Sort by energy (should already be sorted, but ensure)
-                    let mut indices: Vec<usize> = (0..energy.len()).collect();
-                    indices.sort_by(|&a, &b| energy[a].partial_cmp(&energy[b]).unwrap());
-                    let sorted_e: Vec<f64> = indices.iter().map(|&i| energy[i]).collect();
-                    let sorted_xs: Vec<f64> = indices.iter().map(|&i| xs[i]).collect();
-                    energy = sorted_e;
-                    xs = sorted_xs;
-
-                    tables.insert((z, process), XsTable { energy, xs });
+                let proc_str = match proc_values[i] {
+                    Some(s) => s,
+                    None => continue,
+                };
+                if let Some(process) = Process::from_str(proc_str) {
+                    let entry = process_data.entry(process).or_default();
+                    entry.0.push(e_col.value(i));
+                    entry.1.push(xs_col.value(i));
                 }
             }
         }
 
-        Ok(tables)
+        if let Some(z) = z_val {
+            for (process, (mut energy, mut xs)) in process_data {
+                // Sort by energy (should already be sorted, but ensure)
+                let mut indices: Vec<usize> = (0..energy.len()).collect();
+                indices.sort_by(|&a, &b| energy[a].partial_cmp(&energy[b]).unwrap());
+                let sorted_e: Vec<f64> = indices.iter().map(|&i| energy[i]).collect();
+                let sorted_xs: Vec<f64> = indices.iter().map(|&i| xs[i]).collect();
+                energy = sorted_e;
+                xs = sorted_xs;
+
+                tables.insert((z, process), XsTable { energy, xs });
+            }
+        }
+
+        Ok(())
     }
 
     fn load_tab_tables(dir: &Path, value_col_name: &str) -> crate::Result<HashMap<u8, TabTable>> {
@@ -390,6 +416,48 @@ mod tests {
     // Integration tests require actual data files.
     // Run with: cargo test -- --ignored
     // from the nucl-parquet repo root.
+
+    fn data_meta_dir() -> std::path::PathBuf {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("..")
+            .join("data")
+            .join("meta")
+    }
+
+    #[test]
+    #[ignore = "requires nucl-parquet data files"]
+    fn from_bytes_matches_open() {
+        let db_file = PhotonDb::open(data_meta_dir()).unwrap();
+        let xs_dir = data_meta_dir().join("epdl97").join("photon_xs");
+        let first_file = std::fs::read_dir(&xs_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .find(|e| {
+                let p = e.path();
+                p.extension().and_then(|x| x.to_str()) == Some("parquet")
+                    && !p
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .is_some_and(|n| n.starts_with("._"))
+            })
+            .expect("at least one photon_xs file");
+        let data = std::fs::read(first_file.path()).unwrap();
+        let db_bytes = PhotonDb::from_bytes(&data).unwrap();
+        // Find the Z loaded and compare a cross-section
+        for z in 1..=100u8 {
+            if db_bytes.has_element(z) {
+                let xs_file = db_file.cross_section(z, 0.511, Process::Total);
+                let xs_bytes = db_bytes.cross_section(z, 0.511, Process::Total);
+                assert!(
+                    (xs_file - xs_bytes).abs() < 1e-12,
+                    "Z={z} total XS mismatch: {xs_file} vs {xs_bytes}"
+                );
+                break;
+            }
+        }
+    }
 
     #[test]
     #[ignore = "requires nucl-parquet data files"]

--- a/clients/rs/nucl-parquet/src/relaxation.rs
+++ b/clients/rs/nucl-parquet/src/relaxation.rs
@@ -66,73 +66,97 @@ impl RelaxationDb {
             }
 
             let file = fs::File::open(&path)?;
-            let reader = ParquetRecordBatchReaderBuilder::try_new(file)?.build()?;
+            if let Some((z, trans_list)) = Self::parse_one(file)? {
+                transitions.insert(z, trans_list);
+            }
+        }
 
-            let mut z_val: Option<u8> = None;
-            let mut trans_list = Vec::new();
+        Ok(Self { transitions })
+    }
 
-            for batch in reader {
-                let batch = batch?;
+    /// Construct from a single element's EADL Parquet bytes.
+    ///
+    /// The element Z is determined from the `Z` column in the data.
+    pub fn from_bytes(data: &[u8]) -> crate::Result<Self> {
+        let bytes = bytes::Bytes::from(data.to_vec());
+        let mut transitions: HashMap<u8, Vec<Transition>> = HashMap::new();
+        if let Some((z, trans_list)) = Self::parse_one(bytes)? {
+            transitions.insert(z, trans_list);
+        }
+        Ok(Self { transitions })
+    }
 
-                let z_col = batch
-                    .column_by_name("Z")
-                    .and_then(|c| c.as_any().downcast_ref::<Int32Array>());
-                let vac_col_ref = batch.column_by_name("vacancy_shell");
-                let vac_values = vac_col_ref.and_then(|c| crate::interp::as_string_array(c));
-                let fill_col_ref = batch.column_by_name("filling_shell");
-                let fill_values = fill_col_ref.and_then(|c| crate::interp::as_string_array(c));
-                let type_col_ref = batch.column_by_name("transition_type");
-                let type_values = type_col_ref.and_then(|c| crate::interp::as_string_array(c));
-                let energy_col = batch
-                    .column_by_name("energy_keV")
-                    .and_then(|c| c.as_any().downcast_ref::<Float64Array>());
-                let prob_col = batch
-                    .column_by_name("probability")
-                    .and_then(|c| c.as_any().downcast_ref::<Float64Array>());
-                let edge_col = batch
-                    .column_by_name("edge_keV")
-                    .and_then(|c| c.as_any().downcast_ref::<Float64Array>());
+    /// Parse a single parquet source into (Z, transitions).
+    fn parse_one(
+        reader_source: impl parquet::file::reader::ChunkReader + 'static,
+    ) -> crate::Result<Option<(u8, Vec<Transition>)>> {
+        let reader = ParquetRecordBatchReaderBuilder::try_new(reader_source)?.build()?;
 
-                if let (Some(z), Some(vac), Some(fill), Some(tt), Some(e), Some(p), Some(edge)) = (
-                    z_col,
-                    vac_values,
-                    fill_values,
-                    type_values,
-                    energy_col,
-                    prob_col,
-                    edge_col,
-                ) {
-                    for i in 0..batch.num_rows() {
-                        if z_val.is_none() {
-                            z_val = Some(z.value(i) as u8);
-                        }
-                        trans_list.push(Transition {
-                            vacancy_shell: vac[i].unwrap_or("").to_string(),
-                            filling_shell: fill[i].unwrap_or("").to_string(),
-                            transition_type: match tt[i].unwrap_or("") {
-                                "radiative" => TransitionType::Radiative,
-                                _ => TransitionType::Auger,
-                            },
-                            energy_kev: e.value(i),
-                            probability: p.value(i),
-                            edge_kev: edge.value(i),
-                        });
+        let mut z_val: Option<u8> = None;
+        let mut trans_list = Vec::new();
+
+        for batch in reader {
+            let batch = batch?;
+
+            let z_col = batch
+                .column_by_name("Z")
+                .and_then(|c| c.as_any().downcast_ref::<Int32Array>());
+            let vac_col_ref = batch.column_by_name("vacancy_shell");
+            let vac_values = vac_col_ref.and_then(|c| crate::interp::as_string_array(c));
+            let fill_col_ref = batch.column_by_name("filling_shell");
+            let fill_values = fill_col_ref.and_then(|c| crate::interp::as_string_array(c));
+            let type_col_ref = batch.column_by_name("transition_type");
+            let type_values = type_col_ref.and_then(|c| crate::interp::as_string_array(c));
+            let energy_col = batch
+                .column_by_name("energy_keV")
+                .and_then(|c| c.as_any().downcast_ref::<Float64Array>());
+            let prob_col = batch
+                .column_by_name("probability")
+                .and_then(|c| c.as_any().downcast_ref::<Float64Array>());
+            let edge_col = batch
+                .column_by_name("edge_keV")
+                .and_then(|c| c.as_any().downcast_ref::<Float64Array>());
+
+            if let (Some(z), Some(vac), Some(fill), Some(tt), Some(e), Some(p), Some(edge)) = (
+                z_col,
+                vac_values,
+                fill_values,
+                type_values,
+                energy_col,
+                prob_col,
+                edge_col,
+            ) {
+                for i in 0..batch.num_rows() {
+                    if z_val.is_none() {
+                        z_val = Some(z.value(i) as u8);
                     }
+                    trans_list.push(Transition {
+                        vacancy_shell: vac[i].unwrap_or("").to_string(),
+                        filling_shell: fill[i].unwrap_or("").to_string(),
+                        transition_type: match tt[i].unwrap_or("") {
+                            "radiative" => TransitionType::Radiative,
+                            _ => TransitionType::Auger,
+                        },
+                        energy_kev: e.value(i),
+                        probability: p.value(i),
+                        edge_kev: edge.value(i),
+                    });
                 }
             }
+        }
 
-            if let Some(z) = z_val {
+        match z_val {
+            Some(z) => {
                 // Sort by shell, then probability descending
                 trans_list.sort_by(|a, b| {
                     a.vacancy_shell
                         .cmp(&b.vacancy_shell)
                         .then(b.probability.partial_cmp(&a.probability).unwrap())
                 });
-                transitions.insert(z, trans_list);
+                Ok(Some((z, trans_list)))
             }
+            None => Ok(None),
         }
-
-        Ok(Self { transitions })
     }
 
     /// Get all transitions for element Z.
@@ -177,6 +201,51 @@ impl RelaxationDb {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn data_meta_dir() -> std::path::PathBuf {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("..")
+            .join("data")
+            .join("meta")
+    }
+
+    #[test]
+    #[ignore = "requires nucl-parquet data files"]
+    fn from_bytes_matches_open() {
+        let db_file = RelaxationDb::open(data_meta_dir()).unwrap();
+        assert!(db_file.has_element(29));
+        // Read the first valid EADL file and load via from_bytes
+        let eadl_dir = data_meta_dir().join("eadl");
+        let first_file = std::fs::read_dir(&eadl_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .find(|e| {
+                e.path().extension().and_then(|x| x.to_str()) == Some("parquet")
+                    && !e
+                        .path()
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .is_some_and(|n| n.starts_with("._"))
+            })
+            .expect("at least one EADL file");
+        let data = std::fs::read(first_file.path()).unwrap();
+        let db_bytes = RelaxationDb::from_bytes(&data).unwrap();
+        // Find what Z the bytes DB loaded and verify transitions match the file DB
+        for z in 1..=100u8 {
+            if db_bytes.has_element(z) {
+                let t_file = db_file.transitions(z);
+                let t_bytes = db_bytes.transitions(z);
+                assert_eq!(
+                    t_file.len(),
+                    t_bytes.len(),
+                    "Z={z} transition count mismatch"
+                );
+                break;
+            }
+        }
+    }
 
     #[test]
     #[ignore = "requires nucl-parquet data files"]

--- a/clients/rs/nucl-parquet/src/stopping.rs
+++ b/clients/rs/nucl-parquet/src/stopping.rs
@@ -73,6 +73,28 @@ impl StoppingDb {
         })
     }
 
+    /// Construct from in-memory NIST Parquet bytes (a single `*.parquet` file
+    /// containing `source`, `target_Z`, `energy_MeV`, `dedx` columns).
+    ///
+    /// Compounds and CatIMA data will be empty. Suitable for loading a single
+    /// PSTAR/ASTAR/ESTAR/dSTAR/tSTAR file from bytes.
+    pub fn from_bytes(data: &[u8]) -> crate::Result<Self> {
+        let bytes = bytes::Bytes::from(data.to_vec());
+        let mut nist: HashMap<(String, u32), XYTable> = HashMap::new();
+        Self::parse_nist_into(bytes, &mut nist)?;
+
+        for (e_vec, s_vec) in nist.values_mut() {
+            sort_paired_vecs(e_vec, s_vec);
+        }
+
+        Ok(Self {
+            nist,
+            compounds: HashMap::new(),
+            catima: HashMap::new(),
+            catima_strag: HashMap::new(),
+        })
+    }
+
     /// Mass stopping power [MeV cm²/g] for a NIST source.
     ///
     /// Valid `source` values: `"PSTAR"`, `"ASTAR"`, `"ESTAR"`, `"dSTAR"`, `"tSTAR"`.
@@ -167,33 +189,7 @@ impl StoppingDb {
             }
 
             let file = fs::File::open(&path)?;
-            let reader = ParquetRecordBatchReaderBuilder::try_new(file)?.build()?;
-
-            for batch in reader {
-                let batch = batch?;
-
-                let src_col_ref = batch.column_by_name("source");
-                let src_values = src_col_ref.and_then(|c| crate::interp::as_string_array(c));
-                let z_col = batch
-                    .column_by_name("target_Z")
-                    .and_then(|c| c.as_any().downcast_ref::<Int32Array>());
-                let e_col = batch
-                    .column_by_name("energy_MeV")
-                    .and_then(|c| c.as_any().downcast_ref::<Float64Array>());
-                let s_col = batch
-                    .column_by_name("dedx")
-                    .and_then(|c| c.as_any().downcast_ref::<Float64Array>());
-
-                if let (Some(src), Some(z), Some(e), Some(s)) = (src_values, z_col, e_col, s_col) {
-                    #[allow(clippy::needless_range_loop)]
-                    for i in 0..batch.num_rows() {
-                        let key = (src[i].unwrap_or("").to_string(), z.value(i) as u32);
-                        let entry = map.entry(key).or_default();
-                        entry.0.push(e.value(i));
-                        entry.1.push(s.value(i));
-                    }
-                }
-            }
+            Self::parse_nist_into(file, &mut map)?;
         }
 
         for (e_vec, s_vec) in map.values_mut() {
@@ -201,6 +197,41 @@ impl StoppingDb {
         }
 
         Ok(map)
+    }
+
+    fn parse_nist_into(
+        reader_source: impl parquet::file::reader::ChunkReader + 'static,
+        map: &mut HashMap<(String, u32), XYTable>,
+    ) -> crate::Result<()> {
+        let reader = ParquetRecordBatchReaderBuilder::try_new(reader_source)?.build()?;
+
+        for batch in reader {
+            let batch = batch?;
+
+            let src_col_ref = batch.column_by_name("source");
+            let src_values = src_col_ref.and_then(|c| crate::interp::as_string_array(c));
+            let z_col = batch
+                .column_by_name("target_Z")
+                .and_then(|c| c.as_any().downcast_ref::<Int32Array>());
+            let e_col = batch
+                .column_by_name("energy_MeV")
+                .and_then(|c| c.as_any().downcast_ref::<Float64Array>());
+            let s_col = batch
+                .column_by_name("dedx")
+                .and_then(|c| c.as_any().downcast_ref::<Float64Array>());
+
+            if let (Some(src), Some(z), Some(e), Some(s)) = (src_values, z_col, e_col, s_col) {
+                #[allow(clippy::needless_range_loop)]
+                for i in 0..batch.num_rows() {
+                    let key = (src[i].unwrap_or("").to_string(), z.value(i) as u32);
+                    let entry = map.entry(key).or_default();
+                    entry.0.push(e.value(i));
+                    entry.1.push(s.value(i));
+                }
+            }
+        }
+
+        Ok(())
     }
 
     fn load_compounds(dir: &Path) -> crate::Result<HashMap<(String, String), XYTable>> {
@@ -395,6 +426,36 @@ mod tests {
         assert!(db
             .compound_dedx("PSTAR_compound", "NONEXISTENT", 10.0)
             .is_nan());
+    }
+
+    #[test]
+    #[ignore = "requires nucl-parquet data files"]
+    fn from_bytes_matches_open() {
+        let db_file = StoppingDb::open(data_dir()).unwrap();
+        // Read the first NIST parquet file
+        let first_file = std::fs::read_dir(data_dir())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .find(|e| {
+                let p = e.path();
+                !p.is_dir() && p.extension().and_then(|x| x.to_str()) == Some("parquet")
+            })
+            .expect("at least one stopping file");
+        let data = std::fs::read(first_file.path()).unwrap();
+        let db_bytes = StoppingDb::from_bytes(&data).unwrap();
+        // Find a loaded (source, Z) and compare
+        for (source, z) in db_bytes.nist_keys().take(3) {
+            let val_file = db_file.dedx(source, z, 10.0);
+            let val_bytes = db_bytes.dedx(source, z, 10.0);
+            if val_file.is_finite() && val_bytes.is_finite() {
+                assert!(
+                    (val_file - val_bytes).abs() / val_file < 1e-10,
+                    "{source} Z={z} dedx mismatch: {val_file} vs {val_bytes}"
+                );
+                return;
+            }
+        }
+        panic!("no matching NIST key found");
     }
 
     #[test]

--- a/clients/rs/nucl-parquet/src/subshell_pe.rs
+++ b/clients/rs/nucl-parquet/src/subshell_pe.rs
@@ -52,60 +52,12 @@ impl SubshellPeDb {
             }
 
             let file = fs::File::open(&path)?;
-            let reader = ParquetRecordBatchReaderBuilder::try_new(file)?.build()?;
-
-            let mut shell_data: HashMap<String, (Vec<f64>, Vec<f64>, f64)> = HashMap::new();
-            let mut z_val: Option<u8> = None;
-
-            for batch in reader {
-                let batch = batch?;
-
-                let z_col = batch
-                    .column_by_name("Z")
-                    .and_then(|c| c.as_any().downcast_ref::<Int32Array>());
-                let e_col = batch
-                    .column_by_name("energy_MeV")
-                    .and_then(|c| c.as_any().downcast_ref::<Float64Array>());
-                let shell_col_ref = batch.column_by_name("subshell");
-                let shell_values = shell_col_ref.and_then(|c| crate::interp::as_string_array(c));
-                let xs_col = batch
-                    .column_by_name("xs_barns")
-                    .and_then(|c| c.as_any().downcast_ref::<Float64Array>());
-                let edge_col = batch
-                    .column_by_name("edge_MeV")
-                    .and_then(|c| c.as_any().downcast_ref::<Float64Array>());
-
-                if let (Some(z), Some(e), Some(shell), Some(xs), Some(edge)) =
-                    (z_col, e_col, shell_values, xs_col, edge_col)
-                {
-                    #[allow(clippy::needless_range_loop)]
-                    for i in 0..batch.num_rows() {
-                        if z_val.is_none() {
-                            z_val = Some(z.value(i) as u8);
-                        }
-                        let shell_name = shell[i].unwrap_or("").to_string();
-                        let entry = shell_data
-                            .entry(shell_name)
-                            .or_insert_with(|| (Vec::new(), Vec::new(), edge.value(i)));
-                        entry.0.push(e.value(i));
-                        entry.1.push(xs.value(i));
-                    }
-                }
-            }
-
-            if let Some(z) = z_val {
-                let mut names: Vec<String> = shell_data.keys().cloned().collect();
-                names.sort();
-
-                for (idx, name) in names.iter().enumerate() {
-                    let (mut energies, mut xs, edge) = shell_data.remove(name).expect("key exists");
-                    sort_paired_vecs(&mut energies, &mut xs);
-                    let shell_idx = idx as u8;
-                    xs_tables.insert((z, shell_idx), (energies, xs));
-                    binding_energies.insert((z, shell_idx), edge);
-                }
-                shell_names.insert(z, names);
-            }
+            Self::parse_one_into(
+                file,
+                &mut xs_tables,
+                &mut binding_energies,
+                &mut shell_names,
+            )?;
         }
 
         Ok(Self {
@@ -113,6 +65,92 @@ impl SubshellPeDb {
             binding_energies,
             shell_names,
         })
+    }
+
+    /// Construct from a single element's subshell PE Parquet bytes.
+    ///
+    /// The element Z is determined from the `Z` column in the data.
+    pub fn from_bytes(data: &[u8]) -> crate::Result<Self> {
+        let bytes = bytes::Bytes::from(data.to_vec());
+        let mut xs_tables = HashMap::new();
+        let mut binding_energies = HashMap::new();
+        let mut shell_names: HashMap<u8, Vec<String>> = HashMap::new();
+        Self::parse_one_into(
+            bytes,
+            &mut xs_tables,
+            &mut binding_energies,
+            &mut shell_names,
+        )?;
+        Ok(Self {
+            xs_tables,
+            binding_energies,
+            shell_names,
+        })
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn parse_one_into(
+        reader_source: impl parquet::file::reader::ChunkReader + 'static,
+        xs_tables: &mut HashMap<(u8, u8), (Vec<f64>, Vec<f64>)>,
+        binding_energies: &mut HashMap<(u8, u8), f64>,
+        shell_names: &mut HashMap<u8, Vec<String>>,
+    ) -> crate::Result<()> {
+        let reader = ParquetRecordBatchReaderBuilder::try_new(reader_source)?.build()?;
+
+        let mut shell_data: HashMap<String, (Vec<f64>, Vec<f64>, f64)> = HashMap::new();
+        let mut z_val: Option<u8> = None;
+
+        for batch in reader {
+            let batch = batch?;
+
+            let z_col = batch
+                .column_by_name("Z")
+                .and_then(|c| c.as_any().downcast_ref::<Int32Array>());
+            let e_col = batch
+                .column_by_name("energy_MeV")
+                .and_then(|c| c.as_any().downcast_ref::<Float64Array>());
+            let shell_col_ref = batch.column_by_name("subshell");
+            let shell_values = shell_col_ref.and_then(|c| crate::interp::as_string_array(c));
+            let xs_col = batch
+                .column_by_name("xs_barns")
+                .and_then(|c| c.as_any().downcast_ref::<Float64Array>());
+            let edge_col = batch
+                .column_by_name("edge_MeV")
+                .and_then(|c| c.as_any().downcast_ref::<Float64Array>());
+
+            if let (Some(z), Some(e), Some(shell), Some(xs), Some(edge)) =
+                (z_col, e_col, shell_values, xs_col, edge_col)
+            {
+                #[allow(clippy::needless_range_loop)]
+                for i in 0..batch.num_rows() {
+                    if z_val.is_none() {
+                        z_val = Some(z.value(i) as u8);
+                    }
+                    let shell_name = shell[i].unwrap_or("").to_string();
+                    let entry = shell_data
+                        .entry(shell_name)
+                        .or_insert_with(|| (Vec::new(), Vec::new(), edge.value(i)));
+                    entry.0.push(e.value(i));
+                    entry.1.push(xs.value(i));
+                }
+            }
+        }
+
+        if let Some(z) = z_val {
+            let mut names: Vec<String> = shell_data.keys().cloned().collect();
+            names.sort();
+
+            for (idx, name) in names.iter().enumerate() {
+                let (mut energies, mut xs, edge) = shell_data.remove(name).expect("key exists");
+                sort_paired_vecs(&mut energies, &mut xs);
+                let shell_idx = idx as u8;
+                xs_tables.insert((z, shell_idx), (energies, xs));
+                binding_energies.insert((z, shell_idx), edge);
+            }
+            shell_names.insert(z, names);
+        }
+
+        Ok(())
     }
 
     /// Photoelectric cross-section [barns/atom] for a specific subshell.
@@ -202,5 +240,44 @@ mod tests {
             be.is_finite() && be > 0.0,
             "Cu shell 0 binding energy: {be}"
         );
+    }
+
+    fn data_meta_dir() -> std::path::PathBuf {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("..")
+            .join("data")
+            .join("meta")
+    }
+
+    #[test]
+    #[ignore = "requires nucl-parquet data files"]
+    fn from_bytes_matches_open() {
+        let db_file = SubshellPeDb::open(data_meta_dir()).unwrap();
+        let pe_dir = data_meta_dir().join("epdl97").join("subshell_pe");
+        let first_file = std::fs::read_dir(&pe_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .find(|e| e.path().extension().and_then(|x| x.to_str()) == Some("parquet"))
+            .expect("at least one subshell_pe file");
+        let data = std::fs::read(first_file.path()).unwrap();
+        let db_bytes = SubshellPeDb::from_bytes(&data).unwrap();
+        for z in 1..=100u8 {
+            if db_bytes.has_element(z) {
+                assert_eq!(
+                    db_bytes.num_shells(z),
+                    db_file.num_shells(z),
+                    "Z={z} shell count mismatch"
+                );
+                let xs_file = db_file.cross_section(z, 0, 0.1);
+                let xs_bytes = db_bytes.cross_section(z, 0, 0.1);
+                assert!(
+                    (xs_file - xs_bytes).abs() < 1e-12,
+                    "Z={z} shell 0 XS mismatch: {xs_file} vs {xs_bytes}"
+                );
+                break;
+            }
+        }
     }
 }

--- a/clients/rs/nucl-parquet/src/xcom.rs
+++ b/clients/rs/nucl-parquet/src/xcom.rs
@@ -51,6 +51,28 @@ impl XcomDb {
         })
     }
 
+    /// Construct from in-memory Parquet bytes.
+    ///
+    /// `elements_data` is the contents of `xcom_elements.parquet`.
+    /// `compounds_data` is the contents of `xcom_compounds.parquet` (pass an
+    /// empty slice to omit compounds).
+    pub fn from_bytes(elements_data: &[u8], compounds_data: &[u8]) -> crate::Result<Self> {
+        let (elem_mu_rho, elem_mu_en_rho) =
+            Self::parse_elements(bytes::Bytes::from(elements_data.to_vec()))?;
+        let (comp_mu_rho, comp_mu_en_rho) = if compounds_data.is_empty() {
+            (HashMap::new(), HashMap::new())
+        } else {
+            Self::parse_compounds(bytes::Bytes::from(compounds_data.to_vec()))?
+        };
+
+        Ok(Self {
+            elem_mu_rho,
+            elem_mu_en_rho,
+            comp_mu_rho,
+            comp_mu_en_rho,
+        })
+    }
+
     /// Mass attenuation coefficient µ/ρ [cm²/g] for element Z.
     ///
     /// Returns `f64::NAN` if the element is not loaded.
@@ -108,11 +130,17 @@ impl XcomDb {
     // --- Internal loaders ---
 
     fn load_elements(path: &Path) -> crate::Result<(HashMap<u8, XYTable>, HashMap<u8, XYTable>)> {
+        let file = fs::File::open(path)?;
+        Self::parse_elements(file)
+    }
+
+    fn parse_elements(
+        reader_source: impl parquet::file::reader::ChunkReader + 'static,
+    ) -> crate::Result<(HashMap<u8, XYTable>, HashMap<u8, XYTable>)> {
         let mut mu_rho: HashMap<u8, XYTable> = HashMap::new();
         let mut mu_en: HashMap<u8, XYTable> = HashMap::new();
 
-        let file = fs::File::open(path)?;
-        let reader = ParquetRecordBatchReaderBuilder::try_new(file)?.build()?;
+        let reader = ParquetRecordBatchReaderBuilder::try_new(reader_source)?.build()?;
 
         for batch in reader {
             let batch = batch?;
@@ -158,11 +186,17 @@ impl XcomDb {
     fn load_compounds(
         path: &Path,
     ) -> crate::Result<(HashMap<String, XYTable>, HashMap<String, XYTable>)> {
+        let file = fs::File::open(path)?;
+        Self::parse_compounds(file)
+    }
+
+    fn parse_compounds(
+        reader_source: impl parquet::file::reader::ChunkReader + 'static,
+    ) -> crate::Result<(HashMap<String, XYTable>, HashMap<String, XYTable>)> {
         let mut mu_rho: HashMap<String, XYTable> = HashMap::new();
         let mut mu_en: HashMap<String, XYTable> = HashMap::new();
 
-        let file = fs::File::open(path)?;
-        let reader = ParquetRecordBatchReaderBuilder::try_new(file)?.build()?;
+        let reader = ParquetRecordBatchReaderBuilder::try_new(reader_source)?.build()?;
 
         for batch in reader {
             let batch = batch?;
@@ -252,5 +286,35 @@ mod tests {
         );
         let mu = db.compound_mu_rho("water", 0.1);
         assert!(mu.is_finite() && mu > 0.0, "water mu/rho at 0.1 MeV: {mu}");
+    }
+
+    fn data_meta_dir() -> std::path::PathBuf {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("..")
+            .join("data")
+            .join("meta")
+    }
+
+    #[test]
+    #[ignore = "requires nucl-parquet data files"]
+    fn from_bytes_matches_open() {
+        let db_file = XcomDb::open(data_meta_dir()).unwrap();
+        let elem_data = std::fs::read(data_meta_dir().join("xcom_elements.parquet")).unwrap();
+        let comp_data = std::fs::read(data_meta_dir().join("xcom_compounds.parquet")).unwrap();
+        let db_bytes = XcomDb::from_bytes(&elem_data, &comp_data).unwrap();
+        let mu_file = db_file.mu_rho(29, 0.1);
+        let mu_bytes = db_bytes.mu_rho(29, 0.1);
+        assert!(
+            (mu_file - mu_bytes).abs() < 1e-12,
+            "Cu mu/rho mismatch: {mu_file} vs {mu_bytes}"
+        );
+        let mu_water_file = db_file.compound_mu_rho("water", 0.1);
+        let mu_water_bytes = db_bytes.compound_mu_rho("water", 0.1);
+        assert!(
+            (mu_water_file - mu_water_bytes).abs() < 1e-12,
+            "water mu/rho mismatch: {mu_water_file} vs {mu_water_bytes}"
+        );
     }
 }

--- a/clients/rs/nucl-parquet/src/xs.rs
+++ b/clients/rs/nucl-parquet/src/xs.rs
@@ -49,10 +49,34 @@ impl CrossSectionDb {
         let target_z =
             z_from_path(path).ok_or_else(|| Error::DataDirNotFound(path.to_path_buf()))?;
 
+        let file = fs::File::open(path)?;
+        let reactions = Self::parse(file)?;
+
+        Ok(Self {
+            reactions,
+            target_z,
+        })
+    }
+
+    /// Construct from in-memory Parquet bytes for a known target element.
+    ///
+    /// Unlike [`open`](Self::open), the caller must supply `target_z` since
+    /// there is no file path to derive the element symbol from.
+    pub fn from_bytes(target_z: u32, data: &[u8]) -> crate::Result<Self> {
+        let bytes = bytes::Bytes::from(data.to_vec());
+        let reactions = Self::parse(bytes)?;
+        Ok(Self {
+            reactions,
+            target_z,
+        })
+    }
+
+    fn parse(
+        reader_source: impl parquet::file::reader::ChunkReader + 'static,
+    ) -> crate::Result<HashMap<(u32, u32, u32, String), XYTable>> {
         let mut reactions: HashMap<(u32, u32, u32, String), XYTable> = HashMap::new();
 
-        let file = fs::File::open(path)?;
-        let reader = ParquetRecordBatchReaderBuilder::try_new(file)?.build()?;
+        let reader = ParquetRecordBatchReaderBuilder::try_new(reader_source)?.build()?;
 
         for batch in reader {
             let batch = batch?;
@@ -97,10 +121,7 @@ impl CrossSectionDb {
             sort_paired_vecs(e_vec, xs_vec);
         }
 
-        Ok(Self {
-            reactions,
-            target_z,
-        })
+        Ok(reactions)
     }
 
     /// Interpolated cross-section [mb] at `energy_mev`.
@@ -364,5 +385,36 @@ mod tests {
     fn entries_nonempty() {
         let db = CrossSectionDb::open(xs_file()).unwrap();
         assert!(db.num_reactions() > 0, "should have at least one reaction");
+    }
+
+    fn data_xs_file() -> std::path::PathBuf {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("..")
+            .join("data")
+            .join("tendl-2025")
+            .join("xs")
+            .join("p_Cu.parquet")
+    }
+
+    #[test]
+    #[ignore = "requires nucl-parquet data files"]
+    fn from_bytes_matches_open() {
+        let path = data_xs_file();
+        let db_file = CrossSectionDb::open(&path).unwrap();
+        let data = std::fs::read(&path).unwrap();
+        let db_bytes = CrossSectionDb::from_bytes(db_file.target_z(), &data).unwrap();
+        assert_eq!(db_bytes.target_z(), db_file.target_z());
+        assert_eq!(db_bytes.num_reactions(), db_file.num_reactions());
+        // Spot-check a cross-section value
+        for (ta, rz, ra, _st) in db_file.reaction_keys().take(3) {
+            let val_file = db_file.cross_section(ta, rz, ra, 15.0);
+            let val_bytes = db_bytes.cross_section(ta, rz, ra, 15.0);
+            assert!(
+                (val_file.is_nan() && val_bytes.is_nan()) || (val_file - val_bytes).abs() < 1e-12,
+                "mismatch for ({ta},{rz},{ra}): {val_file} vs {val_bytes}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #162.

- Every typed DB in `clients/rs/nucl-parquet/src/` now supports constructing from in-memory Parquet bytes via `from_bytes()`, enabling WASM, embedded, and network-fetched use cases without filesystem access.
- Internal parsing logic extracted into generic `fn parse(impl ChunkReader)` helpers shared by both `open()` and `from_bytes()` -- no duplication of column-reading code.
- **Single-file DBs** (`AbundancesDb`, `DecayDb`, `DoseDb`, `CrossSectionDb`, `StoppingDb`): `from_bytes(&[u8])`
- **Multi-file directory DBs** (`PhotonDb`, `ElectronDb`, `RelaxationDb`, `SubshellPeDb`): `from_bytes(&[u8])` parses a single element's parquet file
- **Dual-file DB** (`XcomDb`): `from_bytes(elements_data, compounds_data)` accepts both payloads
- **Lazy per-element DBs** (`CoincidencesDb`, `RadiationDb`): `from_element_bytes(z, &[u8])` loads and caches one element
- 12 new tests (all `#[ignore]` gated) validate round-trip equivalence between `open()` and `from_bytes()` on real data files

## Test plan

- [x] `cargo test` -- all 12 non-ignored tests pass
- [x] `cargo test from_bytes -- --ignored` -- all 10 from_bytes tests pass with data files
- [x] `cargo test element_bytes -- --ignored` -- both lazy DB tests pass
- [x] `cargo fmt` -- clean
- [x] `cargo clippy` -- clean (zero warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)