### PR TITLE
feat: HTTP-backed lazy per-file fetch (#223)

### DIFF
--- a/clients/rs/nucl-parquet/src/data_dir.rs
+++ b/clients/rs/nucl-parquet/src/data_dir.rs
@@ -42,7 +42,7 @@ impl DataDir {
         Err(Error::DataNotFound)
     }
 
-    /// Ensure data is available, downloading from GitHub Releases if needed.
+    /// Ensure data is available, downloading the full tarball if needed.
     ///
     /// Tries [`resolve()`](Self::resolve) first; downloads only when no local
     /// data is found.
@@ -53,6 +53,99 @@ impl DataDir {
         }
         Self::download()?;
         Self::resolve()
+    }
+
+    /// Ensure data is available in lazy mode — fetch only `catalog.json`.
+    ///
+    /// Individual Parquet files are downloaded on first access via
+    /// [`fetch_file()`](Self::fetch_file). This is ideal for consumers that
+    /// need <10% of the full dataset per session.
+    #[cfg(feature = "fetch")]
+    pub fn ensure_lazy() -> Result<Self> {
+        if let Ok(d) = Self::resolve() {
+            return Ok(d);
+        }
+        let cache = Self::cache_dir();
+        std::fs::create_dir_all(&cache)?;
+
+        // Fetch catalog.json to discover data version + base_url
+        let catalog_url = format!(
+            "https://raw.githubusercontent.com/exoma-ch/nucl-parquet/main/data/catalog.json"
+        );
+        let catalog_path = cache.join("catalog.json");
+        if !catalog_path.exists() {
+            eprintln!("Fetching catalog from {catalog_url} ...");
+            Self::fetch_url(&catalog_url, &catalog_path)?;
+        }
+
+        // Parse catalog to build versioned base_url
+        let catalog_text =
+            std::fs::read_to_string(&catalog_path).map_err(|e| Error::Download(e.to_string()))?;
+        let catalog: serde_json::Value =
+            serde_json::from_str(&catalog_text).map_err(|e| Error::Download(e.to_string()))?;
+
+        let data_version = catalog["data_version"].as_str().unwrap_or("latest");
+        let base_template = catalog["base_url"].as_str().unwrap_or(
+            "https://raw.githubusercontent.com/exoma-ch/nucl-parquet/data-{version}/data",
+        );
+        let base_url = base_template.replace("{version}", data_version);
+
+        // Write lazy marker for fetch_file()
+        let marker = cache.join(".lazy_base_url");
+        std::fs::write(&marker, &base_url)?;
+
+        // Create meta/ directory so resolve() finds it
+        std::fs::create_dir_all(cache.join("meta"))?;
+
+        eprintln!(
+            "Lazy mode: catalog at {}, files on demand from {base_url}",
+            cache.display()
+        );
+        Ok(Self { root: cache })
+    }
+
+    /// Fetch a single file from the lazy HTTP base if not already cached.
+    ///
+    /// Returns the local path to the file. No-op if the file exists on disk.
+    #[cfg(feature = "fetch")]
+    pub fn fetch_file(&self, rel_path: &str) -> Result<std::path::PathBuf> {
+        let dest = self.root.join(rel_path);
+        if dest.exists() {
+            return Ok(dest);
+        }
+
+        let marker = self.root.join(".lazy_base_url");
+        if !marker.exists() {
+            return Err(Error::DataDirNotFound(dest));
+        }
+
+        let base_url =
+            std::fs::read_to_string(&marker).map_err(|e| Error::Download(e.to_string()))?;
+        let url = format!("{}/{}", base_url.trim(), rel_path);
+        eprintln!("  Fetching {rel_path} ...");
+        Self::fetch_url(&url, &dest)?;
+        Ok(dest)
+    }
+
+    #[cfg(feature = "fetch")]
+    fn fetch_url(url: &str, dest: &Path) -> Result<()> {
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let resp = reqwest::blocking::get(url).map_err(|e| Error::Download(e.to_string()))?;
+        if !resp.status().is_success() {
+            return Err(Error::Download(format!("HTTP {} for {url}", resp.status())));
+        }
+        let bytes = resp.bytes().map_err(|e| Error::Download(e.to_string()))?;
+        std::fs::write(dest, &bytes)?;
+        Ok(())
+    }
+
+    /// Create a DataDir from an existing root path (no resolution or download).
+    pub fn from_root(root: impl AsRef<Path>) -> Self {
+        Self {
+            root: root.as_ref().to_path_buf(),
+        }
     }
 
     /// Path to the data root directory.

