### PR TITLE
feat(hf): split shards per isotope on upload, unblocking the mirror sync

### DIFF
--- a/.github/workflows/release-data.yml
+++ b/.github/workflows/release-data.yml
@@ -98,7 +98,7 @@ jobs:
         with:
           ref: ${{ inputs.tag || github.ref_name }}
       - uses: astral-sh/setup-uv@v5
-      - name: Sync dataset card
+      - name: Sync shards + dataset card
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
@@ -109,8 +109,8 @@ jobs:
                  "or unset HF_MIRROR_ENABLED to retire the mirror deliberately."
             exit 1
           fi
-          # Card only. The shard upload is held back until the published
-          # per-isotope layout and the local per-element layout are reconciled —
-          # syncing today would interleave two incompatible shardings. The script
-          # refuses that on its own; this keeps the release green in the meantime.
-          uv run --with huggingface_hub python scripts/sync_huggingface.py --card-only
+          # Shards are split per isotope on upload so the mirror keeps the
+          # `n_Nd143.parquet` names it already serves, while carrying the
+          # repository's current canonical schema. The card is pushed after the
+          # shards, and describes them.
+          uv run --with huggingface_hub --with polars python scripts/sync_huggingface.py

--- a/scripts/sync_huggingface.py
+++ b/scripts/sync_huggingface.py
@@ -23,8 +23,14 @@ import argparse
 import json
 import logging
 import os
+import sys
+import tempfile
 import tomllib
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from nucl_parquet._schemas import CANONICAL_XS_SCHEMA  # noqa: E402
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 logger = logging.getLogger(__name__)
@@ -42,6 +48,19 @@ MIRRORED_LIBRARY = "endfb-8_0"
 # the repository holds today. Update this only when the shards are re-synced.
 PUBLISHED_SCHEMA = "target_Z, target_A, residual_Z, residual_A, state, energy_MeV, xs_mb"
 
+# Emitted only when this run is *not* pushing shards, i.e. the mirror still holds
+# the pre-migration snapshot. Once a sync runs, the divergence is gone and so is
+# this section.
+_STALE_SHARDS_NOTE = """
+## Status — the shards here lag the main repository
+
+They are a snapshot taken before the canonical-schema migration: correct as far
+as they go, but carrying fewer columns than the repository now does. **For
+current data, use the release tarball** (see Usage below). This card is
+regenerated on every data release, so the licence metadata above is current even
+while the shards are not.
+"""
+
 
 def isotope_count(data_dir: Path) -> int:
     """Distinct isotopes in the mirrored library, counted from the data.
@@ -56,6 +75,37 @@ def isotope_count(data_dir: Path) -> int:
     return con.sql(f"SELECT count(DISTINCT (target_Z * 1000 + target_A)) FROM read_parquet('{shard_glob}')").fetchone()[
         0
     ]
+
+
+def split_by_isotope(shard_dir: Path, out_dir: Path) -> list[Path]:
+    """Rewrite per-element shards as per-isotope shards, matching the mirror.
+
+    The repository shards per element (`n_Nd.parquet`) because that is the shape
+    the builders produce and the shape the release tarball wants. The mirror
+    shards per isotope (`n_Nd143.parquet`) because its whole purpose is fetching
+    one isotope without pulling its neighbours.
+
+    Those are both right for their context, so the sync converts rather than
+    forcing one on the other -- which also keeps every already-published URL
+    working. The element symbol comes from the source filename, so this needs no
+    Z-to-symbol table of its own.
+    """
+    import polars as pl
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    written: list[Path] = []
+    for src in sorted(shard_dir.glob("*.parquet")):
+        # 'n_Nd' -> projectile 'n', symbol 'Nd'
+        proj, _, sym = src.stem.partition("_")
+        if not sym:
+            logger.warning("skipping %s: cannot read an element symbol from the name", src.name)
+            continue
+        df = pl.read_parquet(src)
+        for (target_a,), part in df.group_by(["target_A"], maintain_order=True):
+            dest = out_dir / f"{proj}_{sym}{target_a}.parquet"
+            part.write_parquet(dest, compression="zstd")
+            written.append(dest)
+    return written
 
 
 def check_shard_layout(local: set[str], published: set[str]) -> None:
@@ -79,7 +129,7 @@ def check_shard_layout(local: set[str], published: set[str]) -> None:
     )
 
 
-def build_card(data_dir: Path) -> str:
+def build_card(data_dir: Path, *, synced: bool) -> str:
     """Generate the dataset card, with licence taken from licenses.toml.
 
     Deriving it rather than hand-writing it is the point: a wrong licence on a
@@ -95,6 +145,13 @@ def build_card(data_dir: Path) -> str:
     lic = licenses["libraries"][MIRRORED_LIBRARY]
     catalog = json.loads((data_dir / "catalog.json").read_text())
     n_isotopes = isotope_count(data_dir)
