### PR TITLE
ci(release): npm publish via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,12 +93,13 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
-      # OIDC trusted publishing (no NPM_TOKEN). Requires npm >= 11.5.1; node 22
-      # ships npm 10.x, so upgrade first. The package must have a trusted
-      # publisher configured on npmjs.com pointing at this repo + workflow +
-      # `npm` environment. Provenance is emitted automatically.
+      # OIDC trusted publishing (no NPM_TOKEN). Node 24 bundles npm 11.x; the
+      # explicit upgrade guards the >= 11.5.1 floor that trusted publishing
+      # needs regardless of the runner's bundled version. The package must have
+      # a trusted publisher configured on npmjs.com pointing at this repo +
+      # workflow + `npm` environment. Provenance is emitted automatically.
       - run: npm install -g npm@latest
       - run: npm ci
       - run: npm run build
@@ -119,12 +120,13 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
-      # OIDC trusted publishing (no NPM_TOKEN). Requires npm >= 11.5.1; node 22
-      # ships npm 10.x, so upgrade first. The package must have a trusted
-      # publisher configured on npmjs.com pointing at this repo + workflow +
-      # `npm` environment. Provenance is emitted automatically.
+      # OIDC trusted publishing (no NPM_TOKEN). Node 24 bundles npm 11.x; the
+      # explicit upgrade guards the >= 11.5.1 floor that trusted publishing
+      # needs regardless of the runner's bundled version. The package must have
+      # a trusted publisher configured on npmjs.com pointing at this repo +
+      # workflow + `npm` environment. Provenance is emitted automatically.
       - run: npm install -g npm@latest
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,11 +95,14 @@ jobs:
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
+      # OIDC trusted publishing (no NPM_TOKEN). Requires npm >= 11.5.1; node 22
+      # ships npm 10.x, so upgrade first. The package must have a trusted
+      # publisher configured on npmjs.com pointing at this repo + workflow +
+      # `npm` environment. Provenance is emitted automatically.
+      - run: npm install -g npm@latest
       - run: npm ci
       - run: npm run build
       - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   npm-mcp:
     name: Publish @nucl-parquet/mcp to npm
@@ -118,11 +121,14 @@ jobs:
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
+      # OIDC trusted publishing (no NPM_TOKEN). Requires npm >= 11.5.1; node 22
+      # ships npm 10.x, so upgrade first. The package must have a trusted
+      # publisher configured on npmjs.com pointing at this repo + workflow +
+      # `npm` environment. Provenance is emitted automatically.
+      - run: npm install -g npm@latest
       - run: npm ci
       - run: npm run build
       - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   # Go does not need a publish job: release-please tags `clients/go/nucl-parquet/v*`
   # directly, which is the form the Go module proxy resolves. The tag's


### PR DESCRIPTION
## Summary

Switches the two npm publish jobs (`@nucl-parquet/core`, `@nucl-parquet/mcp`) from a long-lived `NPM_TOKEN` secret to **OIDC trusted publishing** — the same keyless model the PyPI job in this workflow already uses.

Motivation: `NPM_TOKEN` expired (last rotated 2026-03-13), which silently broke npm publishing — `@nucl-parquet/core` is stuck at 0.14.0 on npm (0.14.1/0.14.2 never shipped, 0.14.3 just failed with E404). Trusted publishing removes the expiring-secret failure mode entirely.

## Changes
- Remove `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from both npm jobs.
- Add `npm install -g npm@latest` — OIDC trusted publishing requires npm ≥ 11.5.1, but node 22 ships npm 10.x.
- Keep `id-token: write`, `environment: npm`, and `--provenance` (provenance is emitted automatically under trusted publishing).

## Required one-time setup (maintainer, on npmjs.com)
For **each** of `@nucl-parquet/core` and `@nucl-parquet/mcp`: package → Settings → **Trusted Publishers** → add GitHub Actions publisher:
- Repository: `exoma-ch/nucl-parquet`
- Workflow: `.github/workflows/release.yml`
- Environment: `npm`

Once both are configured and this is merged, `NPM_TOKEN` can be deleted from repo secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)