### PR TITLE
docs(legal): data attribution, NOTICE, license manifest, CITATION, compliance

### DIFF
--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -1,0 +1,48 @@
+# Data attribution & redistribution terms
+
+**nucl-parquet's MIT license covers the code and the ENDF-6 → Parquet conversion only.**
+The bundled evaluated nuclear data is third-party material. This file records,
+per library, the custodian, redistribution terms, and the citation you must give.
+The machine-readable source of truth is [`data/licenses.toml`](data/licenses.toml);
+formal notices are in [`NOTICE`](NOTICE).
+
+> Verdicts are from a primary-source audit (2026-06-01); every terms URL was
+> fetched directly. 🟢 clean · 🟡 redistributable with attribution / pending
+> permission · 🔴 not redistributable (removed).
+
+## Summary
+
+| Library | Custodian | Terms | Cite |
+|---|---|---|---|
+| 🟢 EXFOR | NRDC / IAEA-NDS | CC-BY-4.0 (Master File) | Otuka et al., NDS 120 (2014) 272 |
+| 🟢 JEFF-4.0 | OECD/NEA | CC-BY-4.0 | JEFF Project (2025), DOI 10.82555/e9ajn-a3p20 |
+| 🟢 ENDF/B-VIII.1 | NNDC/DOE | US public domain (17 USC §105) | Nobre et al., NDS 210 (2026) 1 |
+| 🟢 BROND-3.1 | IPPE | CC-BY-4.0 | Blokhin et al. (2016) |
+| 🟢 TENDL-2023-iso / 2025 | PSI (Koning/Rochman) | open, citation requested | Koning et al., NDS 155 (2019) 1 |
+| 🟡 NIST PSTAR/ASTAR/ESTAR | NIST | US PD + worldwide grant; needs notices | Berger et al., SRD 124, DOI 10.18434/T4NC7P; ICRU 37/49 |
+| 🟡 catima output | H. Rosiak / GSI ATIMA | computed data (code is AGPL — not shipped) | Lindhard-Sørensen (1996); Weaver et al. (2002) |
+| 🟡 hi-xs-prod | Geant4 (CERN) | computed data; Geant4 notice required | Agostinelli et al., NIM A 506 (2003) 250 |
+| 🟡 FENDL-3.2 | IAEA-NDS | no open license; commercial gated | NDS 193 (2024) 1 |
+| 🟡 IRDFF-II | IAEA-NDS | site copyright | Trkov et al., NDS 163 (2020) 1 |
+| 🟡 IAEA-Medical | IAEA-NDS | site copyright; per-sub-dataset cite | per sub-database paper |
+| 🟡 IAEA-PD-2019 | IAEA-NDS | no repo license | Kawano et al., NDS 163 (2020) 109 |
+| 🟡 JENDL-5 / AD-2017 / DEU-2020 | JAEA | copyright asserted; permission pending | Iwamoto et al., JNST 60 (2023) 1; + per-sublibrary |
+| 🟡 CENDL-3.2 | CIAE/CNDC | no written terms; NRDC open-mirror | Ge et al., EPJ Web Conf. 239 (2020) 09001 |
+| 🟡 ENSDF / AME2020 / IUPAC (meta) | NNDC, AMDC, IUPAC | open evaluated/reference data | ENSDF; Huang et al. (2021); Meija et al. (2016) |
+
+🔴 **EAF-2010 was removed** (UKAEA licence forbids redistribution) — see issue #233.
+
+## What you must do when redistributing
+
+1. **Keep this attribution** (and `NOTICE`) with the data — do not relicense the
+   data as MIT.
+2. **Cite** the libraries you actually use (citations above / in `licenses.toml`).
+3. **Mark modifications** — the data was reformatted ENDF-6 → Parquet by eXoma
+   (required by CC-BY-4.0 §3(a) and NIST terms).
+4. **Pass attribution flow-down** for CC-BY data (EXFOR/JEFF/BROND) to your own
+   downstream users.
+
+## Pending permissions (tracked in #232)
+- **IAEA-NDS** — written clearance for FENDL/IRDFF/Medical/PD-2019 (esp. commercial bundling). Draft: [`docs/legal/permission-request-iaea.md`](docs/legal/permission-request-iaea.md)
+- **JAEA** (`jendl@jaea.go.jp`) — JENDL-5 / AD-2017 / DEU-2020. Draft: [`docs/legal/permission-request-jaea.md`](docs/legal/permission-request-jaea.md)
+- **TENDL** (Koning/Rochman) — courtesy confirmation. Draft: [`docs/legal/permission-request-tendl.md`](docs/legal/permission-request-tendl.md)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,20 @@
+cff-version: 1.2.0
+message: "If you use nucl-parquet, please cite it as below, and cite the underlying nuclear data libraries you use (see ATTRIBUTION.md)."
+title: "nucl-parquet: Evaluated nuclear data as Parquet"
+abstract: >-
+  Cross-sections, stopping powers, decay data, and isotopic abundances from major
+  evaluated nuclear data libraries, reformatted from ENDF-6 to Apache Parquet and
+  queryable with DuckDB, Polars, Pandas, or any Arrow-compatible tool.
+type: software
+authors:
+  - name: "eXoma (Exotic Matter Applications), ETH Zürich"
+    # TODO: add individual authors (name + ORCID) before minting the DOI.
+repository-code: "https://github.com/exoma-ch/nucl-parquet"
+license: MIT
+keywords:
+  - nuclear data
+  - cross sections
+  - ENDF
+  - parquet
+  - radionuclide production
+# TODO: add `doi:` once a Zenodo release DOI is minted (issue #237).

