### PR TITLE
test(hf): cover the shard-layout guard

### DIFF
--- a/scripts/sync_huggingface.py
+++ b/scripts/sync_huggingface.py
@@ -58,6 +58,27 @@ def isotope_count(data_dir: Path) -> int:
     ]
 
 
+def check_shard_layout(local: set[str], published: set[str]) -> None:
+    """Refuse to upload a shard set that does not overlap what is published.
+
+    The published mirror shards per *isotope* (`n_Nd143.parquet`); the local tree
+    shards per *element* (`n_Nd.parquet`). Uploading one into the other does not
+    overwrite anything — it interleaves two incompatible layouts in one
+    directory, leaving the same data under two namings with nothing to say which
+    is authoritative. Refuse rather than corrupt.
+
+    An empty `published` is not a mismatch: that is a first sync into an empty
+    directory, which is exactly when uploading is correct.
+    """
+    if not published or local & published:
+        return
+    raise SystemExit(
+        f"refusing to upload: {len(local)} local shards ({sorted(local)[0]}, …) share no name "
+        f"with the {len(published)} already published ({sorted(published)[0]}, …). "
+        "These are different sharding schemes; reconcile them before syncing."
+    )
+
+
 def build_card(data_dir: Path) -> str:
     """Generate the dataset card, with licence taken from licenses.toml.
 
@@ -215,23 +236,13 @@ def main() -> None:
         logger.warning("no shards at %s — card only", shard_dir)
         return
 
-    # The published mirror shards per *isotope* (`n_Nd143.parquet`); the local
-    # tree shards per *element* (`n_Nd.parquet`). Uploading one into the other
-    # does not overwrite — it interleaves two incompatible layouts in the same
-    # directory, leaving the same data under two namings and no way for a
-    # consumer to tell which is authoritative. Refuse rather than corrupt.
     published = {
         f.rsplit("/", 1)[-1]
         for f in (s.path for s in api.list_repo_tree(args.repo_id, "neutron", repo_type="dataset"))
         if f.endswith(".parquet")
     }
     local = {p.name for p in shard_dir.glob("*.parquet")}
-    if published and not local & published:
-        raise SystemExit(
-            f"refusing to upload: {len(local)} local shards ({sorted(local)[0]}, …) share no name "
-            f"with the {len(published)} already published ({sorted(published)[0]}, …). "
-            "These are different sharding schemes; reconcile them before syncing."
-        )
+    check_shard_layout(local, published)
 
     api.upload_folder(
         folder_path=str(shard_dir),

--- a/tests/test_hf_card.py
+++ b/tests/test_hf_card.py
@@ -117,6 +117,35 @@ def test_coverage_count_is_derived_not_hardcoded() -> None:
     assert f"Coverage:** {n} target isotopes" in _card()
 
 
+def test_shard_layout_guard_blocks_incompatible_shardings() -> None:
+    """The guard is the only thing standing between a sync and a corrupted mirror.
+
+    Uploading element shards into a directory of isotope shards does not
+    overwrite -- it interleaves, leaving `n_Nd.parquet` beside `n_Nd143.parquet`
+    with the same data under two namings. This is the live situation: 97 local
+    element files against 533 published isotope files.
+    """
+    from sync_huggingface import check_shard_layout
+
+    with pytest.raises(SystemExit) as e:
+        check_shard_layout({"n_Nd.parquet", "n_Fe.parquet"}, {"n_Nd143.parquet", "n_Fe56.parquet"})
+    assert "different sharding schemes" in str(e.value)
+
+
+def test_shard_layout_guard_allows_a_matching_sync() -> None:
+    """It must not block the case it exists to permit: same scheme, newer data."""
+    from sync_huggingface import check_shard_layout
+
+    check_shard_layout({"n_Nd143.parquet", "n_Fe56.parquet"}, {"n_Nd143.parquet"})
+
+
+def test_shard_layout_guard_allows_a_first_sync() -> None:
+    """An empty published set is not a mismatch -- it is the initial upload."""
+    from sync_huggingface import check_shard_layout
+
+    check_shard_layout({"n_Nd.parquet"}, set())
+
+
 @pytest.mark.data
 def test_card_advertises_no_api_that_does_not_exist() -> None:
     """The published card demonstrated `nucl_parquet.neutron_xs(...)`, which is


### PR DESCRIPTION
The shard-layout guard added in #283 is the only thing standing between a sync and a corrupted mirror — and it shipped untested.

A guard wrong in either direction is expensive: too strict and it blocks a legitimate sync forever; too loose and it interleaves 97 local element shards among the 533 published isotope shards, same data under two namings with nothing to say which is authoritative.

Extracted from `main()` into `check_shard_layout()` so it can be exercised directly, and covered the three cases that matter:

- incompatible schemes are **refused**
- a matching scheme with newer data is **allowed** (the case it exists to permit)
- an empty published set is a **first sync**, not a mismatch

**Mutation-verified:** removing the guard's condition fails `test_shard_layout_guard_blocks_incompatible_shardings`.

`./scripts/ci.sh` green. `tests/test_hf_card.py` now 9 tests.