--- a/clients/rs/nucl-parquet/src/data_dir.rs
+++ b/clients/rs/nucl-parquet/src/data_dir.rs
@@ -68,7 +68,9 @@ impl DataDir {
         let cache = Self::cache_dir();
         std::fs::create_dir_all(&cache)?;
 
-        // Fetch catalog.json to discover data version + base_url
+        // Fetch catalog.json from main to discover data_version + base_url.
+        // The catalog's base_url template resolves to a versioned tag, so
+        // actual data files are fetched from the pinned data release, not main.
         let catalog_url = format!(
             "https://raw.githubusercontent.com/exoma-ch/nucl-parquet/main/data/catalog.json"
         );
@@ -137,7 +139,10 @@ impl DataDir {
             return Err(Error::Download(format!("HTTP {} for {url}", resp.status())));
         }
         let bytes = resp.bytes().map_err(|e| Error::Download(e.to_string()))?;
-        std::fs::write(dest, &bytes)?;
+        // Atomic write: tmp file + rename to avoid partial files on failure
+        let tmp = dest.with_extension("tmp");
+        std::fs::write(&tmp, &bytes)?;
+        std::fs::rename(&tmp, dest)?;
         Ok(())
     }
 

--- a/clients/rs/nucl-parquet/src/store.rs
+++ b/clients/rs/nucl-parquet/src/store.rs
@@ -67,7 +67,17 @@ impl ParquetStore {
         // Slow path: read file, cache, return.
         let path = self.data_dir.join(rel_path);
         if !path.exists() {
-            return Err(Error::DataDirNotFound(path));
+            // Try lazy HTTP fetch if configured
+            #[cfg(feature = "fetch")]
+            {
+                let marker = self.data_dir.join(".lazy_base_url");
+                if marker.exists() {
+                    crate::DataDir::from_root(&self.data_dir).fetch_file(rel_path)?;
+                }
+            }
+            if !path.exists() {
+                return Err(Error::DataDirNotFound(path));
+            }
         }
         let rows = Arc::new(parse_parquet_file(&path)?);
 

--- a/data/catalog.json
+++ b/data/catalog.json
@@ -3,6 +3,7 @@
   "version": 1,
   "data_version": "2026.5.4",
   "data_sha256": "a4edf294f82c4b540c7fbe443a97e2c793a05bee08c256a89224c261377fbfb3",
+  "base_url": "https://raw.githubusercontent.com/exoma-ch/nucl-parquet/data-{version}/data",
   "description": "Registry of available nuclear data libraries",
   "libraries": {
     "tendl-2023-iso": {

--- a/nucl_parquet/__init__.py
+++ b/nucl_parquet/__init__.py
@@ -1,6 +1,6 @@
 """nucl-parquet: Nuclear data as Parquet — queryable with DuckDB."""
 
-from .download import compute_data_sha256, data_dir, data_sha256, data_version, download
+from .download import compute_data_sha256, data_dir, data_sha256, data_version, download, ensure, fetch_file
 from .loader import (
     COINCIDENCE_SQL,
     DECAY_CHAIN_SQL,
@@ -34,6 +34,8 @@ __all__ = [
     "data_version",
     "download",
     "elemental_dedx",
+    "ensure",
+    "fetch_file",
     "emissions",
     "gamma_lines",
     "identify_gamma",

--- a/nucl_parquet/download.py
+++ b/nucl_parquet/download.py
@@ -224,3 +224,119 @@ def download(
 
     print(f"Data extracted to {dest}")
     return dest
+
+
+def _resolve_base_url(catalog: dict, data_tag: str) -> str:
+    """Build per-file base URL from catalog template or hardcoded fallback."""
+    template = catalog.get("base_url", "")
+    cal = data_tag.removeprefix("data-")
+    if template and "{version}" in template:
+        return template.replace("{version}", cal)
+    return f"https://raw.githubusercontent.com/{_GITHUB_REPO}/{data_tag}/data"
+
+
+def _fetch_one(url: str, dest: Path) -> None:
+    """Download a single file from *url* into *dest*."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with urlopen(url) as resp:  # noqa: S310
+        with open(dest, "wb") as f:
+            while chunk := resp.read(1 << 20):
+                f.write(chunk)
+
+
+def ensure(
+    dest: Path | str | None = None,
+    data_version: str = "latest",
+    *,
+    lazy: bool = False,
+) -> Path:
+    """Ensure nucl-parquet data is available, downloading if needed.
+
+    With ``lazy=False`` (default), behaves identically to ``download()`` —
+    fetches the full tarball.
+
+    With ``lazy=True``, fetches only ``catalog.json`` up front. Individual
+    Parquet files are downloaded on first access by the loader. This is
+    ideal for consumers that touch <10% of the dataset per session.
+
+    Args:
+        dest: Cache directory. Defaults to ``~/.nucl-parquet/``.
+        data_version: CalVer string or ``"latest"``.
+        lazy: If True, defer per-file downloads until first access.
+
+    Returns:
+        Path to the data directory (may be partially populated in lazy mode).
+    """
+    # Try to find existing data first
+    try:
+        existing = data_dir()
+        if existing.is_dir() and (existing / "catalog.json").exists():
+            return existing
+    except FileNotFoundError:
+        pass
+
+    dest = Path(dest) if dest else Path.home() / ".nucl-parquet"
+    dest.mkdir(parents=True, exist_ok=True)
+
+    if not lazy:
+        return download(dest=dest, data_version=data_version)
+
+    # Lazy mode: fetch only catalog.json, resolve base_url for later per-file fetches.
+    if data_version == "latest":
+        data_tag = _resolve_latest_data_tag()
+    elif _DATA_TAG_RE.match(data_version):
+        data_tag = data_version
+    else:
+        data_tag = f"data-{data_version}"
+
+    # Fetch catalog.json
+    base = f"https://raw.githubusercontent.com/{_GITHUB_REPO}/{data_tag}/data"
+    catalog_url = f"{base}/catalog.json"
+    catalog_dest = dest / "catalog.json"
+
+    if not catalog_dest.exists():
+        print(f"Fetching catalog from {catalog_url} ...")
+        _fetch_one(catalog_url, catalog_dest)
+
+    # Write a marker so fetch_file() knows the base URL for lazy fetches
+    marker = dest / ".lazy_base_url"
+    catalog = json.loads(catalog_dest.read_text())
+    resolved_base = _resolve_base_url(catalog, data_tag)
+    marker.write_text(resolved_base)
+
+    print(f"Lazy mode: catalog cached at {dest}, files fetched on demand from {resolved_base}")
+    return dest
+
+
+def fetch_file(data_root: Path, rel_path: str) -> Path:
+    """Fetch a single data file if not already cached.
+
+    Called by the loader when a view's backing file is missing. Reads the
+    base URL from the ``.lazy_base_url`` marker written by ``ensure(lazy=True)``.
+
+    Args:
+        data_root: The data directory (from ``data_dir()`` or ``ensure()``).
+        rel_path: Relative path within the data dir (e.g. ``meta/abundances.parquet``).
+
+    Returns:
+        Absolute path to the (now-local) file.
+
+    Raises:
+        FileNotFoundError: If no lazy base URL is configured (tarball mode).
+    """
+    dest = data_root / rel_path
+    if dest.exists():
+        return dest
+
+    marker = data_root / ".lazy_base_url"
+    if not marker.exists():
+        raise FileNotFoundError(
+            f"File not found: {dest}. No lazy fetch configured — "
+            "run nucl_parquet.ensure(lazy=True) or nucl_parquet.download()."
+        )
+
+    base_url = marker.read_text().strip()
+    url = f"{base_url}/{rel_path}"
+    print(f"  Fetching {rel_path} ...")
+    _fetch_one(url, dest)
+    return dest

--- a/nucl_parquet/download.py
+++ b/nucl_parquet/download.py
@@ -236,12 +236,18 @@ def _resolve_base_url(catalog: dict, data_tag: str) -> str:
 
 
 def _fetch_one(url: str, dest: Path) -> None:
-    """Download a single file from *url* into *dest*."""
+    """Download a single file from *url* into *dest* (atomic)."""
     dest.parent.mkdir(parents=True, exist_ok=True)
-    with urlopen(url) as resp:  # noqa: S310
-        with open(dest, "wb") as f:
-            while chunk := resp.read(1 << 20):
-                f.write(chunk)
+    tmp = dest.with_suffix(dest.suffix + ".tmp")
+    try:
+        with urlopen(url) as resp:  # noqa: S310
+            with open(tmp, "wb") as f:
+                while chunk := resp.read(1 << 20):
+                    f.write(chunk)
+        tmp.rename(dest)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
 
 
 def ensure(

--- a/nucl_parquet/loader.py
+++ b/nucl_parquet/loader.py
@@ -241,7 +241,9 @@ def _register_parquet(
     path: Path,
     view_name: str,
 ) -> None:
-    """Register a single Parquet file as a view if it exists."""
+    """Register a single Parquet file as a view, fetching lazily if needed."""
+    if not path.exists():
+        _try_lazy_fetch(path)
     if path.exists():
         db.execute(f"CREATE VIEW {view_name} AS SELECT * FROM read_parquet('{path}')")
 
@@ -252,9 +254,42 @@ def _register_glob(
     view_name: str,
 ) -> None:
     """Register a directory of per-element Parquet files as a single view."""
+    if not directory.exists():
+        _try_lazy_fetch_glob(directory)
     if directory.exists() and list(directory.glob("*.parquet")):
         glob_path = str(directory / "*.parquet")
         db.execute(f"CREATE VIEW {view_name} AS SELECT * FROM read_parquet('{glob_path}')")
+
+
+def _try_lazy_fetch(path: Path) -> None:
+    """If lazy fetch is configured, download a single missing file."""
+    from .download import fetch_file
+
+    # Walk up to find data root (contains catalog.json)
+    for parent in [path.parent, *path.parents]:
+        if (parent / "catalog.json").exists():
+            rel = path.relative_to(parent).as_posix()
+            try:
+                fetch_file(parent, rel)
+            except FileNotFoundError:
+                pass  # No lazy base URL — normal tarball mode
+            return
+
+
+def _try_lazy_fetch_glob(directory: Path) -> None:
+    """If lazy fetch is configured, download all parquet files for a glob directory.
+
+    Note: glob views (per-element files) cannot be lazily fetched without a
+    manifest listing individual files. The catalog only declares the directory
+    path. For now, glob views are skipped in lazy mode — they'll be registered
+    once the user fetches the full tarball or specific files are cached.
+    """
+    # Glob views require knowing which element files exist. The catalog
+    # doesn't list them individually (they're discovered at build time).
+    # Skip silently — the view won't register, which is acceptable in
+    # lazy mode. Users who need glob views should use download() for
+    # the full tarball.
+    pass
 
 
 # ---------------------------------------------------------------------------

--- a/nucl_parquet/loader.py
+++ b/nucl_parquet/loader.py
@@ -266,7 +266,7 @@ def _try_lazy_fetch(path: Path) -> None:
     from .download import fetch_file
 
     # Walk up to find data root (contains catalog.json)
-    for parent in [path.parent, *path.parents]:
+    for parent in path.parents:
         if (parent / "catalog.json").exists():
             rel = path.relative_to(parent).as_posix()
             try:
@@ -284,12 +284,19 @@ def _try_lazy_fetch_glob(directory: Path) -> None:
     path. For now, glob views are skipped in lazy mode — they'll be registered
     once the user fetches the full tarball or specific files are cached.
     """
-    # Glob views require knowing which element files exist. The catalog
-    # doesn't list them individually (they're discovered at build time).
-    # Skip silently — the view won't register, which is acceptable in
-    # lazy mode. Users who need glob views should use download() for
-    # the full tarball.
-    pass
+    import warnings
+
+    # Check if we're actually in lazy mode (marker file exists)
+    for parent in directory.parents:
+        if (parent / ".lazy_base_url").exists():
+            rel = directory.relative_to(parent).as_posix()
+            warnings.warn(
+                f"View '{rel}' is a glob directory and cannot be lazily fetched. "
+                "Run nucl_parquet.download() for the full dataset, or manually "
+                "fetch the needed element files.",
+                stacklevel=4,
+            )
+            return
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add lazy data fetching to Python and Rust clients — fetch only the files you need instead of the full 400 MB tarball. Most consumers touch <10% of the dataset per session (~30 MB).

**Python:**
- `nucl_parquet.ensure(lazy=True)` fetches catalog.json, defers file downloads
- Loader auto-fetches individual parquet files on first view registration
- `nucl_parquet.fetch_file(data_root, rel_path)` for manual fetches

**Rust** (feature-gated behind `fetch`):
- `DataDir::ensure_lazy()` — catalog-only bootstrap
- `DataDir::fetch_file(rel_path)` — on-demand per-file download
- `ParquetStore::load()` auto-fetches when lazy marker exists
- `DataDir::from_root()` — convenience constructor

**Catalog:**
- `base_url` template: `https://raw.githubusercontent.com/.../data-{version}/data`

**Limitation:** Glob views (per-element directories like `radiation/`, `emissions/`) skip lazy fetch — they need a file manifest. Single-file views (majority of catalog) work fully.

## Test plan

- [x] Python: ruff clean, loader test passes
- [x] Rust: `cargo check` + `cargo test` pass (without fetch feature)
- [x] Rust MCP: `cargo check` passes
- [ ] CI: all 7 checks

Closes #223.