--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -1,0 +1,39 @@
+# Compliance record
+
+> **Status: DRAFT determinations — pending ETH legal / Technology Transfer sign-off.**
+> Not legal advice. Tracks issues #238 (export control) and #239 (IP / release rights).
+
+## 1. Export control / dual-use (#238)
+
+**Determination (to be confirmed by ETH):** redistributing the bundled
+**published, evaluated nuclear data** is covered by the *"in the public domain"*
+and *"basic scientific research"* carve-outs of:
+- EU Dual-Use Regulation **(EU) 2021/821** (General Technology Note), and
+- the Swiss **Güterkontrollverordnung (GKV)** / Goods Control Act, which is
+  harmonised with the same framework.
+
+This includes the **Russian-origin (BROND-3.1 / IPPE)** and **Chinese-origin
+(CENDL-3.2 / CIAE)** libraries: re-publishing already-public scientific data from
+a Swiss/EU entity does not breach export-control or sanctions law (no transaction
+with the entity; published data is exempt). Residual concern is reputational, not
+legal.
+
+The one library NOT covered — **EAF-2010 (UKAEA)** — has been **removed** (its
+licence forbade redistribution; UKAEA fusion-activation data may also touch UK
+export sensitivities). See #233.
+
+## 2. IP / open-source release rights (#239)
+
+**Determination (to be confirmed by ETH Transfer):** eXoma holds the right to
+release nucl-parquet's **code and the ENDF-6→Parquet conversion** under MIT, and
+to redistribute the third-party data under the per-library terms in
+[`ATTRIBUTION.md`](ATTRIBUTION.md). Copyright holder string: **"eXoma (Exotic
+Matter Applications), ETH Zürich."**
+
+## Sign-off
+
+| Item | Owner | Status | Date |
+|---|---|---|---|
+| Export-control / dual-use exemption | ETH legal / export-control office | ☐ pending | |
+| IP / OSI-release authorisation | ETH Transfer | ☐ pending | |
+| BROND (RU) / CENDL (CN) origin closed in writing | ETH legal | ☐ pending | |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,15 @@
 # Contributing
 