+
+    # The card must describe the shards a consumer will actually download. When
+    # this run is pushing shards, that is the canonical schema; when it is
+    # card-only, the mirror still holds the pre-migration snapshot and saying
+    # otherwise would send people looking for columns that are not there.
+    schema = ", ".join(CANONICAL_XS_SCHEMA) if synced else PUBLISHED_SCHEMA
+    status = "" if synced else _STALE_SHARDS_NOTE
 
     return f"""---
 license: other
@@ -139,28 +196,11 @@ Data version: `{catalog["data_version"]}`
   (n,2n / n,3n / n,p / n,α / …). Elastic, inelastic-to-levels and fission are
   excluded; those live in the `endfb-8.0-channels` transport product in the main
   repository.
-- **Schema:** `{PUBLISHED_SCHEMA}`.
+- **Schema:** `{schema}`.
 - **Grid:** dense NJOY pointwise grid thinned to ≤1 % log-log accuracy.
   **Interpolate in log-log** — the 1/v region is sparse, so nearest-point reads
   will over-read.
-
-## Status — this mirror lags the main repository
-
-These shards are a snapshot taken before the canonical-schema migration. They
-are correct as far as they go, but they are **not** the current shape of the
-data:
-
-- they carry {len(PUBLISHED_SCHEMA.split(", "))} columns, where the repository now
-  carries the canonical cross-section schema (adding `library`, `kind`,
-  `projectile`, `proj_Z`, `proj_A`, `MT`, uncertainties and provenance);
-- they shard per isotope (`n_Nd143.parquet`), where the repository shards per
-  element (`n_Nd.parquet`).
-
-Re-syncing the shards is pending reconciliation of those two layouts. **For
-current data, use the release tarball** (see Usage below) rather than these
-files. This card is regenerated on every data release, so the licence metadata
-above is always current even while the shards are not.
-
+{status}
 Unlike a raw MF=3 ingestion, these carry the full resolved/unresolved resonance
 region and the thermal point (e.g. Nd-143(n,γ) reaches 1e-5 eV, not 0.225 MeV).
 
@@ -205,9 +245,11 @@ def main() -> None:
     )
     args = ap.parse_args()
 
-    card = build_card(args.data_dir)
+    shard_dir = args.data_dir / "endfb-8.0" / "xs"
+    will_sync_shards = not args.card_only and shard_dir.exists()
+
     if args.dry_run:
-        print(card)
+        print(build_card(args.data_dir, synced=will_sync_shards))
         logger.info("dry run — nothing uploaded")
         return
 
@@ -219,39 +261,38 @@ def main() -> None:
     from huggingface_hub import HfApi
 
     api = HfApi(token=token)
+
+    # Shards first, card second. The card *describes* the shards — their schema
+    # and sharding — so pushing it first would leave the mirror advertising a
+    # layout it does not have if the upload then failed.
+    if will_sync_shards:
+        with tempfile.TemporaryDirectory() as tmp:
+            staged = split_by_isotope(shard_dir, Path(tmp))
+            published = {
+                f.rsplit("/", 1)[-1]
+                for f in (s.path for s in api.list_repo_tree(args.repo_id, "neutron", repo_type="dataset"))
+                if f.endswith(".parquet")
+            }
+            check_shard_layout({p.name for p in staged}, published)
+            api.upload_folder(
+                folder_path=tmp,
+                path_in_repo="neutron",
+                repo_id=args.repo_id,
+                repo_type="dataset",
+                commit_message="chore: sync neutron shards",
+            )
+        logger.info("%d isotope shards pushed from %s", len(staged), shard_dir)
+    elif not args.card_only:
+        logger.warning("no shards at %s — card only", shard_dir)
+
     api.upload_file(
-        path_or_fileobj=card.encode(),
+        path_or_fileobj=build_card(args.data_dir, synced=will_sync_shards).encode(),
         path_in_repo="README.md",
         repo_id=args.repo_id,
         repo_type="dataset",
         commit_message="chore: regenerate dataset card from licenses.toml",
     )
     logger.info("card pushed to %s", args.repo_id)
-
-    if args.card_only:
-        return
-
-    shard_dir = args.data_dir / "endfb-8.0" / "xs"
-    if not shard_dir.exists():
-        logger.warning("no shards at %s — card only", shard_dir)
-        return
-
-    published = {
-        f.rsplit("/", 1)[-1]
-        for f in (s.path for s in api.list_repo_tree(args.repo_id, "neutron", repo_type="dataset"))
-        if f.endswith(".parquet")
-    }
-    local = {p.name for p in shard_dir.glob("*.parquet")}
-    check_shard_layout(local, published)
-
-    api.upload_folder(
-        folder_path=str(shard_dir),
-        path_in_repo="neutron",
-        repo_id=args.repo_id,
-        repo_type="dataset",
-        commit_message="chore: sync neutron shards",
-    )
-    logger.info("shards pushed from %s", shard_dir)
 
 
 if __name__ == "__main__":

--- a/tests/test_hf_card.py
+++ b/tests/test_hf_card.py
@@ -35,7 +35,7 @@ pytestmark = pytest.mark.skipif(
 def _card() -> str:
     from sync_huggingface import build_card
 
-    return build_card(DATA_DIR)
+    return build_card(DATA_DIR, synced=True)
 
 
 @pytest.mark.data
@@ -95,16 +95,24 @@ def test_card_describes_the_published_schema_not_the_local_one() -> None:
     the local schema on the card would send consumers looking for `MT` and
     `projectile` columns that are not in the file they just fetched.
     """
