### PR TITLE
fix(hf): mirror job reported green while doing nothing, and would have damaged the card

### DIFF
--- a/.github/workflows/release-data.yml
+++ b/.github/workflows/release-data.yml
@@ -80,20 +80,30 @@ jobs:
     name: Sync Hugging Face mirror
     runs-on: ubuntu-latest
     needs: [verify, data-asset]
-    # Skip cleanly on forks and wherever the secret is absent, rather than
-    # failing a release for want of a mirror.
+    # Forks have no business pushing to the mirror, so they skip. On the canonical
+    # repo a missing token is a *failure*, not a skip: the card is what keeps the
+    # published licence from drifting (#234), so "mirror silently did nothing"
+    # must never be indistinguishable from "mirror is current". It reported green
+    # for the whole of 2026.8.0 and 2026.8.1 while doing nothing at all.
     if: ${{ github.repository == 'exoma-ch/nucl-parquet' }}
     steps:
       - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.tag || github.ref_name }}
       - uses: astral-sh/setup-uv@v5
-      - name: Sync card + shards
+      - name: Sync dataset card
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           if [ -z "${HF_TOKEN}" ]; then
-            echo "::warning::HF_TOKEN not set — skipping Hugging Face mirror"
-            exit 0
+            echo "::error::HF_TOKEN is not set — the Hugging Face mirror cannot be" \
+                 "updated, so its licence metadata will drift from data/licenses.toml." \
+                 "Add HF_TOKEN (write scope on gerchowl/nucl-parquet-data) as a" \
+                 "repository secret, or remove this job if the mirror is retired."
+            exit 1
           fi
-          uv run --with huggingface_hub python scripts/sync_huggingface.py
+          # Card only. The shard upload is held back until the published
+          # per-isotope layout and the local per-element layout are reconciled —
+          # syncing today would interleave two incompatible shardings. The script
+          # refuses that on its own; this keeps the release green in the meantime.
+          uv run --with huggingface_hub python scripts/sync_huggingface.py --card-only

--- a/.github/workflows/release-data.yml
+++ b/.github/workflows/release-data.yml
@@ -80,12 +80,19 @@ jobs:
     name: Sync Hugging Face mirror
     runs-on: ubuntu-latest
     needs: [verify, data-asset]
