### PR TITLE
fix(ts-client): surface proj_A in catimaColumns (isotope resolution)

### DIFF
--- a/clients/ts/nucl-parquet/src/columns.ts
+++ b/clients/ts/nucl-parquet/src/columns.ts
@@ -34,6 +34,13 @@ export interface StoppingColumns {
 /** Column-oriented catima stopping data (energy in MeV/u). */
 export interface CatimaColumns {
   projZ: Int32Array;
+  /**
+   * Projectile mass number. CatIMA stopping is reduced-mass dependent, so
+   * isotopes of the same Z differ (up to ~15% below ~0.01 MeV/u). Lookups must
+   * key on (projZ, projA, targetZ) — keying on (projZ, targetZ) alone merges
+   * isotopes onto one energy axis (see #248).
+   */
+  projA: Int32Array;
   targetZ: Int32Array;
   energyMeVu: Float64Array;
   dedx: Float64Array;
@@ -125,12 +132,13 @@ export async function stoppingColumns(buffer: ArrayBuffer): Promise<StoppingColu
 
 /**
  * Extract catima stopping columns from a `catima.parquet` ArrayBuffer.
- * Schema: proj_Z i32, target_Z i32, energy_MeV_u f64, dedx f64, straggling f64
+ * Schema: proj_Z i32, proj_A i32, target_Z i32, energy_MeV_u f64, dedx f64, straggling f64
  */
 export async function catimaColumns(buffer: ArrayBuffer): Promise<CatimaColumns> {
   const cols = await extractColumns(buffer);
   return {
     projZ: getI32(cols, "proj_Z"),
+    projA: getI32(cols, "proj_A"),
     targetZ: getI32(cols, "target_Z"),
     energyMeVu: getF64(cols, "energy_MeV_u"),
     dedx: getF64(cols, "dedx"),

--- a/clients/ts/nucl-parquet/test/columns.test.ts
+++ b/clients/ts/nucl-parquet/test/columns.test.ts
@@ -1,7 +1,7 @@
 import { readFile } from "fs/promises";
 import { join } from "path";
 import { describe, expect, it } from "vitest";
-import { stoppingColumns, xsColumns } from "../src/columns.js";
+import { catimaColumns, stoppingColumns, xsColumns } from "../src/columns.js";
 
 const DATA_DIR = join(import.meta.dirname, "../../../../data");
 
@@ -54,5 +54,37 @@ describe("xsColumns", () => {
 
     // Cu-63 and Cu-65 should be present
     expect(Array.from(new Set(cols.targetA))).toEqual(expect.arrayContaining([63, 65]));
+  });
+});
+
+describe("catimaColumns", () => {
+  it("surfaces proj_A so isotopes are distinguishable (#248)", async () => {
+    const buf = await readFile(join(DATA_DIR, "stopping/catima/catima.parquet"));
+    const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+    const cols = await catimaColumns(ab);
+
+    expect(cols.projZ).toBeInstanceOf(Int32Array);
+    expect(cols.projA).toBeInstanceOf(Int32Array);
+    expect(cols.targetZ).toBeInstanceOf(Int32Array);
+    expect(cols.energyMeVu).toBeInstanceOf(Float64Array);
+    expect(cols.dedx).toBeInstanceOf(Float64Array);
+    expect(cols.straggling).toBeInstanceOf(Float64Array);
+
+    // All columns share one row count.
+    const n = cols.projZ.length;
+    expect(n).toBeGreaterThan(0);
+    expect(cols.projA.length).toBe(n);
+    expect(cols.targetZ.length).toBe(n);
+    expect(cols.energyMeVu.length).toBe(n);
+    expect(cols.dedx.length).toBe(n);
+    expect(cols.straggling.length).toBe(n);
+
+    // Multiple isotopes of He (Z=2) — both A=3 and A=4 must be present, else a
+    // (projZ, targetZ) lookup would silently merge them (the #246/#248 bug).
+    const heMassNumbers = new Set<number>();
+    for (let i = 0; i < n; i++) {
+      if (cols.projZ[i] === 2) heMassNumbers.add(cols.projA[i]);
+    }
+    expect(Array.from(heMassNumbers)).toEqual(expect.arrayContaining([3, 4]));
   });
 });


### PR DESCRIPTION
## Summary

`catimaColumns` (`clients/ts/nucl-parquet/src/columns.ts`) extracted `proj_Z, target_Z, energy_MeV_u, dedx, straggling` but **dropped `proj_A`**, even though it's in `catima.parquet`. A consumer keying a lookup on `(projZ, targetZ)` therefore couldn't distinguish isotopes — the same isotope-merge defect just fixed for the Rust client in #246/#247, where collapsing same-Z isotopes onto one energy axis produced errors up to ~44% at low energy.

Surfaced by the cross-language parity audit that produced #246.

## Changes

- Add `projA: Int32Array` to the `CatimaColumns` interface (with a note on why isotope keying matters).
- Extract `proj_A` in `catimaColumns`; fix the schema doc comment.
- New `catimaColumns` test: asserts `projA` is present, all columns share a row count, and both He-3 and He-4 (`proj_Z=2`, A=3 & A=4) are surfaced — so a `(projZ, targetZ)` merge can't slip back in.

## Verification

- ✅ `vitest run`: **25/25** pass (incl. the new catima test).
- ✅ `tsup` build + `.d.ts` generation succeed (types valid).
- Data unchanged (`proj_A` already in the parquet).

## Scope

Go client has no stopping/catima implemented yet — unaffected.

Closes #248.

🤖 Generated with [Claude Code](https://claude.com/claude-code)