### PR TITLE
fix(loader): expose target_Z in unified xs view to separate isobars (#273)

### DIFF
--- a/nucl_parquet/loader.py
+++ b/nucl_parquet/loader.py
@@ -10,8 +10,8 @@ Usage:
     # Cross-section query:
     db.sql("SELECT * FROM tendl_2023_iso WHERE target_A=63 AND residual_Z=30")
 
-    # Compare all libraries:
-    db.sql("SELECT library, energy_MeV, xs_mb FROM xs WHERE target_A=63 AND residual_Z=30")
+    # Compare all libraries (filter target_Z to disambiguate isobaric targets):
+    db.sql("SELECT library, energy_MeV, xs_mb FROM xs WHERE target_Z=29 AND target_A=63 AND residual_Z=30")
 
     # Decay radiation:
     db.sql("SELECT * FROM radiation WHERE Z=27 AND A=60 AND rad_type='gamma'")
@@ -178,6 +178,15 @@ def connect(data_dir: Path | str | None = None) -> duckdb.DuckDBPyConnection:
     # --- Cross-section libraries ---
     lib_views: list[str] = []
 
+    # Element symbol → Z map as a temp table, so the cross-section views can expose
+    # a first-class `target_Z` derived from each file's element symbol. The shared
+    # 6-col xs schema has no target_Z (target is implied by the <proj>_<Symbol>
+    # filename), so without this the unified `xs` view silently interleaves isobaric
+    # targets that reach the same *absolute* residual via different reactions —
+    # e.g. Nd/Pm/Sm-145 all → Nd-143 at 14–20 MeV. target_Z makes them separable. (#273)
+    db.execute("CREATE TEMP TABLE _element_z(symbol_lc VARCHAR, z INTEGER)")
+    db.executemany("INSERT INTO _element_z VALUES (?, ?)", list(_SYMBOL_TO_Z.items()))
+
     for lib_key, lib_info in catalog.get("libraries", {}).items():
         # Some catalog entries (e.g. strata-data-nuclear) are build-time
         # provenance records, not queryable cross-section directories — they
@@ -194,13 +203,23 @@ def connect(data_dir: Path | str | None = None) -> duckdb.DuckDBPyConnection:
         glob_path = str(lib_dir / "*.parquet")
 
         data_type = lib_info.get("data_type", "cross_sections")
-        db.execute(f"""
-            CREATE VIEW {view_name} AS
-            SELECT *, '{lib_key}' AS library
-            FROM read_parquet('{glob_path}', filename=true)
-        """)
         if data_type == "cross_sections":
+            # Expose target_Z, derived from the <proj>_<Symbol>.parquet filename, so
+            # isobaric targets are separable in the unified `xs` view (#273).
+            db.execute(f"""
+                CREATE VIEW {view_name} AS
+                SELECT r.*, '{lib_key}' AS library, e.z AS target_Z
+                FROM read_parquet('{glob_path}', filename=true) r
+                LEFT JOIN _element_z e
+                  ON e.symbol_lc = lower(regexp_extract(r.filename, '_([A-Za-z]+)[.]parquet$', 1))
+            """)
             lib_views.append(view_name)
+        else:
+            db.execute(f"""
+                CREATE VIEW {view_name} AS
+                SELECT *, '{lib_key}' AS library
+                FROM read_parquet('{glob_path}', filename=true)
+            """)
 
     # Unified xs view: UNION ALL of all evaluated libraries
     if lib_views:

--- a/tests/test_neutron_njoy.py
+++ b/tests/test_neutron_njoy.py
@@ -207,6 +207,40 @@ def test_charged_particle_out_thermal_summed(sym, target_a, res_z, res_a, lo, hi
 
 
 @pytest.mark.data
+def test_xs_view_target_Z_disambiguates_isobars():
+    """The unified `xs` view must carry a `target_Z` (derived from the element file)
+    so isobaric targets reaching the same absolute residual via different reactions
+    are separable — without it the target_Z-less view interleaves them (#273)."""
+    import nucl_parquet
+
+    db = nucl_parquet.connect()
+    # Nd-145, Pm-145, Sm-145 all reach Nd-143 (residual_Z=60) at 14–20 MeV via
+    # different multi-particle channels — they collide on (target_A, residual).
+    zs = [
+        r[0]
+        for r in db.sql(
+            "SELECT DISTINCT target_Z FROM xs "
+            "WHERE library='endfb-8.0' AND target_A=145 AND residual_Z=60 AND residual_A=143 "
+            "ORDER BY target_Z"
+        ).fetchall()
+    ]
+    assert zs == [60, 61, 62], f"expected Nd/Pm/Sm target_Z, got {zs}"
+    # With target_Z pinned the channel is single-valued again (no interleaving).
+    dup = db.sql(
+        "SELECT COUNT(*) FROM ("
+        "  SELECT energy_MeV, COUNT(*) c FROM xs "
+        "  WHERE library='endfb-8.0' AND target_Z=60 AND target_A=145 AND residual_Z=60 AND residual_A=143 "
+        "  GROUP BY energy_MeV HAVING COUNT(*) > 1)"
+    ).fetchone()[0]
+    assert dup == 0, f"{dup} interleaved points even with target_Z pinned"
+    # target_Z is correct for a plain (n,γ) channel too (Co-59 → Z=27).
+    co = db.sql(
+        "SELECT DISTINCT target_Z FROM xs WHERE library='endfb-8.0' AND target_A=59 AND residual_Z=27 AND residual_A=60"
+    ).fetchall()
+    assert [r[0] for r in co] == [27]
+
+
+@pytest.mark.data
 def test_resonance_region_present():
     """The processed data must reach thermal (raw MF=3 started ~0.2 MeV)."""
     import nucl_parquet


### PR DESCRIPTION
Closes #273.

The shared 6-column xs schema drops `target_Z` (target element is implied by the `<proj>_<Symbol>` filename), so the Python loader's unified `xs` view — a UNION over every library — silently **interleaves isobaric targets** that reach the same *absolute* residual via different reactions.

**Example:** Nd-145, Pm-145, Sm-145 all produce Nd-143 (residual_Z=60) at 14–20 MeV via (n,3n)/(n,2np)/(n,2pn). `… WHERE target_A=145 AND residual_Z=60 AND residual_A=143` returned all three interleaved.

## Fix (option 2 from the issue — view-only)
Derive `target_Z` in each cross-section view from the file's element symbol, via a small symbol→Z temp table built from the loader's existing `_SYMBOL_TO_Z`. The unified `xs` view now carries a first-class `target_Z`.

- **No data rebuild, no on-disk schema change** — purely the loader's view SQL.
- **Additive** — existing queries unaffected; `SELECT *` just gains a column.
- **rs/go/ts untouched** — they read per-element files and already know the target from the filename; only Python builds the cross-library union.

## Verified
```
Nd/Pm/Sm-145→Nd-143 target_Z: [60, 61, 62]     # now separable
dup energies with target_Z pinned: 0            # single-valued again
Co-59(n,γ) target_Z: [27]                       # correct for plain channels
```
New test `test_xs_view_target_Z_disambiguates_isobars`; full loader + neutron + data-release suites pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)