### PR TITLE
docs(legal): reflect non-commercial academic posture

### DIFF
--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -6,6 +6,12 @@ per library, the custodian, redistribution terms, and the citation you must give
 The machine-readable source of truth is [`data/licenses.toml`](data/licenses.toml);
 formal notices are in [`NOTICE`](NOTICE).
 
+**nucl-parquet and its downstreams (e.g. HYRR) are non-commercial academic
+projects** of eXoma (ETH Zürich). The IAEA / JAEA / NDS terms below permit reuse
+for research, education, and non-commercial products with acknowledgement, which
+this redistribution falls under. **Commercial** users must obtain their own
+permission from the relevant custodian for the IAEA- and JAEA-sourced libraries.
+
 > Verdicts are from a primary-source audit (2026-06-01); every terms URL was
 > fetched directly. 🟢 clean · 🟡 redistributable with attribution / pending
 > permission · 🔴 not redistributable (removed).
@@ -22,11 +28,11 @@ formal notices are in [`NOTICE`](NOTICE).
 | 🟡 NIST PSTAR/ASTAR/ESTAR | NIST | US PD + worldwide grant; needs notices | Berger et al., SRD 124, DOI 10.18434/T4NC7P; ICRU 37/49 |
 | 🟡 catima output | H. Rosiak / GSI ATIMA | computed data (code is AGPL — not shipped) | Lindhard-Sørensen (1996); Weaver et al. (2002) |
 | 🟡 hi-xs-prod | Geant4 (CERN) | computed data; Geant4 notice required | Agostinelli et al., NIM A 506 (2003) 250 |
-| 🟡 FENDL-3.2 | IAEA-NDS | no open license; commercial gated | NDS 193 (2024) 1 |
+| 🟢 FENDL-3.2 | IAEA-NDS | non-commercial academic reuse granted (acknowledge IAEA) | NDS 193 (2024) 1 |
 | 🟡 IRDFF-II | IAEA-NDS | site copyright | Trkov et al., NDS 163 (2020) 1 |
 | 🟡 IAEA-Medical | IAEA-NDS | site copyright; per-sub-dataset cite | per sub-database paper |
 | 🟡 IAEA-PD-2019 | IAEA-NDS | no repo license | Kawano et al., NDS 163 (2020) 109 |
-| 🟡 JENDL-5 / AD-2017 / DEU-2020 | JAEA | copyright asserted; permission pending | Iwamoto et al., JNST 60 (2023) 1; + per-sublibrary |
+| 🟡 JENDL-5 / AD-2017 / DEU-2020 | JAEA | copyright asserted, no explicit license; non-commercial + community practice | Iwamoto et al., JNST 60 (2023) 1; + per-sublibrary |
 | 🟡 CENDL-3.2 | CIAE/CNDC | no written terms; NRDC open-mirror | Ge et al., EPJ Web Conf. 239 (2020) 09001 |
 | 🟡 ENSDF / AME2020 / IUPAC (meta) | NNDC, AMDC, IUPAC | open evaluated/reference data | ENSDF; Huang et al. (2021); Meija et al. (2016) |
 
@@ -42,7 +48,12 @@ formal notices are in [`NOTICE`](NOTICE).
 4. **Pass attribution flow-down** for CC-BY data (EXFOR/JEFF/BROND) to your own
    downstream users.
 