-    # Forks have no business pushing to the mirror, so they skip. On the canonical
-    # repo a missing token is a *failure*, not a skip: the card is what keeps the
-    # published licence from drifting (#234), so "mirror silently did nothing"
-    # must never be indistinguishable from "mirror is current". It reported green
-    # for the whole of 2026.8.0 and 2026.8.1 while doing nothing at all.
-    if: ${{ github.repository == 'exoma-ch/nucl-parquet' }}
+    # Whether the mirror is maintained is a *declared* state, not something to
+    # infer from whether a secret happens to exist.
+    #
+    #   vars.HF_MIRROR_ENABLED unset  -> job is skipped. Grey, and honestly so.
+    #   set to 'true', token missing  -> job fails loudly (see below).
+    #   set to 'true', token present  -> card is pushed.
+    #
+    # The bug this replaces: the job keyed off the secret and warn-and-skipped
+    # when it was absent, so it reported *success* through 2026.8.0 and 2026.8.1
+    # while pushing nothing. The card is what keeps the published licence from
+    # drifting (#234), so "mirror silently did nothing" must never be
+    # indistinguishable from "mirror is current". Skipped says that; green lies.
+    if: ${{ github.repository == 'exoma-ch/nucl-parquet' && vars.HF_MIRROR_ENABLED == 'true' }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -96,10 +103,10 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           if [ -z "${HF_TOKEN}" ]; then
-            echo "::error::HF_TOKEN is not set — the Hugging Face mirror cannot be" \
-                 "updated, so its licence metadata will drift from data/licenses.toml." \
-                 "Add HF_TOKEN (write scope on gerchowl/nucl-parquet-data) as a" \
-                 "repository secret, or remove this job if the mirror is retired."
+            echo "::error::HF_MIRROR_ENABLED is 'true' but HF_TOKEN is not set." \
+                 "The mirror's licence metadata will drift from data/licenses.toml" \
+                 "(#234). Add HF_TOKEN with write scope on gerchowl/nucl-parquet-data," \
+                 "or unset HF_MIRROR_ENABLED to retire the mirror deliberately."
             exit 1
           fi
           # Card only. The shard upload is held back until the published

--- a/scripts/sync_huggingface.py
+++ b/scripts/sync_huggingface.py
@@ -36,16 +36,44 @@ REPO_ID = "gerchowl/nucl-parquet-data"
 # the dataset card.
 MIRRORED_LIBRARY = "endfb-8_0"
 
+# The columns the *published* shards actually have. Deliberately not
+# `CANONICAL_XS_SCHEMA`: the mirror is a pre-migration snapshot, and the card
+# must describe what a consumer will find when they download the file, not what
+# the repository holds today. Update this only when the shards are re-synced.
+PUBLISHED_SCHEMA = "target_Z, target_A, residual_Z, residual_A, state, energy_MeV, xs_mb"
+
+
+def isotope_count(data_dir: Path) -> int:
+    """Distinct isotopes in the mirrored library, counted from the data.
+
+    Derived rather than written down: the card states coverage, and a hardcoded
+    number is the same drift problem as a hardcoded licence.
+    """
+    import duckdb
+
+    shard_glob = data_dir / "endfb-8.0" / "xs" / "*.parquet"
+    con = duckdb.connect()
+    return con.sql(f"SELECT count(DISTINCT (target_Z * 1000 + target_A)) FROM read_parquet('{shard_glob}')").fetchone()[
+        0
+    ]
+
 
 def build_card(data_dir: Path) -> str:
     """Generate the dataset card, with licence taken from licenses.toml.
 
     Deriving it rather than hand-writing it is the point: a wrong licence on a
     public mirror is a compliance problem, and hand-maintained metadata drifts.
+
+    The technical sections are generated too, because this card *overwrites* the
+    published one. An earlier version emitted only the licence block, which would
+    have silently deleted the coverage, schema and log-log interpolation guidance
+    a consumer needs to use the shards correctly. Anything the published card
+    must keep has to be produced here.
     """
     licenses = tomllib.loads((data_dir / "licenses.toml").read_text())
     lic = licenses["libraries"][MIRRORED_LIBRARY]
     catalog = json.loads((data_dir / "catalog.json").read_text())
+    n_isotopes = isotope_count(data_dir)
 
     return f"""---
 license: other
@@ -59,27 +87,82 @@ tags:
 pretty_name: nucl-parquet data (NJOY-processed neutron cross sections)
 ---
 
-# nucl-parquet-data
+> **Licensing.** **{lic["license"]}**
+>
+> {lic["notes"]}
+>
+> MIT covers the nucl-parquet *code and conversion*, not the bundled evaluated
+> data. Per-library terms are recorded in
+> [`data/licenses.toml`](https://github.com/exoma-ch/nucl-parquet/blob/main/data/licenses.toml).
+>
+> Cite: {lic["citation"]}
+>
+> Custodian: {lic["custodian"]}
+
+# nucl-parquet-data — NJOY-processed neutron cross sections
 
 Per-isotope neutron cross-section shards for
-[nucl-parquet](https://github.com/exoma-ch/nucl-parquet), hosted so consumers can
-**range-fetch one isotope at a time** rather than download a monolith.
+[nucl-parquet](https://github.com/exoma-ch/nucl-parquet), hosted here so consumers
+**fetch one isotope at a time** rather than download a monolith.
 
 Data version: `{catalog["data_version"]}`
 
-## Licensing
+## `neutron/` — ENDF/B-VIII.0, NJOY-processed
 
-**{lic["license"]}**
+- **Source:** OpenMC-processed ENDF/B-VIII.0 HDF5
+  ([openmc-data-storage/ENDF-B-VIII.0-NNDC](https://github.com/openmc-data-storage/ENDF-B-VIII.0-NNDC))
+  — the pointwise data OpenMC / MCNP / Serpent transport on.
+- **Temperature:** 294 K (Doppler-broadened).
+- **Coverage:** {n_isotopes} target isotopes.
+- **Channels:** transmutation only — capture (MT 102) plus threshold reactions
+  (n,2n / n,3n / n,p / n,α / …). Elastic, inelastic-to-levels and fission are
+  excluded; those live in the `endfb-8.0-channels` transport product in the main
+  repository.
+- **Schema:** `{PUBLISHED_SCHEMA}`.
+- **Grid:** dense NJOY pointwise grid thinned to ≤1 % log-log accuracy.
+  **Interpolate in log-log** — the 1/v region is sparse, so nearest-point reads
+  will over-read.
 
-{lic["notes"]}
+## Status — this mirror lags the main repository
 
-MIT covers the nucl-parquet *code and conversion*, not the bundled evaluated
-data. Per-library terms are recorded in
-[`data/licenses.toml`](https://github.com/exoma-ch/nucl-parquet/blob/main/data/licenses.toml).
+These shards are a snapshot taken before the canonical-schema migration. They
+are correct as far as they go, but they are **not** the current shape of the
+data:
 
-Cite: {lic["citation"]}
+- they carry {len(PUBLISHED_SCHEMA.split(", "))} columns, where the repository now
+  carries the canonical cross-section schema (adding `library`, `kind`,
+  `projectile`, `proj_Z`, `proj_A`, `MT`, uncertainties and provenance);
+- they shard per isotope (`n_Nd143.parquet`), where the repository shards per
+  element (`n_Nd.parquet`).
 
-Custodian: {lic["custodian"]}
+Re-syncing the shards is pending reconciliation of those two layouts. **For
+current data, use the release tarball** (see Usage below) rather than these
+files. This card is regenerated on every data release, so the licence metadata
+above is always current even while the shards are not.
+
+Unlike a raw MF=3 ingestion, these carry the full resolved/unresolved resonance
+region and the thermal point (e.g. Nd-143(n,γ) reaches 1e-5 eV, not 0.225 MeV).
+
+## Usage
+
+The shards are plain Parquet — read them directly:
+
+```python
+from huggingface_hub import hf_hub_download
+import duckdb
+
+path = hf_hub_download(
+    "gerchowl/nucl-parquet-data", "neutron/n_Nd143.parquet", repo_type="dataset"
+)
+duckdb.sql(f"SELECT energy_MeV, xs_mb FROM '{{path}}' WHERE residual_A = 144")
+```
+
+For the full dataset — every library, not just neutron — install the package and
+use the release tarball instead:
+
+```bash
+pip install nucl-parquet && python -c "import nucl_parquet; nucl_parquet.download()"
+```
 
 ---
 
@@ -131,6 +214,25 @@ def main() -> None:
     if not shard_dir.exists():
         logger.warning("no shards at %s — card only", shard_dir)
         return
+
+    # The published mirror shards per *isotope* (`n_Nd143.parquet`); the local
+    # tree shards per *element* (`n_Nd.parquet`). Uploading one into the other
+    # does not overwrite — it interleaves two incompatible layouts in the same
+    # directory, leaving the same data under two namings and no way for a
+    # consumer to tell which is authoritative. Refuse rather than corrupt.
+    published = {
+        f.rsplit("/", 1)[-1]
+        for f in (s.path for s in api.list_repo_tree(args.repo_id, "neutron", repo_type="dataset"))
+        if f.endswith(".parquet")
+    }
+    local = {p.name for p in shard_dir.glob("*.parquet")}
+    if published and not local & published:
+        raise SystemExit(
+            f"refusing to upload: {len(local)} local shards ({sorted(local)[0]}, …) share no name "
+            f"with the {len(published)} already published ({sorted(published)[0]}, …). "
+            "These are different sharding schemes; reconcile them before syncing."
+        )
+
     api.upload_folder(
         folder_path=str(shard_dir),
         path_in_repo="neutron",

--- a/tests/test_hf_card.py
+++ b/tests/test_hf_card.py
@@ -1,0 +1,133 @@
+"""The generated Hugging Face dataset card must stay complete and correct.
+
+`scripts/sync_huggingface.py` *overwrites* the published card on every data
+release. That makes the generator the single source of truth for what the public
+mirror says -- and it means anything the generator forgets to emit is silently
+deleted from a public page on the next release.
+
+It had already forgotten most of it. An earlier version emitted the licence block
+and nothing else, which would have wiped the coverage, schema and the log-log
+interpolation warning a consumer needs to read the shards correctly.
+
+Two things are therefore pinned here: the licence really is derived from
+`data/licenses.toml` (the #234 compliance guarantee), and the technical sections
+are actually present.
+"""
+
+from __future__ import annotations
+
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent
+DATA_DIR = ROOT / "data"
+sys.path.insert(0, str(ROOT / "scripts"))
+
+pytestmark = pytest.mark.skipif(
+    not (DATA_DIR / "licenses.toml").exists(),
+    reason="no data tree",
+)
+
+
+def _card() -> str:
+    from sync_huggingface import build_card
+
+    return build_card(DATA_DIR)
+
+
+@pytest.mark.data
+def test_licence_frontmatter_is_not_mit() -> None:
+    """The mirror published `license: mit` over a US Government work (#234).
+
+    An MIT grant is not ours to make over ENDF/B-VIII.0. This is the regression
+    that must never come back.
+    """
+    card = _card()
+    head = card.split("---")[1]
+    assert "license: other" in head
+    assert "license_name: us-government-work" in head
+    assert "mit" not in head.lower(), "the mirror must not claim MIT over evaluated data"
+
+
+@pytest.mark.data
+def test_licence_text_is_derived_from_licenses_toml() -> None:
+    """Not merely correct today -- structurally unable to drift.
+
+    If the card restated the licence in prose, `licenses.toml` could be corrected
+    and the public mirror would keep the old claim.
+    """
+    lic = tomllib.loads((DATA_DIR / "licenses.toml").read_text())["libraries"]["endfb-8_0"]
+    card = _card()
+    for field in ("license", "notes", "citation", "custodian"):
+        value = lic[field]
+        assert value in card, f"card does not carry licenses.toml::{field} verbatim"
+
+
+@pytest.mark.data
+def test_card_keeps_the_documentation_a_consumer_needs() -> None:
+    """The card overwrites a published page; omissions are deletions.
+
+    Each of these was present on the live card and absent from the generator --
+    they would have been destroyed on the next release with a token configured.
+    """
+    card = _card()
+    required = {
+        "log-log": "how to interpolate; nearest-point reads over-read the 1/v region",
+        "294 K": "the temperature the data is broadened to",
+        "Coverage:": "how many isotopes are here",
+        "Schema:": "the column layout",
+        "openmc-data-storage": "provenance of the processed form",
+        "Usage": "a worked example",
+    }
+    missing = [f"{k} ({why})" for k, why in required.items() if k not in card]
+    assert not missing, "generated card is missing:\n  " + "\n  ".join(missing)
+
+
+@pytest.mark.data
+def test_card_describes_the_published_schema_not_the_local_one() -> None:
+    """The card documents what a consumer downloads, which is not what we hold.
+
+    The mirror is a pre-migration snapshot: 7 columns, sharded per isotope. The
+    repository is on the 18-column canonical schema, sharded per element. Naming
+    the local schema on the card would send consumers looking for `MT` and
+    `projectile` columns that are not in the file they just fetched.
+    """
+    from sync_huggingface import PUBLISHED_SCHEMA
+
+    from nucl_parquet._schemas import CANONICAL_XS_SCHEMA
+
+    card = _card()
+    assert PUBLISHED_SCHEMA in card
+    published_cols = {c.strip() for c in PUBLISHED_SCHEMA.split(",")}
+    assert published_cols < set(CANONICAL_XS_SCHEMA), "published schema should be a subset of canonical"
+    # And the divergence must be disclosed, not quietly papered over.
+    assert "lags the main repository" in card
+
+
+@pytest.mark.data
+def test_coverage_count_is_derived_not_hardcoded() -> None:
+    """A written-down isotope count is the same drift problem as a written-down licence."""
+    from sync_huggingface import isotope_count
+
+    n = isotope_count(DATA_DIR)
+    assert n > 0
+    assert f"Coverage:** {n} target isotopes" in _card()
+
+
+@pytest.mark.data
+def test_card_advertises_no_api_that_does_not_exist() -> None:
+    """The published card demonstrated `nucl_parquet.neutron_xs(...)`, which is
+    not a function this package has ever defined. A usage example that does not
+    run is worse than none -- it sends consumers to a traceback."""
+    import nucl_parquet
+
+    card = _card()
+    for line in card.splitlines():
+        if "nucl_parquet." not in line:
+            continue
+        attr = line.split("nucl_parquet.", 1)[1].split("(")[0].strip()
+        if attr and attr.isidentifier():
+            assert hasattr(nucl_parquet, attr), f"card references nucl_parquet.{attr}, which does not exist"


### PR DESCRIPTION
Closes the last of the pre-release items. The stop-gate was right that "HF upload automation" was not done — it turned out to be worse than not-done.

## Three problems, none visible from a passing check

**1. The job could not run.** `HF_TOKEN` is not a repository secret (`gh secret list` shows `CARGO_REGISTRY_TOKEN`, `DATA_RELEASE_PAT`, `RELEASE_PLEASE_TOKEN`, `RP_APP_ID`, `RP_APP_PRIVATE_KEY` — no `HF_TOKEN`). The guard was warn-and-skip, so **`Sync Hugging Face mirror` reported success for both 2026.8.0 and 2026.8.1 while pushing nothing.** The 2026.8.1 job ran 35 s and did no work.

A green check meaning "did nothing" is indistinguishable from "mirror is current" — precisely the failure mode #234 was about. It now fails with an actionable message.

**2. The generated card was a subset of the published one.** The script *overwrites* `README.md` on the mirror, but emitted only the licence block. Diffed against the live card: it would have deleted coverage, temperature, provenance, schema, the log-log interpolation warning, and the usage example. **With a token present, the first release would have silently wiped a public page.** The generator now emits the full card (40 → 81 lines).

**3. The card advertised an API that does not exist.** It demonstrated `nucl_parquet.neutron_xs(...)`. No such function has ever been defined — `grep -rn "def neutron_xs" nucl_parquet/` returns nothing. Replaced with `hf_hub_download` + duckdb, which runs.

## A false claim I nearly published

While writing the card I asserted the canonical 18-column schema. Checked it instead of trusting it — downloaded `neutron/n_Nd143.parquet` from the live mirror:

| | published shard | local tree |
|---|---|---|
| columns | **7** (`target_Z, target_A, residual_Z, residual_A, state, energy_MeV, xs_mb`) | **18** (canonical) |
| sharding | per **isotope** (`n_Nd143.parquet`) | per **element** (`n_Nd.parquet`) |

The mirror is a pre-migration snapshot. The card now documents what a consumer actually downloads and has a **Status** section disclosing the divergence, rather than papering over it.

## Shard upload held back deliberately

Two guards:
- workflow runs `--card-only`
- the script refuses to upload when local and published shard names have no overlap

Pushing today would **not** overwrite the published shards — it would interleave 97 element files among 533 isotope files in one directory, same data under two namings, no way to tell which is authoritative. Reconciling the layouts is a separate decision (see below).

## Coverage

`tests/test_hf_card.py` (6 tests): licence derived from `licenses.toml` and never MIT; documentation sections present; coverage count derived (533, from the data) not hardcoded; published schema described and a strict subset of canonical; divergence disclosed; every `nucl_parquet.*` the card names actually resolves.

`./scripts/ci.sh` green.

## Gate is a declared variable, not secret-presence

Reworked after a first pass got this wrong. Whether the mirror is maintained is now a state someone *declares*:

| `vars.HF_MIRROR_ENABLED` | `HF_TOKEN` | job |
|---|---|---|
| unset | — | **skipped** (grey, honestly so) |
| `true` | missing | **fails loudly** |
| `true` | present | pushes the card |

My first version hard-failed on a missing token unconditionally — that fixed the lying-green problem but turned the release pipeline red until someone added a credential, trading a false pass for a false alarm. A skipped job already carries the honest signal. The failure is now reserved for the genuinely broken case: mirror declared on, and misconfigured.

**This makes the PR safe to merge before the token exists** — nothing goes red.

## Two things needing you (after merge, at your pace)

1. **Add `HF_TOKEN`** (write scope on `gerchowl/nucl-parquet-data`) and set repo variable `HF_MIRROR_ENABLED=true`. Until then the job skips. If the mirror is retired instead, leave the variable unset and delete the job.
2. **Decide the shard layout**: re-shard the mirror per element to match the repo, or keep per-isotope and have the sync split element files. I did not pick for you — it changes what published URLs mean, and consumers may be fetching the current names.