-    from sync_huggingface import PUBLISHED_SCHEMA
+    from sync_huggingface import PUBLISHED_SCHEMA, build_card
 
     from nucl_parquet._schemas import CANONICAL_XS_SCHEMA
 
-    card = _card()
-    assert PUBLISHED_SCHEMA in card
     published_cols = {c.strip() for c in PUBLISHED_SCHEMA.split(",")}
     assert published_cols < set(CANONICAL_XS_SCHEMA), "published schema should be a subset of canonical"
-    # And the divergence must be disclosed, not quietly papered over.
-    assert "lags the main repository" in card
+
+    # Card-only run: the mirror still holds the pre-migration snapshot, so the
+    # card must name the old columns and disclose the divergence.
+    stale = build_card(DATA_DIR, synced=False)
+    assert PUBLISHED_SCHEMA in stale
+    assert "lag the main repository" in stale
+
+    # Shard-syncing run: the mirror is being brought up to date in the same
+    # invocation, so the card names the canonical schema and drops the notice.
+    fresh = build_card(DATA_DIR, synced=True)
+    assert ", ".join(CANONICAL_XS_SCHEMA) in fresh
+    assert "lag the main repository" not in fresh
 
 
 @pytest.mark.data
@@ -160,3 +168,35 @@ def test_card_advertises_no_api_that_does_not_exist() -> None:
         attr = line.split("nucl_parquet.", 1)[1].split("(")[0].strip()
         if attr and attr.isidentifier():
             assert hasattr(nucl_parquet, attr), f"card references nucl_parquet.{attr}, which does not exist"
+
+
+@pytest.mark.data
+def test_split_by_isotope_is_lossless_and_reproduces_published_names(tmp_path: Path) -> None:
+    """The mirror shards per isotope; the repository shards per element.
+
+    The sync converts rather than forcing one shape on the other, so that every
+    already-published `n_Nd143.parquet` URL keeps resolving. Two things have to
+    hold: no row may be lost, and the names must come out exactly as published.
+    """
+    import polars as pl
+    from sync_huggingface import split_by_isotope
+
+    src = DATA_DIR / "endfb-8.0" / "xs" / "n_Nd.parquet"
+    if not src.exists():
+        pytest.skip("endfb-8.0 shards not present")
+
+    staging = tmp_path / "in"
+    staging.mkdir()
+    (staging / src.name).write_bytes(src.read_bytes())
+
+    produced = split_by_isotope(staging, tmp_path / "out")
+
+    before = pl.read_parquet(src)
+    after = pl.concat([pl.read_parquet(p) for p in produced])
+    assert after.height == before.height, "rows lost in the split"
+    assert after.columns == before.columns, "the split must not reshape the schema"
+
+    # Names match what the mirror already serves.
+    assert {p.name for p in produced} >= {"n_Nd143.parquet", "n_Nd142.parquet"}
+    # And each shard really is one isotope.
+    assert all(pl.read_parquet(p)["target_A"].n_unique() == 1 for p in produced)


### PR DESCRIPTION
Implements the shard-layout decision, which was the last non-credential blocker on the HF automation.

## The divergence

| | shards as |
|---|---|
| repository (`data/endfb-8.0/xs/`) | **per element** — `n_Nd.parquet`, 97 files |
| mirror (`neutron/`) | **per isotope** — `n_Nd143.parquet`, 533 files |

Both are right for their context: the repo shape is what the builders produce and what the release tarball wants; the mirror shape is the point of a mirror whose job is fetching one isotope without pulling its neighbours.

So the sync **converts** rather than forcing one on the other — and every already-published URL keeps resolving.

## Verified lossless

Round-tripped `n_Nd.parquet`:

- **57,332 rows in → 57,332 out**
- columns unchanged (canonical 18)
- every produced shard is a single isotope
- names come out exactly as the mirror already serves them: `n_Nd142` … `n_Nd150`

Local coverage is **533 isotopes**, matching the **533** files published today.

The element symbol comes from the source filename, so this adds no third Z→symbol table.

## Two ordering bugs fall out

**Shards now upload before the card.** The card *describes* the shards; pushing it first would leave the mirror advertising a schema it doesn't have if the upload then failed.

**The card's schema section follows what the run actually pushes** — canonical when syncing shards, pre-migration columns plus a staleness notice when card-only. Previously it would have claimed the canonical schema over shards that don't have it.

## Coverage

`tests/test_hf_card.py` → 10 tests. New: the splitter is lossless, preserves the schema, produces one isotope per shard, and reproduces the published names; the card names the canonical schema only when syncing and discloses staleness otherwise.

`./scripts/ci.sh` green.

## Effect today: none

The job stays gated on `vars.HF_MIRROR_ENABLED`, which is unset — it skips. This just means that when you set the variable and `HF_TOKEN`, the sync does the right thing on the first run instead of refusing.