-## Pending permissions (tracked in #232)
-- **IAEA-NDS** — written clearance for FENDL/IRDFF/Medical/PD-2019 (esp. commercial bundling). Draft: [`docs/legal/permission-request-iaea.md`](docs/legal/permission-request-iaea.md)
-- **JAEA** (`jendl@jaea.go.jp`) — JENDL-5 / AD-2017 / DEU-2020. Draft: [`docs/legal/permission-request-jaea.md`](docs/legal/permission-request-jaea.md)
-- **TENDL** (Koning/Rochman) — courtesy confirmation. Draft: [`docs/legal/permission-request-tendl.md`](docs/legal/permission-request-tendl.md)
+## Permissions — optional for non-commercial use (tracked in #232)
+
+As a non-commercial academic project we rely on the custodians' non-commercial /
+open-distribution grants above; **none of these emails is required to ship.**
+Drafts are kept for the record and for anyone who later needs a commercial grant:
+
+- **IAEA-NDS** — *not needed* for non-commercial reuse (already granted with acknowledgement); send only if a commercial grant for FENDL/IRDFF/Medical/PD-2019 is ever required. Draft: [`docs/legal/permission-request-iaea.md`](docs/legal/permission-request-iaea.md)
+- **JAEA** (`jendl@jaea.go.jp`) — *optional* insurance; JENDL has no explicit license either way, so redistribution rests on universal community practice. Draft: [`docs/legal/permission-request-jaea.md`](docs/legal/permission-request-jaea.md)
+- **TENDL** (Koning/Rochman) — *courtesy* confirmation only. Draft: [`docs/legal/permission-request-tendl.md`](docs/legal/permission-request-tendl.md)

--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -3,6 +3,11 @@
 > **Status: DRAFT determinations — pending ETH legal / Technology Transfer sign-off.**
 > Not legal advice. Tracks issues #238 (export control) and #239 (IP / release rights).
 
+**Project status:** nucl-parquet and its downstreams (e.g. HYRR) are
+**non-commercial academic** projects of eXoma (ETH Zürich). This is the basis for
+the data-reuse posture in [`ATTRIBUTION.md`](ATTRIBUTION.md): the custodians'
+non-commercial / open grants cover this redistribution with acknowledgement.
+
 ## 1. Export control / dual-use (#238)
 
 **Determination (to be confirmed by ETH):** redistributing the bundled

--- a/data/licenses.toml
+++ b/data/licenses.toml
@@ -23,6 +23,7 @@ schema_version = 1
 maintainer = "eXoma (Exotic Matter Applications), ETH Zürich"
 audited = "2026-06-01"
 note = "MIT applies to code + conversion, NOT to the data. See ATTRIBUTION.md."
+usage = "non-commercial academic (eXoma / ETH Zürich). Custodian non-commercial / open-distribution grants cover this redistribution with acknowledgement; commercial users must obtain their own permission for IAEA- and JAEA-sourced libraries."
 
 # ───────────────────────── Cross-section libraries ─────────────────────────
 
@@ -73,7 +74,7 @@ license = "No explicit license on ENDF-6 source; copyright asserted, citation re
 redistributable = "attribution"
 risk = "amber"
 citation = "O. Iwamoto et al., 'Japanese evaluated nuclear data library version 5: JENDL-5', J. Nucl. Sci. Technol. 60(1) (2023) 1. DOI 10.1080/00223131.2022.2141903."
-notes = "Written redistribution permission requested from jendl@jaea.go.jp (pending). JAEA's processed ACE-J50 derivative is BSD-2."
+notes = "No explicit license either way; non-commercial academic reuse + universal community practice. Optional permission: jendl@jaea.go.jp. JAEA's processed ACE-J50 derivative is BSD-2."
 
 [libraries.jendl-ad-2017]
 name = "JENDL/AD-2017"
@@ -83,7 +84,7 @@ license = "No explicit license; copyright asserted"
 redistributable = "attribution"
 risk = "amber"
 citation = "K. Shibata, N. Iwamoto, S. Kunieda, F. Minato, O. Iwamoto, 'Activation Cross-section File for Decommissioning of LWRs', JAEA-Conf 2016-004, 47."
-notes = "Covered by the JAEA permission request (pending)."
+notes = "Covered by the optional JAEA permission request; non-commercial reuse relies on community practice."
 
 [libraries.jendl-deu-2020]
 name = "JENDL/DEU-2020"
@@ -93,7 +94,7 @@ license = "No explicit license; copyright asserted"
 redistributable = "attribution"
 risk = "amber"
 citation = "S. Nakayama, O. Iwamoto, Y. Watanabe, K. Ogata, 'JENDL/DEU-2020...', J. Nucl. Sci. Technol. 58(7) (2021) 805. DOI 10.1080/00223131.2020.1870010."
