### PR TITLE
ci: authenticate release-please via GitHub App (fixes #274)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,12 +18,18 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # Mint a short-lived installation token from the "nucl-parquet-release-bot"
+      # GitHub App (app_id in RP_APP_ID, PEM in RP_APP_PRIVATE_KEY). An App token
+      # (unlike GITHUB_TOKEN) makes the tag push trigger release.yml, and (unlike
+      # a PAT) never expires — the App is the durable credential. Replaces the
+      # expired RELEASE_PLEASE_TOKEN PAT (#274).
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.RP_APP_ID }}
+          private-key: ${{ secrets.RP_APP_PRIVATE_KEY }}
       - uses: googleapis/release-please-action@v4
         with:
-          # PAT (or GitHub App token) is required so the tag push triggers
-          # release.yml. GITHUB_TOKEN-pushed tags are silently ignored by
-          # workflow triggers (GitHub security feature) — see #35 / #57 for
-          # the history. Falls back to GITHUB_TOKEN if the secret is unset.
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
Replaces the expired `RELEASE_PLEASE_TOKEN` PAT (#274) with a short-lived installation token minted from the **nucl-parquet-release-bot** GitHub App.

## Why
- The PAT expired → release-please failed `Bad credentials` on every push to `main`, blocking all package release PRs.
- An **App** token still makes the tag push trigger `release.yml` (plain `GITHUB_TOKEN` pushes are ignored by workflow triggers), **and** never expires — no yearly rotation.

## What
- New step `actions/create-github-app-token@v1` mints the token from `RP_APP_ID` + `RP_APP_PRIVATE_KEY` (both set as repo secrets).
- release-please now uses `steps.app-token.outputs.token`.
- App is installed on this repo (install `149824971`), scoped to Contents R/W + Pull requests R/W.

Closes #274. After merge, the next push to `main` re-runs release-please and it should open the pending python release PR (covering #272's neutron fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)