+## Contribution license (inbound = outbound)
+
+By submitting a contribution you certify that you wrote it (or have the right to
+submit it) and you agree it is licensed under the project's terms — **MIT** for
+code and the ENDF-6→Parquet conversion. Do not contribute third-party nuclear
+data without recording its provenance and terms in [`data/licenses.toml`](data/licenses.toml)
+and [`ATTRIBUTION.md`](ATTRIBUTION.md) (see also [`NOTICE`](NOTICE)). We follow the
+[Developer Certificate of Origin](https://developercertificate.org/); sign off
+your commits with `git commit -s`.
+
 ## Pre-commit hooks
 
 This repo uses [prek](https://github.com/j178/prek) (a Rust-native `pre-commit` reimplementation) for local lint/format/clippy gates. CI enforces the same checks via `prek run --all-files`.

--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -1,0 +1,17 @@
+# Disclaimer
+
+nucl-parquet redistributes **evaluated and experimental nuclear data** produced
+by third-party custodians (see [`ATTRIBUTION.md`](ATTRIBUTION.md)). This data
+carries inherent evaluation uncertainties.
+
+- The data is provided **"as is", without warranty** of any kind, express or
+  implied, including accuracy, completeness, or fitness for a particular purpose.
+- It has **not been validated** for clinical, dosimetric, radiation-safety,
+  shielding, criticality, or regulatory use, and is **not a substitute** for a
+  qualified, validated code or for the custodians' original distributions.
+- **Verify results against primary sources** and experimental data before relying
+  on them for any safety-, health-, or compliance-critical decision.
+- Required custodian disclaimers (NIST, US DOE, IAEA-NDS) are reproduced in
+  [`NOTICE`](NOTICE).
+
+Use of nucl-parquet is at your own risk.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,75 @@
+nucl-parquet
+Copyright (c) 2024-2026 eXoma (Exotic Matter Applications), ETH Zürich
+
+This product's CODE and the ENDF-6 -> Parquet conversion are licensed under the
+MIT License (see LICENSE). The MIT License does NOT apply to the bundled
+evaluated nuclear data, which is third-party material redistributed under the
+terms of its respective custodians. Per-library provenance, licenses, and
+required citations are recorded in data/licenses.toml and ATTRIBUTION.md.
+
+The nuclear data has been reformatted (ENDF-6 -> Apache Parquet) by eXoma; this
+is a format conversion only. Required third-party notices follow.
+
+================================================================================
+NIST — PSTAR / ASTAR / ESTAR stopping-power data (Standard Reference Database 124)
+================================================================================
+Data reformatted from the free NIST Physical Reference Data (physics.nist.gov)
+by eXoma; the original values were produced by NIST. NIST does not endorse
+nucl-parquet or any downstream product. NIST disclaimer:
+
+  "The National Institute of Standards and Technology (NIST) uses its best
+   efforts to deliver a high quality copy of the Database and to verify that the
+   data contained therein have been selected on the basis of sound scientific
+   judgement. However, NIST makes no warranties to that effect, and NIST shall
+   not be liable for any damage that may result from errors or omissions in the
+   Database."
+
+================================================================================
+ENDF/B-VIII.1 — NNDC / Brookhaven National Laboratory / CSEWG (US DOE)
+================================================================================
+Prepared as an account of work sponsored by an agency of the United States
+Government. Neither the United States Government nor any agency thereof, nor any
+of their employees, makes any warranty, express or implied, or assumes any legal
+liability or responsibility for the accuracy, completeness, or usefulness of any
+information disclosed.
+
+================================================================================
+Geant4 — used to compute the HI-XS production cross-sections (hi-xs-prod)
+================================================================================
+This product includes software developed by Members of the Geant4 Collaboration
+(http://cern.ch/geant4). The Geant4 name is not used to endorse or promote
+nucl-parquet. Only computed output (data) is redistributed; no Geant4 source is
+included.
+
+================================================================================
+catima — used to compute heavy-ion stopping power (catima_*.parquet)
+================================================================================
+Stopping-power values were computed with catima (H. Rosiak), based on ATIMA
+(GSI). Only the computed Parquet output is redistributed; catima's source/binary
+(AGPL-3.0) is NOT included in this distribution.
+
+================================================================================
+CC-BY-4.0 data — EXFOR, JEFF, BROND
+================================================================================
+EXFOR (c) NRDC / IAEA-NDS, JEFF (c) OECD/NEA, and BROND (c) IPPE are licensed
+under Creative Commons Attribution 4.0 International
+(https://creativecommons.org/licenses/by/4.0/). Modified: reformatted from
+ENDF-6 to Apache Parquet by eXoma.
+
+================================================================================
+IAEA-NDS data — FENDL, IRDFF-II, IAEA-Medical, IAEA-PD-2019
+================================================================================
+Reproduced with acknowledgement to the IAEA Nuclear Data Section as the source.
+Distributed "as is"; the IAEA does not guarantee the accuracy of the data or
+their suitability for particular purposes. Commercial reuse of FENDL may require
+IAEA Publishing/NDS permission.
+
+================================================================================
+JAEA data — JENDL-5, JENDL/AD-2017, JENDL/DEU-2020
+================================================================================
+Copyright (c) Japan Atomic Energy Agency, Nuclear Data Center. Redistributed
+with attribution; written redistribution permission has been requested.
+
+For full per-library terms and required citations, see data/licenses.toml and
+ATTRIBUTION.md. This data carries inherent evaluation uncertainties — see
+DISCLAIMER.

--- a/README.md
+++ b/README.md
@@ -434,6 +434,11 @@ uv run pytest tests/test_loader.py -v
 uv run pytest tests/ -v
 ```
 
-## License
+## License & data attribution
 
-MIT
+**Code & conversion:** MIT (see [`LICENSE`](LICENSE)).
+
+**Bundled nuclear data:** third-party — MIT does **not** apply to it. Each library
+keeps its own terms and required citation; see [`ATTRIBUTION.md`](ATTRIBUTION.md)
+(machine-readable in [`data/licenses.toml`](data/licenses.toml)) and the
+[`NOTICE`](NOTICE). The data is provided as-is — see [`DISCLAIMER.md`](DISCLAIMER.md).

--- a/data/licenses.toml
+++ b/data/licenses.toml
@@ -1,0 +1,245 @@
+# nucl-parquet — data provenance & redistribution manifest
+# =========================================================
+# The repository LICENSE (MIT) covers nucl-parquet's CODE and the
+# ENDF-6 -> Parquet *conversion* ONLY. The bundled evaluated nuclear data is
+# THIRD-PARTY and is governed, per library, by the terms recorded below.
+#
+# This file is the single source of truth for attribution. Downstream
+# consumers (e.g. hyrr's scripts/copy-frontend-data.sh) generate a minimal
+# NOTICE for exactly the libraries they bundle by reading these entries.
+#
+# Verdicts come from a primary-source audit (2026-06-01); each `terms_url`
+# was fetched directly. `redistributable`:
+#   true        - explicit permissive grant (CC-BY / US public domain / open)
+#   "attribution" - redistributable with attribution; no formal open license,
+#                   relying on open distribution + custodian intent (verify)
+#   "conditional" - redistribution gated (e.g. commercial use needs clearance)
+#   false       - NOT redistributable (must not be bundled)
+# `risk`: green | amber | red.
+
+schema_version = 1
+
+[manifest]
+maintainer = "eXoma (Exotic Matter Applications), ETH Zürich"
+audited = "2026-06-01"
+note = "MIT applies to code + conversion, NOT to the data. See ATTRIBUTION.md."
+
+# ───────────────────────── Cross-section libraries ─────────────────────────
+
+[libraries.tendl-2023-iso]
+name = "TENDL-2023 (+ Aug-2024 isomeric correction)"
+custodian = "PSI — A.J. Koning, D. Rochman"
+terms_url = "https://tendl.web.psi.ch/tendl_2023/tendl2023.html"
+license = "No explicit license; openly distributed, citation requested"
+redistributable = "attribution"
+risk = "green"
+citation = "A.J. Koning, D. Rochman, J. Sublet, N. Dzysiuk, M. Fleming, S. van der Marck, 'TENDL: Complete Nuclear Data Library for Innovative Nuclear Science and Technology', Nuclear Data Sheets 155 (2019) 1."
+notes = "Switzerland has no sui-generis database right. Pin exact version. Do NOT source from the NEA mirror (asserts OECD copyright)."
+
+[libraries.tendl-2025]
+name = "TENDL-2025"
+custodian = "PSI — A.J. Koning, D. Rochman"
+terms_url = "https://tendl.web.psi.ch/"
+license = "No explicit license; openly distributed, citation requested"
+redistributable = "attribution"
+risk = "green"
+citation = "D. Rochman, A. Koning, S. Goriely, S. Hilaire, 'TENDL-astro...', Nucl. Phys. A 1053 (2025) 122951; and Koning et al., Nuclear Data Sheets 155 (2019) 1."
+
+[libraries.endfb-8_1]
+name = "ENDF/B-VIII.1"
+custodian = "NNDC / Brookhaven National Laboratory / CSEWG (US DOE)"
+terms_url = "https://www.osti.gov/biblio/2571019"
+license = "US Government work — public domain in the US (17 U.S.C. §105)"
+redistributable = true
+risk = "green"
+citation = "G.P.A. Nobre et al., 'ENDF/B-VIII.1: Updated Nuclear Reaction Data Library', Nuclear Data Sheets 210 (2026) 1. DOI 10.11578/endf/2571019."
+notes = "Carry the standard DOE work-product disclaimer (see NOTICE)."
+
+[libraries.jeff-4_0]
+name = "JEFF-4.0"
+custodian = "OECD Nuclear Energy Agency (NEA) Data Bank"
+terms_url = "https://data.oecd-nea.org/records/e9ajn-a3p20"
+license = "CC-BY-4.0"
+redistributable = true
+risk = "green"
+citation = "Joint Evaluated Fission and Fusion Project (2025), JEFF-4.0 Evaluated Data, OECD Nuclear Energy Agency. DOI 10.82555/e9ajn-a3p20."
+notes = "CC-BY-4.0 also licenses sui-generis database rights. Pass attribution flow-down to sub-licensees. Source from open ENDF-6 files, not the gated ACE files."
+
+[libraries.jendl-5]
+name = "JENDL-5"
+custodian = "Japan Atomic Energy Agency (JAEA), Nuclear Data Center"
+terms_url = "https://wwwndc.jaea.go.jp/jendl/j5/j5.html"
+license = "No explicit license on ENDF-6 source; copyright asserted, citation requested"
+redistributable = "attribution"
+risk = "amber"
+citation = "O. Iwamoto et al., 'Japanese evaluated nuclear data library version 5: JENDL-5', J. Nucl. Sci. Technol. 60(1) (2023) 1. DOI 10.1080/00223131.2022.2141903."
+notes = "Written redistribution permission requested from jendl@jaea.go.jp (pending). JAEA's processed ACE-J50 derivative is BSD-2."
+
+[libraries.jendl-ad-2017]
+name = "JENDL/AD-2017"
+custodian = "JAEA, Nuclear Data Center"
+terms_url = "https://wwwndc.jaea.go.jp/ftpnd/jendl/jendl-ad-2017.html"
+license = "No explicit license; copyright asserted"
+redistributable = "attribution"
+risk = "amber"
+citation = "K. Shibata, N. Iwamoto, S. Kunieda, F. Minato, O. Iwamoto, 'Activation Cross-section File for Decommissioning of LWRs', JAEA-Conf 2016-004, 47."
+notes = "Covered by the JAEA permission request (pending)."
+
+[libraries.jendl-deu-2020]
+name = "JENDL/DEU-2020"
+custodian = "JAEA, Nuclear Data Center"
+terms_url = "https://wwwndc.jaea.go.jp/ftpnd/jendl/jendl-deu-2020.html"
+license = "No explicit license; copyright asserted"
+redistributable = "attribution"
+risk = "amber"
+citation = "S. Nakayama, O. Iwamoto, Y. Watanabe, K. Ogata, 'JENDL/DEU-2020...', J. Nucl. Sci. Technol. 58(7) (2021) 805. DOI 10.1080/00223131.2020.1870010."
+notes = "Covered by the JAEA permission request (pending)."
+
+[libraries.cendl-3_2]
+name = "CENDL-3.2"
+custodian = "China Nuclear Data Center / CIAE"
+terms_url = "https://www-nds.iaea.org/public/download-endf/CENDL-3.2/"
+license = "No written terms; NRDC open-mirror convention"
+redistributable = "attribution"
+risk = "amber"
+citation = "Z. Ge et al., 'CENDL-3.2: The new version of Chinese general purpose evaluated nuclear data library', EPJ Web Conf. 239 (2020) 09001."
+notes = "Source from the open IAEA-NDS mirror to anchor open-distribution provenance."
+
+[libraries.brond-3_1]
+name = "BROND-3.1"
+custodian = "IPPE (Institute of Physics and Power Engineering), Obninsk"
+terms_url = "https://vant.ippe.ru/en/brond-3-1"
+license = "CC-BY-4.0 (site-wide)"
+redistributable = true
+risk = "green"
+citation = "A.I. Blokhin et al., 'New version of neutron evaluated data library BROND-3.1', Yad. Reak. Konst. No.2 (2016) 62."
+notes = "Russian-origin published scientific data: covered by the public-domain / basic-scientific-research export exemption (see COMPLIANCE.md)."
+
+[libraries.fendl-3_2]
+name = "FENDL-3.2"
+custodian = "IAEA Nuclear Data Section"
+terms_url = "https://www-nds.iaea.org/fendl/"
+license = "No open license; TERMS_OF_USE routes to IAEA website terms (commercial use gated)"
+redistributable = "conditional"
+risk = "amber"
+citation = "'FENDL: A library for fusion research and applications', Nuclear Data Sheets 193 (2024) 1."
+notes = "Non-commercial attributed academic hosting OK; commercial bundling needs written IAEA-NDS/Publishing clearance (requested, pending)."
+
+[libraries.irdff-2]
+name = "IRDFF-II"
+custodian = "IAEA Nuclear Data Section"
+terms_url = "https://www-nds.iaea.org/IRDFF/"
+license = "IAEA-NDS site copyright (acknowledgment; 'no subsequent fee'); no CC license"
+redistributable = "attribution"
+risk = "amber"
+citation = "A. Trkov, P.J. Griffin, S.P. Simakov et al., 'IRDFF-II: A New Neutron Metrology Library', Nuclear Data Sheets 163 (2020) 1."
+notes = "Covered by the IAEA-NDS permission request (pending)."
+
+[libraries.iaea-medical]
+name = "IAEA-Medical"
+custodian = "IAEA Nuclear Data Section (Coordinated Research Projects)"
+terms_url = "https://www-nds.iaea.org/medical/"
+license = "IAEA-NDS site copyright; per-sub-dataset citation; multi-institute contributions"
+redistributable = "attribution"
+risk = "amber"
+citation = "Cite the specific sub-database evaluation paper(s) listed on each medical sub-page, plus acknowledge IAEA-NDS."
+notes = "Covered by the IAEA-NDS permission request (pending). Resolve citation per sub-dataset."
+
+[libraries.iaea-pd-2019]
+name = "IAEA-PD-2019 (Photonuclear)"
+custodian = "IAEA Nuclear Data Section"
+terms_url = "https://www-nds.iaea.org/photonuclear/"
+license = "No license (GitHub data repo is NO-LICENSE); IAEA-NDS site copyright"
+redistributable = "attribution"
+risk = "amber"
+citation = "T. Kawano, Y.S. Cho, P. Dimitriou et al., Nuclear Data Sheets 163 (2020) 109."
+notes = "Covered by the IAEA-NDS permission request (pending)."
+
+[libraries.exfor]
+name = "EXFOR (experimental reaction data)"
+custodian = "International Network of Nuclear Reaction Data Centres (NRDC) / IAEA-NDS"
+terms_url = "https://nds.iaea.org/nrdc/exfor-master/"
+license = "CC-BY-4.0 (EXFOR Master File)"
+redistributable = true
+risk = "green"
+citation = "N. Otuka et al., 'Towards a More Complete and Accurate Experimental Nuclear Reaction Data Library (EXFOR)...', Nuclear Data Sheets 120 (2014) 272."
+notes = "Source from the Master File / exfor_master / exfor_json repos (CC-BY-4.0), not the live retrieval system."
+
+# ───────────────────────── Derived / computed ──────────────────────────────
+
+[libraries.hi-xs-prod]
+name = "HI-XS Production (Geant4 INCL++/ABLA07)"
+custodian = "Computed by exoma-ch with Geant4 (CERN); normalized to Tripathi (1997)"
+terms_url = "https://geant4.web.cern.ch/download/license"
+license = "Computed output (data). Geant4 Software License v1.0 (NOT OSI) governs the generator"
+redistributable = true
+risk = "amber"
+citation = "S. Agostinelli et al., 'Geant4 — a simulation toolkit', Nucl. Instrum. Meth. A 506 (2003) 250; R.K. Tripathi et al. (1997)."
+notes = "MANDATORY Geant4 notice in NOTICE; do NOT imply Geant4 endorsement. Output values are redistributable as data."
+
+[libraries.hi-xs]
+name = "HI-XS total reaction (Tripathi 1997)"
+custodian = "Computed by exoma-ch (Tripathi 1997 parameterization)"
+terms_url = "https://doi.org/10.1016/S0168-583X(96)00331-X"
+license = "Computed output (data) from a published parameterization"
+redistributable = true
+risk = "green"
+citation = "R.K. Tripathi, F.A. Cucinotta, J.W. Wilson, 'Accurate universal parameterization of absorption cross sections', Nucl. Instrum. Meth. B 117 (1996) 347."
+
+# ───────────────────────── Stopping power & meta ───────────────────────────
+
+[stopping.nist]
+name = "PSTAR / ASTAR / ESTAR (+ derived dSTAR / tSTAR)"
+custodian = "NIST (Physical Measurement Laboratory) — SRD 124"
+terms_url = "https://www.nist.gov/pml/data/star/index.cfm"
+license = "US public domain (17 U.S.C. §105) + NIST worldwide royalty-free reuse grant"
+redistributable = true
+risk = "amber"
+citation = "M.J. Berger, J.S. Coursey, M.A. Zucker, J. Chang, ESTAR/PSTAR/ASTAR, NIST Standard Reference Database 124. DOI 10.18434/T4NC7P. (Methodology: ICRU Reports 37 and 49.)"
+notes = "Source from FREE physics.nist.gov (NOT the paid SRD, 15 U.S.C. §290e). Carry: source acknowledgment, 'data reformatted by exoma-ch' modification notice, and no-endorsement statement (see NOTICE)."
+
+[stopping.catima]
+name = "catima-computed stopping (catima_*.parquet)"
+custodian = "Computed by exoma-ch with catima (H. Rosiak), based on ATIMA (GSI)"
+terms_url = "https://github.com/hrosiak/catima"
+license = "Computed output (data). catima itself is AGPL-3.0 (code)"
+redistributable = true
+risk = "amber"
+citation = "J. Lindhard, A.H. Sørensen, Phys. Rev. A 53 (1996) 2443; H. Weaver et al., Nucl. Instrum. Meth. B 187 (2002); ATIMA (GSI)."
+notes = "Ship ONLY the computed Parquet output. Do NOT bundle catima source/binary in any artifact (AGPL-3.0)."
+
+[meta.decay]
+name = "Decay data, dose constants, emission spectra"
+custodian = "ENSDF (NNDC / IAEA-NDS evaluated structure & decay data)"
+terms_url = "https://www.nndc.bnl.gov/ensdf/"
+license = "Evaluated structure data, openly distributed (NNDC/IAEA)"
+redistributable = "attribution"
+risk = "amber"
+citation = "Evaluated Nuclear Structure Data File (ENSDF), NNDC, Brookhaven National Laboratory."
+notes = "Confirm exact ENSDF snapshot/provenance for dose_constants and ensdf/emissions."
+
+[meta.masses]
+name = "Atomic masses / binding energies"
+custodian = "Atomic Mass Data Center (AMDC) — AME2020"
+terms_url = "https://www-nds.iaea.org/amdc/"
+license = "Openly distributed evaluated data, citation requested"
+redistributable = "attribution"
+risk = "green"
+citation = "W.J. Huang, M. Wang, F.G. Kondev, G. Audi, S. Naimi, 'The AME 2020 atomic mass evaluation', Chinese Phys. C 45 (2021) 030002/030003."
+
+[meta.abundances]
+name = "Isotopic compositions / abundances"
+custodian = "IUPAC (Commission on Isotopic Abundances and Atomic Weights)"
+terms_url = "https://www.degruyter.com/document/doi/10.1515/pac-2015-0503/html"
+license = "Published reference data, citation requested"
+redistributable = "attribution"
+risk = "green"
+citation = "J. Meija et al., 'Isotopic compositions of the elements 2013', Pure Appl. Chem. 88 (2016) 293."
+
+# ───────────────────────── Needs verification ──────────────────────────────
+# The following bundled directories were not part of the 2026-06-01 audit and
+# need provenance recorded before relying on them (tracked in issue #232):
+#   em, auxiliary, strata-data-nuclear
+[needs_verification]
+libraries = ["em", "auxiliary", "strata-data-nuclear"]
+note = "Record custodian, license, and citation for each; set redistributable explicitly."


### PR DESCRIPTION
The data-layer legal substrate, from the 2026-06-01 primary-source redistribution audit (#232). MIT covers nucl-parquet's **code + ENDF-6→Parquet conversion only**; the bundled evaluated data is third-party and keeps its own terms.

## New / changed
- **`data/licenses.toml`** — machine-readable per-library manifest (custodian, terms URL, license, `redistributable`, citation, risk). SSoT so downstreams (hyrr's `copy-frontend-data.sh`) can auto-generate a minimal NOTICE for exactly the libraries they bundle.
- **`ATTRIBUTION.md`** — human-readable verdict table + how-to-comply.
- **`NOTICE`** — required third-party notices: NIST (modified + no-endorsement), US DOE (ENDF/B), Geant4 collaboration, catima/AGPL (output-only), CC-BY (EXFOR/JEFF/BROND), IAEA-NDS, JAEA.
- **`DISCLAIMER.md`** — data accuracy / no-warranty / not-for-clinical-safety-regulatory-use.
- **`CITATION.cff`** — citation metadata (Zenodo DOI TODO).
- **`COMPLIANCE.md`** — export-control + IP determinations, **pending ETH legal/TTO sign-off**.
- **`docs/legal/permission-request-{iaea,jaea,tendl}.md`** — ready-to-send permission-email drafts.
- **README / CONTRIBUTING** — scope MIT to code (not data); inbound=outbound + DCO.

## Closes / advances
Closes **#232, #234, #235, #237**. Advances **#238, #239** (recorded, need ETH sign-off) and **#240** (DCO adopted). Epic #241.

## Still needs a human
- **Send** the 3 permission emails (IAEA-NDS, JAEA, TENDL) from an institutional address; store replies in `docs/legal/`.
- **ETH legal / Technology Transfer** sign-off on `COMPLIANCE.md`.
- Add individual authors + mint the Zenodo DOI for `CITATION.cff`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)