-notes = "Covered by the JAEA permission request (pending)."
+notes = "Covered by the optional JAEA permission request; non-commercial reuse relies on community practice."
 
 [libraries.cendl-3_2]
 name = "CENDL-3.2"
@@ -119,11 +120,11 @@ notes = "Russian-origin published scientific data: covered by the public-domain 
 name = "FENDL-3.2"
 custodian = "IAEA Nuclear Data Section"
 terms_url = "https://www-nds.iaea.org/fendl/"
-license = "No open license; TERMS_OF_USE routes to IAEA website terms (commercial use gated)"
-redistributable = "conditional"
-risk = "amber"
+license = "IAEA website terms grant non-commercial reuse with acknowledgement (commercial use gated); no CC license"
+redistributable = "attribution"
+risk = "green"
 citation = "'FENDL: A library for fusion research and applications', Nuclear Data Sheets 193 (2024) 1."
-notes = "Non-commercial attributed academic hosting OK; commercial bundling needs written IAEA-NDS/Publishing clearance (requested, pending)."
+notes = "Non-commercial academic reuse with acknowledgement is granted — this project qualifies. Commercial downstream users must obtain their own IAEA-NDS/Publishing clearance."
 
 [libraries.irdff-2]
 name = "IRDFF-II"
@@ -133,7 +134,7 @@ license = "IAEA-NDS site copyright (acknowledgment; 'no subsequent fee'); no CC 
 redistributable = "attribution"
 risk = "amber"
 citation = "A. Trkov, P.J. Griffin, S.P. Simakov et al., 'IRDFF-II: A New Neutron Metrology Library', Nuclear Data Sheets 163 (2020) 1."
-notes = "Covered by the IAEA-NDS permission request (pending)."
+notes = "Non-commercial academic reuse granted (acknowledge IAEA); permission only needed for commercial use."
 
 [libraries.iaea-medical]
 name = "IAEA-Medical"
@@ -143,7 +144,7 @@ license = "IAEA-NDS site copyright; per-sub-dataset citation; multi-institute co
 redistributable = "attribution"
 risk = "amber"
 citation = "Cite the specific sub-database evaluation paper(s) listed on each medical sub-page, plus acknowledge IAEA-NDS."
-notes = "Covered by the IAEA-NDS permission request (pending). Resolve citation per sub-dataset."
+notes = "Non-commercial academic reuse granted (acknowledge IAEA); permission only needed for commercial use. Resolve citation per sub-dataset."
 
 [libraries.iaea-pd-2019]
 name = "IAEA-PD-2019 (Photonuclear)"
@@ -153,7 +154,7 @@ license = "No license (GitHub data repo is NO-LICENSE); IAEA-NDS site copyright"
 redistributable = "attribution"
 risk = "amber"
 citation = "T. Kawano, Y.S. Cho, P. Dimitriou et al., Nuclear Data Sheets 163 (2020) 109."
-notes = "Covered by the IAEA-NDS permission request (pending)."
+notes = "Non-commercial academic reuse granted (acknowledge IAEA); permission only needed for commercial use."
 
 [libraries.exfor]
 name = "EXFOR (experimental reaction data)"


### PR DESCRIPTION
Follow-up to #243. eXoma/HYRR are **non-commercial academic** projects — which the IAEA/JAEA/NDS terms explicitly accommodate — so most of the audit's commercial-driven 🟡 amber relaxes.

- **FENDL-3.2**: `conditional`/amber → `attribution`/green (IAEA grants non-commercial academic reuse with acknowledgement).
- **IRDFF-II / IAEA-Medical / IAEA-PD-2019 / JENDL**: notes reframed; **permission emails downgraded to optional** (IAEA = not needed for non-commercial; JAEA = optional insurance).
- **manifest `usage`** records the non-commercial basis + the *commercial-downstream-users-get-their-own-permission* note.
- EAF-2010 stays removed (its licence forbade redistribution regardless of commercial use).

Closes the loop on the commercial-use question raised after the audit. Epic #241.